### PR TITLE
fix: タイマーAPIを統一してTypeScriptの型不一致を解消

### DIFF
--- a/Vyline/apps/desktop/src/lib/store.ts
+++ b/Vyline/apps/desktop/src/lib/store.ts
@@ -599,8 +599,8 @@ resetAccountData: () =>
       showNotice: (msg, ms = 4_000) => {
         set({ notice: msg });
         const prev = noticeTimer.current;
-        if (prev) window.clearTimeout(prev);
-        noticeTimer.current = window.setTimeout(() => set({ notice: null }), ms);
+        if (prev) clearTimeout(prev);
+        noticeTimer.current = setTimeout(() => set({ notice: null }), ms);
       },
 
       resetSettings: () =>


### PR DESCRIPTION
## Summary
`noticeTimer` の型定義とタイマーAPIの実装が異なる環境を参照していたため、TypeScriptのビルドで型エラーが発生していました。
`setTimeout` / `clearTimeout` をグローバルAPIに統一し、ブラウザとBunの型環境で一貫して扱えるようにします。

## Changes

- `window.setTimeout` をグローバルの `setTimeout` に変更
- `window.clearTimeout` をグローバルの `clearTimeout` に変更

## Test Plan

- [x] `bun run build`（`tsc -b && vite build`）が通る
- [x] `bun run typecheck` が通る
- [ ] `bun run dev` で起動確認
  - フロントエンドは起動
  - バックエンドは既存の別問題である
    `Vyline/packages/protocol/data/desktop-profile.fallback.json`
    の欠落により起動不可 ( https://github.com/nezumi0627/vyline/issues/6 を参照 )
