### PR TITLE
fix: enforce LF line endings with .gitattributes + format scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+* text=auto eol=lf
+*.md   text eol=lf
+*.ts   text eol=lf
+*.tsx  text eol=lf
+*.js   text eol=lf
+*.json text eol=lf
+*.md   eol=lf
+*.yml  eol=lf
+*.yaml eol=lf

--- a/scripts/getEditedMessageJson.ts
+++ b/scripts/getEditedMessageJson.ts
@@ -14,8 +14,12 @@ const { values } = parseArgs({
 const { accountId, chatMid, messageId, text, port } = values;
 
 if (!accountId || !chatMid) {
-  console.error("❌ Usage: bun scripts/getEditedMessageJson.ts -a <accountId> -c <chatMid> [-m <messageId>] [-t <text>]");
-  console.error("Example: bun scripts/getEditedMessageJson.ts -a main -c c1efe9d6cf1848350bc91848a8a29963e -m 628117045912798141 -t 'Hello Edited!'");
+  console.error(
+    "❌ Usage: bun scripts/getEditedMessageJson.ts -a <accountId> -c <chatMid> [-m <messageId>] [-t <text>]",
+  );
+  console.error(
+    "Example: bun scripts/getEditedMessageJson.ts -a main -c c1efe9d6cf1848350bc91848a8a29963e -m 628117045912798141 -t 'Hello Edited!'",
+  );
   process.exit(1);
 }
 


### PR DESCRIPTION
Add .gitattributes to enforce LF line endings across platforms and fix long console.error lines in getEditedMessageJson.ts that exceed the 80-character limit.