### PR TITLE
feat: message edit UI with optimistic update, rollback, and edit notice

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+* text=auto eol=lf
+*.md   text eol=lf
+*.ts   text eol=lf
+*.tsx  text eol=lf
+*.js   text eol=lf
+*.json text eol=lf
+*.md   eol=lf
+*.yml  eol=lf
+*.yaml eol=lf

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <p align="center">
-  <img alt="version" src="https://img.shields.io/badge/version-0.5.0--beta-a78bfa?style=flat-square" />
+  <img alt="version" src="https://img.shields.io/badge/version-0.5.1--beta-a78bfa?style=flat-square" />
   <img alt="license" src="https://img.shields.io/badge/license-MIT-22c55e?style=flat-square" />
   <img alt="runtime" src="https://img.shields.io/badge/runtime-Bun-f472b6?style=flat-square" />
   <img alt="stack" src="https://img.shields.io/badge/stack-Hono%20%2B%20React-0ea5e9?style=flat-square" />

--- a/Vyline/apps/desktop/package.json
+++ b/Vyline/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyline/desktop",
-  "version": "0.5.0-beta",
+  "version": "0.5.1-beta",
   "private": true,
   "type": "module",
   "scripts": {

--- a/Vyline/apps/desktop/src/components/edit-message-dialog.tsx
+++ b/Vyline/apps/desktop/src/components/edit-message-dialog.tsx
@@ -1,0 +1,144 @@
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { IconClose, IconEdit } from "@/components/icons";
+
+interface EditMessageDialogProps {
+  initialText: string;
+  onSave: (newText: string) => Promise<void> | void;
+  onClose: () => void;
+}
+
+export function EditMessageDialog({ initialText, onSave, onClose }: EditMessageDialogProps) {
+  const [text, setText] = useState(initialText);
+  const [saving, setSaving] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    // マウント時にテキストエリアをフォーカスし末尾にカーソルを合わせる
+    const el = textareaRef.current;
+    if (el) {
+      el.focus();
+      el.setSelectionRange(el.value.length, el.value.length);
+    }
+
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const handleSave = async () => {
+    const trimmed = text.trim();
+    if (!trimmed || trimmed === initialText.trim() || saving) return;
+    try {
+      setSaving(true);
+      await onSave(trimmed);
+      onClose();
+    } catch {
+      setSaving(false);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    // Ctrl+Enter or Cmd+Enter or Enter (without Shift if preferred)
+    if (e.key === "Enter" && (e.ctrlKey || e.metaKey || !e.shiftKey)) {
+      e.preventDefault();
+      void handleSave();
+    }
+  };
+
+  const hasChanged = text.trim().length > 0 && text.trim() !== initialText.trim();
+
+  if (typeof document === "undefined") return null;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[120] flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label="メッセージを編集"
+    >
+      {/* 背景オーバーレイ */}
+      <div
+        className="fixed inset-0 bg-black/60 backdrop-blur-sm transition-opacity"
+        onClick={onClose}
+      />
+
+      {/* モーダル本体 */}
+      <div className="vy-scale-in relative w-full max-w-lg overflow-hidden rounded-2xl border border-[var(--vy-border)] bg-[var(--vy-surface)] shadow-2xl transition-all">
+        {/* ヘッダー */}
+        <div className="flex items-center justify-between border-b border-[var(--vy-border)] px-5 py-3.5">
+          <div className="flex items-center gap-2 text-sm font-semibold text-[var(--vy-text)]">
+            <span className="flex h-7 w-7 items-center justify-center rounded-lg bg-[color-mix(in_oklab,var(--vy-accent)_15%,transparent)] text-[var(--vy-accent)]">
+              <IconEdit size={16} />
+            </span>
+            <span>メッセージを編集</span>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="閉じる"
+            className="flex h-7 w-7 items-center justify-center rounded-lg text-[var(--vy-text-dim)] transition-colors hover:bg-[var(--vy-surface-2)] hover:text-[var(--vy-text)]"
+          >
+            <IconClose size={16} />
+          </button>
+        </div>
+
+        {/* コンテンツ */}
+        <div className="p-5">
+          <label htmlFor="edit-message-input" className="sr-only">
+            編集後のメッセージ
+          </label>
+          <textarea
+            id="edit-message-input"
+            ref={textareaRef}
+            rows={4}
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="メッセージを入力…"
+            className="vy-scroll max-h-60 w-full resize-y rounded-xl border border-[var(--vy-border)] bg-[var(--vy-surface-2)] p-3 text-sm leading-relaxed text-[var(--vy-text)] outline-none transition-all placeholder:text-[var(--vy-text-dim)] focus:border-[var(--vy-accent)] focus:ring-1 focus:ring-[var(--vy-accent)]"
+          />
+
+          <div className="mt-2 flex items-center justify-between text-xs text-[var(--vy-text-dim)]">
+            <span>Enter / Ctrl+Enter で保存 · Esc でキャンセル</span>
+            <span>{text.length} 文字</span>
+          </div>
+        </div>
+
+        {/* フッター */}
+        <div className="flex items-center justify-end gap-2 border-t border-[var(--vy-border)] bg-[var(--vy-surface-2)] px-5 py-3">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={saving}
+            className="rounded-xl px-4 py-2 text-xs font-medium text-[var(--vy-text)] transition-colors hover:bg-[color-mix(in_oklab,var(--vy-text)_10%,transparent)] disabled:opacity-50"
+          >
+            キャンセル
+          </button>
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={!hasChanged || saving}
+            className="flex items-center gap-1.5 rounded-xl px-4 py-2 text-xs font-medium text-[var(--vy-accent-contrast)] transition-all hover:brightness-110 active:scale-95 disabled:cursor-not-allowed disabled:opacity-40"
+            style={{ background: "var(--vy-accent)" }}
+          >
+            {saving ? (
+              <>
+                <span className="inline-block h-3.5 w-3.5 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                <span>保存中…</span>
+              </>
+            ) : (
+              <span>保存する</span>
+            )}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/Vyline/apps/desktop/src/components/message-bubble.tsx
+++ b/Vyline/apps/desktop/src/components/message-bubble.tsx
@@ -16,6 +16,7 @@ import { FlexMessageView } from "@/components/flex-message";
 import { FlexActions } from "@/components/flex-actions";
 import { RichMessageView } from "@/components/rich-message";
 import { CallEventMessage } from "@/components/call-event-message";
+import { EditMessageDialog } from "@/components/edit-message-dialog";
 import {
   IconReply,
   IconCopy,
@@ -28,6 +29,7 @@ import {
   IconPin,
   IconHeart,
   IconClose,
+  IconEdit,
 } from "@/components/icons";
 import { copyText, downloadUrl } from "@/utils/clipboard";
 import { segmentUnicodeEmoji } from "@/utils/lineSticon";
@@ -456,6 +458,7 @@ export const MessageBubble = memo(
     const settings = useStore((s) => s.settings);
     const streamerMode = settings.streamerMode;
     const revokeMessage = useStore((s) => s.revokeMessage);
+    const editMessage = useStore((s) => s.editMessage);
     const retryMessage = useStore((s) => s.retryMessage);
     const markRead = useStore((s) => s.markRead);
     const setReplyTo = useStore((s) => s.setReplyTo);
@@ -468,6 +471,8 @@ export const MessageBubble = memo(
     );
     const self = useStore((s) => s.self);
     const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
+    const [editing, setEditing] = useState(false);
+    const [showOriginal, setShowOriginal] = useState(false);
     const [showReaders, setShowReaders] = useState(false);
     const [lightbox, setLightbox] = useState(false);
     const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -687,6 +692,28 @@ export const MessageBubble = memo(
         : []),
       ...(isMe &&
       !message.revoked &&
+      message.kind === "text" &&
+      message.status !== "sending" &&
+      !message.id.startsWith("pending_")
+        ? [
+            {
+              label: "編集",
+              icon: <IconEdit size={16} />,
+              onClick: () => setEditing(true),
+            },
+          ]
+        : []),
+      ...(message.edited && message.originalText
+        ? [
+            {
+              label: showOriginal ? "編集後のメッセージを表示" : "編集前のメッセージを表示",
+              icon: <IconEdit size={16} />,
+              onClick: () => setShowOriginal((v) => !v),
+            },
+          ]
+        : []),
+      ...(isMe &&
+      !message.revoked &&
       message.status !== "sending" &&
       !message.id.startsWith("pending_")
         ? [
@@ -708,6 +735,8 @@ export const MessageBubble = memo(
           ]
         : []),
     ];
+
+    const isMessageEdited = message.edited || Boolean(message.originalText);
 
     const readReceipt = (() => {
       if (!isMe || message.revoked) return null;
@@ -774,12 +803,38 @@ export const MessageBubble = memo(
     const metaLine = !message.revoked && (
       <div
         className={cn(
-          "mt-1 flex items-center gap-2 px-1 text-[0.7rem] text-[var(--vy-text-dim)]",
+          "mt-1 flex items-center gap-1.5 px-1 text-[0.7rem] text-[var(--vy-text-dim)]",
           isMe ? "flex-row-reverse" : "flex-row",
         )}
       >
         <span>{formatTime(message.createdAt)}</span>
         {readReceipt}
+        {isMessageEdited && (
+          <span
+            className="flex items-center gap-0.5 text-[0.65rem] opacity-80"
+            title={
+              message.originalText
+                ? `クリックで${showOriginal ? "編集後" : "編集前"}を表示`
+                : "編集済み"
+            }
+          >
+            <span className="opacity-50">·</span>
+            {message.originalText ? (
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setShowOriginal((v) => !v);
+                }}
+                className="hover:text-[var(--vy-text)] hover:underline focus-visible:outline-none"
+              >
+                {showOriginal ? "編集前を表示中" : "編集済み"}
+              </button>
+            ) : (
+              <span>編集済み</span>
+            )}
+          </span>
+        )}
         {canReaderList && (
           <button
             type="button"
@@ -1082,15 +1137,36 @@ export const MessageBubble = memo(
               {message.kind === "audio" && message.audioSrc && (
                 <AudioBubble src={message.audioSrc} seconds={message.audioSeconds} />
               )}
-              {message.text && message.kind === "text" && (
-                <p className="vy-msg-text whitespace-pre-wrap break-words">
-                  <Highlighted
-                    text={message.text}
-                    query={highlight}
-                    sticons={message.sticons}
-                    mentions={message.mentions}
-                  />
-                </p>
+              {message.kind === "text" && (
+                <div>
+                  {showOriginal && message.originalText && (
+                    <div className="mb-1 flex items-center justify-between border-b border-current/15 pb-1 text-[0.65rem] opacity-70">
+                      <span>編集前のメッセージ</span>
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setShowOriginal(false);
+                        }}
+                        className="underline hover:opacity-100"
+                      >
+                        戻す
+                      </button>
+                    </div>
+                  )}
+                  <p className="vy-msg-text whitespace-pre-wrap break-words">
+                    <Highlighted
+                      text={
+                        showOriginal && message.originalText
+                          ? message.originalText
+                          : (message.text ?? "")
+                      }
+                      query={highlight}
+                      sticons={message.sticons}
+                      mentions={message.mentions}
+                    />
+                  </p>
+                </div>
               )}
               {message.linkPreview && !streamerMode && (
                 <LinkPreviewCard preview={message.linkPreview} />
@@ -1116,6 +1192,15 @@ export const MessageBubble = memo(
             y={menu.y}
             items={menuItems}
             onClose={() => setMenu(null)}
+          />
+        )}
+        {editing && (
+          <EditMessageDialog
+            initialText={message.text ?? ""}
+            onSave={async (newText) => {
+              await editMessage(message.id, newText);
+            }}
+            onClose={() => setEditing(false)}
           />
         )}
         {lightbox && message.imageSrc && (

--- a/Vyline/apps/desktop/src/components/message-input.tsx
+++ b/Vyline/apps/desktop/src/components/message-input.tsx
@@ -9,6 +9,7 @@ import {
   IconMic,
   IconClose,
   IconAtSign,
+  IconBellOff,
 } from "@/components/icons";
 import { StickerEmojiPanel } from "@/components/sticker-emoji-panel";
 import { FloatNotice } from "@/components/float-notice";
@@ -112,6 +113,7 @@ export function MessageInput({ chatId }: { chatId: string }) {
   const fileRef = useRef<HTMLInputElement>(null);
 
   const [picker, setPicker] = useState(false);
+  const [muteNext, setMuteNext] = useState(false);
   const [recording, setRecording] = useState(false);
   const [recSeconds, setRecSeconds] = useState(0);
   // 下書きの本文（￼ プレースホルダ）と絵文字メタデータを同一ストアに永続化して、チャット切替・再起動後もズレないようにする
@@ -338,11 +340,10 @@ export function MessageInput({ chatId }: { chatId: string }) {
     const sticonMeta = buildSticonMetadata(ranged) ?? {};
     const mentionMeta = buildMentionMetadata(state.draftMentions[chatId] ?? []);
     const meta = mentionMeta ? { ...sticonMeta, MENTION: mentionMeta } : sticonMeta;
-    void sendMessage(
-      chatId,
-      text,
-      Object.keys(meta).length ? { contentMetadata: meta } : undefined,
-    );
+    void sendMessage(chatId, text, {
+      contentMetadata: Object.keys(meta).length ? meta : undefined,
+      mute: muteNext || undefined,
+    });
     setDraftSticons(chatId, []);
     setDraftMentions(chatId, []);
     setMentionPicker(null);
@@ -604,6 +605,17 @@ export function MessageInput({ chatId }: { chatId: string }) {
             >
               <IconSmile size={20} />
             </IconButton>
+            <IconButton
+              label={
+                muteNext
+                  ? "ミュートメッセージ: 有効（通知なしで送信）"
+                  : "ミュートメッセージ: 無効（クリックで有効化）"
+              }
+              active={muteNext}
+              onClick={() => setMuteNext((m) => !m)}
+            >
+              <IconBellOff size={19} />
+            </IconButton>
 
             <div className="relative flex min-h-9 max-h-40 min-w-0 flex-1 items-center">
               {overlaySegments && (
@@ -638,7 +650,13 @@ export function MessageInput({ chatId }: { chatId: string }) {
                 onKeyDown={onKeyDown}
                 onPaste={onPaste}
                 onScroll={(e) => setOverlayScrollTop(e.currentTarget.scrollTop)}
-                placeholder={draft ? undefined : "メッセージを入力（絵文字は文中に挿入）"}
+                placeholder={
+                  draft
+                    ? undefined
+                    : muteNext
+                      ? "メッセージを入力（ミュート送信: 通知なし）"
+                      : "メッセージを入力（絵文字は文中に挿入）"
+                }
                 aria-label="メッセージを入力"
                 className={cn(
                   "vy-scroll vy-input-text max-h-40 w-full resize-none bg-transparent py-1.5 leading-relaxed outline-none placeholder:text-[var(--vy-text-dim)]",
@@ -653,11 +671,23 @@ export function MessageInput({ chatId }: { chatId: string }) {
               <button
                 type="button"
                 onClick={send}
-                aria-label="送信"
-                className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-[var(--vy-accent-contrast)] transition-transform hover:scale-105 active:scale-95 focus-visible:ring-2 focus-visible:ring-[var(--vy-accent)] focus-visible:outline-none"
-                style={{ background: "var(--vy-accent)" }}
+                aria-label={muteNext ? "ミュート送信（通知なし）" : "送信"}
+                title={
+                  muteNext ? "ミュートメッセージとして送信（相手に通知されません）" : undefined
+                }
+                className="relative flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-[var(--vy-accent-contrast)] transition-transform hover:scale-105 active:scale-95 focus-visible:ring-2 focus-visible:ring-[var(--vy-accent)] focus-visible:outline-none"
+                style={{
+                  background: muteNext
+                    ? "color-mix(in oklab, var(--vy-accent) 80%, #6366f1)"
+                    : "var(--vy-accent)",
+                }}
               >
                 <IconSend size={18} />
+                {muteNext && (
+                  <span className="absolute -top-1 -right-1 flex h-4 w-4 items-center justify-center rounded-full bg-indigo-600 text-[9px] text-white shadow">
+                    ✕
+                  </span>
+                )}
               </button>
             ) : (
               <IconButton label="音声メッセージを録音" onClick={() => setRecording(true)}>
@@ -667,11 +697,15 @@ export function MessageInput({ chatId }: { chatId: string }) {
           </div>
         </>
       )}
-      {draftSticons.length > 0 && (
-        <p className="mt-1 px-1 text-[0.65rem] text-[var(--vy-text-dim)]">
-          LINE絵文字 {draftSticons.length} 個を文中に挿入中
-        </p>
-      )}
+      <div className="mt-1 flex flex-wrap items-center gap-2 px-1 text-[0.65rem] text-[var(--vy-text-dim)]">
+        {muteNext && (
+          <span className="flex items-center gap-1 rounded-md bg-[color-mix(in_oklab,var(--vy-accent)_15%,transparent)] px-1.5 py-0.5 font-medium text-[var(--vy-accent)]">
+            <IconBellOff size={12} />
+            ミュート送信中（相手にプッシュ通知されません）
+          </span>
+        )}
+        {draftSticons.length > 0 && <span>LINE絵文字 {draftSticons.length} 個を文中に挿入中</span>}
+      </div>
     </div>
   );
 }

--- a/Vyline/apps/desktop/src/lib/mappers.ts
+++ b/Vyline/apps/desktop/src/lib/mappers.ts
@@ -322,6 +322,14 @@ export function mapMessage(
       })),
     stickerAnimated: m.stickerAnimated,
     stickerSticky: m.stickerSticky,
+    edited:
+      m.isEdited ||
+      (m.updatedTime != null && m.updatedTime > 0) ||
+      meta?.EDITED === "1" ||
+      meta?.is_edited === "true" ||
+      Boolean(m.originalText),
+    editedAt: m.updatedTime != null && m.updatedTime > 0 ? m.updatedTime : undefined,
+    originalText: m.originalText || (meta?.ORIGINAL_TEXT as string | undefined),
     contact,
     location,
   };

--- a/Vyline/apps/desktop/src/lib/store-types.ts
+++ b/Vyline/apps/desktop/src/lib/store-types.ts
@@ -108,6 +108,14 @@ export type Message = {
   stickerAnimated?: boolean;
   /** くっつきスタンプ（位置固定マーカーあり） */
   stickerSticky?: boolean;
+  /** 編集済みフラグ */
+  edited?: boolean;
+  /** 編集日時 (ms) */
+  editedAt?: number;
+  /** 編集前の元テキスト */
+  originalText?: string;
+  /** 編集前の元テキストを表示中かどうか */
+  showOriginal?: boolean;
   linkPreview?: LinkPreview;
   /** 失敗時の再送に使う送信意図（楽観メッセージに保持） */
   retry?: RetryIntent;

--- a/Vyline/apps/desktop/src/lib/store.ts
+++ b/Vyline/apps/desktop/src/lib/store.ts
@@ -180,14 +180,13 @@ function messagePreview(m: Message): string {
 }
 
 export const UPDATE_NOTES = {
-  version: "0.5.0-beta",
-  title: "Vyline 0.5.0-beta — fetchOps 刷新 + メッセージ編集・ミュート送信",
+  version: "0.5.1-beta",
+  title: "Vyline 0.5.1-beta — メッセージ編集UI・ミュート送信統合",
   items: [
+    "メッセージ編集UIの完全統合（編集メニュー、編集ダイアログ、編集済みバッジ表示、編集前の表示切替）",
+    "ミュート送信（NOTIFICATION_DISABLED）トグルボタンの追加",
     "受信システムをfetchOps方式に刷新（メッセージ・通話・メンバー変更等の全イベントを統合処理）",
-    "メッセージ編集機能 (editMessage / getMessageEditNotice) の正式追加",
-    "ミュート送信（NOTIFICATION_DISABLED）オプションの追加",
     "公開REST API (/v1/) を追加（Bearer token認証）",
-    "Vyline-Desktop カミングスーン",
     "メンション（@ALL / @名前）の送受信・ハイライト表示",
     "画像送信: クライアント側圧縮 + 本家クライアントでも表示される E2EE メディア対応",
     "チャットイベントの実テキスト化（参加/退出/名前変更等を正確に表示）",
@@ -199,7 +198,6 @@ export const UPDATE_NOTES = {
     "プロフィール背景画像・ステータスメッセージの表示",
     "チャット一覧のスクロールバウンス修正",
     "受信ポーリング高速化（4s/12s/60s → 2s/8s/60s）",
-    "deltaAfterId 最適化（getMessageBoxes RPC 省略）",
     "既読ウォーターマークキャッシュ（30s TTL）",
     "ブロック機能（送信防止・GUI統合）",
     "VylineBackup（トーク履歴・メディアスナップショット）",
@@ -306,6 +304,7 @@ type State = {
   sendAudio: (chatId: string, seconds: number, blob: Blob) => Promise<void>;
   revokeMessage: (id: string) => Promise<void>;
   editMessage: (id: string, newText: string) => Promise<void>;
+  toggleShowOriginal: (id: string) => void;
   retryMessage: (id: string) => Promise<void>;
   markRead: (id: string) => Promise<void>;
   markChatRead: (id: string) => Promise<void>;
@@ -1175,13 +1174,56 @@ export const useStore = create<State>()(
           window.alert("送信が完了してから編集できます");
           return;
         }
-        const res = await api.line.editMessage(accountId, msg.chatId, id, newText);
-        if (res.ok) {
-          if (activeChatId) await get().refreshMessages(activeChatId, { force: true });
-        } else {
-          window.alert(res.error ?? "メッセージの編集に失敗しました");
+        const prevText = msg.text ?? "";
+        if (prevText === newText.trim()) return;
+
+        // 楽観的にローカルメッセージを更新
+        set((st) => ({
+          messages: st.messages.map((m) =>
+            m.id === id
+              ? {
+                  ...m,
+                  text: newText,
+                  edited: true,
+                  editedAt: Date.now(),
+                  originalText: m.originalText ?? prevText,
+                  showOriginal: false,
+                }
+              : m,
+          ),
+        }));
+
+        try {
+          const res = await api.line.editMessage(accountId, msg.chatId, id, newText);
+          if (res.ok) {
+            get().showNotice("メッセージを編集しました");
+            if (activeChatId) await get().refreshMessages(activeChatId, { force: true });
+          } else {
+            // 失敗時はロールバック
+            set((st) => ({
+              messages: st.messages.map((m) =>
+                m.id === id ? { ...m, text: prevText, edited: msg.edited } : m,
+              ),
+            }));
+            window.alert(res.error ?? "メッセージの編集に失敗しました");
+          }
+        } catch (err) {
+          // 失敗時はロールバック
+          set((st) => ({
+            messages: st.messages.map((m) =>
+              m.id === id ? { ...m, text: prevText, edited: msg.edited } : m,
+            ),
+          }));
+          window.alert(`メッセージの編集に失敗しました: ${String(err)}`);
         }
       },
+
+      toggleShowOriginal: (id) =>
+        set((st) => ({
+          messages: st.messages.map((m) =>
+            m.id === id ? { ...m, showOriginal: !m.showOriginal } : m,
+          ),
+        })),
 
       retryMessage: async (id) => {
         const accountId = get().accountId;

--- a/Vyline/backend/src/service/lineService.ts
+++ b/Vyline/backend/src/service/lineService.ts
@@ -4221,12 +4221,26 @@ export async function editMessage(
   return runSendRpc(accountId, async () => {
     const client = requireClient(accountId);
     const myMid = await resolveMyMid(client, accountId);
-    const res = await client.base.talk.editMessage({
-      from: myMid,
-      to: chatMid,
-      messageId,
-      text,
-    });
+    let res: { message: unknown };
+    try {
+      res = await client.base.talk.editMessage({
+        from: myMid,
+        to: chatMid,
+        messageId,
+        text,
+      });
+    } catch (err: unknown) {
+      const errStr = String(err);
+      if (errStr.includes("NOT_PREMIUM") || errStr.includes("non-LYP subscriber")) {
+        throw new Error(
+          "メッセージ編集はLYPプレミアム会員限定の機能です（LINE仕様により副端末からの編集はLYP会員のみ許可されています）",
+        );
+      }
+      if (errStr.includes("TOO_OLD") || errStr.includes("too old")) {
+        throw new Error("メッセージの編集可能時間を過ぎています");
+      }
+      throw err;
+    }
     const mapped = mapDecodedRawToMessage(res.message as unknown as Record<string, unknown>, myMid);
     await upsertMessages(accountId, chatMid, [
       { ...mapped, chatMid, savedAt: new Date().toISOString() },

--- a/Vyline/packages/types/src/index.ts
+++ b/Vyline/packages/types/src/index.ts
@@ -141,6 +141,12 @@ export interface Message {
   stickerAnimated?: boolean;
   /** くっつきスタンプ（位置固定マーカーあり） */
   stickerSticky?: boolean;
+  /** メッセージ編集済みフラグ */
+  isEdited?: boolean;
+  /** 編集日時 (ms) */
+  updatedTime?: number;
+  /** 編集前のオリジナルテキスト（ローカルキャッシュ用） */
+  originalText?: string;
 }
 
 export interface MessageReaction {

--- a/docs/analysis/desktop-edit-premium.md
+++ b/docs/analysis/desktop-edit-premium.md
@@ -1,0 +1,57 @@
+# Desktop LINE におけるメッセージ編集と Premium ゲートの挙動
+
+> 調査日: 2026-08-20
+> 対象バイナリ: `source/desktop/unpacked_LINE.exe`（LINE Desktop 26.3.0.3916, Themida 解凍済み, 85.5 MB）
+> 手法: `tools/findNativeSymbol.ts` による文字列/LEA-xref 特定 → Ghidra 12.1.2 headless 逆コンパイル
+> 目的: メッセージ編集（editMessage）と Premium 制限がクライアント側でどう扱われるかを**文書化するのみ**（実装変更・バイパスは対象外）
+
+## 結論（先行）
+
+**Premium によるメッセージ編集の制限は、クライアント（Desktop LINE）側には存在しない。編集 RPC は常に無条件に送信され、ゲートは LINE サーバー側の資格（cmode / entitlement）チェックで施行される。** クライアントは premium 状態を「観測・キャッシュ・表示」するだけで、独自の gate ロジックは持たない。したがって「クライアント側での抜け穴」は存在せず、非プレミアムでの編集実現はサーバーの認証/資格チェックの偽装・悪用に帰着する（本調査の範囲外）。
+
+## 発見した主要シンボル
+
+| シンボル / 文字列 | 種別 | 意味 |
+|---|---|---|
+| `TalkService_editMessage_pargs` / `TalkService_editMessage_presult` | RTTI (thrift) | 編集 RPC のリクエスト/レスポンス型 |
+| `TalkService_getMessageEditNotice_pargs` / `_presult` | RTTI (thrift) | 編集通知取得 RPC の型 |
+| `line::LanService::onPremiumMessageEditTermsCompleted` | 関数名 | サーバー(LAN)からの premium 編集規約 受信コールバック |
+| `line::PremiumManager::updatePremiumInfo` / `setPremiumStatus` / `onGetPremiumStatus` / `onGetProductTiers` / `onSessionOperationsReceived` | 関数名 | premium 状態の管理・キャッシュ |
+| `[PremiumManager] init premium info` / `premium status changed:%s` / `receive GetPremiumStatus response. success:%d, errorCode:%d` | デバッグログ | サーバー応答の受信・キャッシュの証拠 |
+| `function.premium.common.message_edit.agreement.lan` / `.agreement.version` | 設定キー | premium 編集の規約(agreement)設定 |
+| `function.chatroom.message_edit.timelimit.privatechat` / `.timelimit.keepmemo` | 設定キー | 編集可能時間(プライベート/メモ保持) |
+| `chat.messageedit.popupdesc.linepremiummembershipexpired` / `lyppremiummembershipexpired` | UI 文字列 | premium 期限切れ時のポップアップ文言 |
+| `editMessage failed: unknown result` | エラーログ | サーバーからの失敗（NOT_PREMIUM 含む）の表示 |
+| `NOT_PREMIUM` | 文字列 (1件, rva 0x31961920) | サーバーエラーコードを扱うための定数（クライアント内で gate としては使われない） |
+
+## 逆コンパイルした証拠
+
+出力: `tools/data/out/native-search/onPremiumMessageEdit+message_edit+PremiumManager+editMessage/functions/`
+
+### 1. editMessage 送信側 — `FUN_7ff79b5be760`（命令 rva `0x1d7e7a1`）
+
+`TalkService` クライアント（コンテキスト +0x30）に対してリクエスト引数を詰め、thrift 構造体を組み立て、`/S4` パス（`0x7ff79c953478`）へ `editMessage` メソッド（`0x7ff79c94d5f8`）を**無条件に送信**する。
+この関数内に premium チェック・資格判定は一切ない。つまり RPC 層は「premium かどうか」を知らず、常に送る。
+
+### 2. premium 編集規約 受信ハンドラ — `FUN_7ff79b344340`（命令 rva `0x1b043f5`）
+
+`onPremiumMessageEditTermsCompleted` に対応。引数はサーバーからの結果コード（`param_3 & 0xffffffff`）とフラグ群。分岐は成功/失敗でログ文字列（`0x7ff79c89e300/318/330/348`、すなわち `[LAN] premium message edit terms result: %d` 等）を組み立てるだけ。**実行ロジック・ゲートはなし。** サーバーが「規約/利用可能か」を教えてくるのを受け取り、記録するのみ。
+
+### 3. editMessage 失敗ハンドラ — `FUN_7ff79b576a60`（命令 rva `0x1d36b8f`）
+
+ステータス（`aiStack_298[0]`）を見て、失敗時はエラーオブジェクトを作りログ（`0x7ff79cf21d40` 等 = `editMessage failed: unknown result`）に出す。サーバーから返ったエラー（NOT_PREMIUM を含む）を**表示・通知するだけ**。クライアントが gate を掛けているのではなく、サーバーの判定結果をユーザーへ伝える役割。
+
+### 4. PremiumManager 群 — `FUN_7ff79b3391ba` / `339500` / `3395f0` / `339b52` / `339d80` / `339e70`
+
+`onGetPremiumStatus` / `onGetProductTiers` / `onSessionOperationsReceived(NOTIFIED_UPDATE_PURCHASES)` で受け取ったサーバー応答を、内部オブジェクト（offset 0x1d8/0x1e8, 0x170/0x180 等）へ**コピー/キャッシュするセッター**に過ぎない。ローカルでの資格判定・制限演算は含まれていない。UI はこのキャッシュされた premium 状態を見て編集メニューの表示/非表示を切り替えるが、それはユーザー体験の話であり、権威的ゲートはサーバー。
+
+## 補足: Vyline 側の状況
+
+- `packages/protocol/stack/base/service/talk/mod.ts` の `editMessage` は `/S4` RPC の定義のみ。
+- `backend/src/service/lineService.ts` はサーバーからの `NOT_PREMIUM` を日本語エラーに変換するだけで、クライアント側ゲートはない（Desktop と同じ構造）。
+- よって Vyline でも「非プレミアムで編集できない」のはサーバー側起因。クライアント改修で解決する類のものではない。
+
+## 備考
+
+- `unpacked_LINE.exe` は `source/desktop/unpacked_LINE.exe`（26.3.0.3916）を使用。Themida 仮想化領域の一部は逆コンパイル不能な場合があるが、上記関数はいずれも正常に復元された。
+- 調査は相互運用・理解のためのリバースエンジニアリングであり、Premium 全体のバイパス実装は意図的に行っていない。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vyline",
-  "version": "0.5.0-beta",
+  "version": "0.5.1-beta",
   "private": true,
   "workspaces": [
     "Vyline/packages/*",

--- a/scripts/getEditedMessageJson.ts
+++ b/scripts/getEditedMessageJson.ts
@@ -14,8 +14,12 @@ const { values } = parseArgs({
 const { accountId, chatMid, messageId, text, port } = values;
 
 if (!accountId || !chatMid) {
-  console.error("❌ Usage: bun scripts/getEditedMessageJson.ts -a <accountId> -c <chatMid> [-m <messageId>] [-t <text>]");
-  console.error("Example: bun scripts/getEditedMessageJson.ts -a main -c c1efe9d6cf1848350bc91848a8a29963e -m 628117045912798141 -t 'Hello Edited!'");
+  console.error(
+    "❌ Usage: bun scripts/getEditedMessageJson.ts -a <accountId> -c <chatMid> [-m <messageId>] [-t <text>]",
+  );
+  console.error(
+    "Example: bun scripts/getEditedMessageJson.ts -a main -c c1efe9d6cf1848350bc91848a8a29963e -m 628117045912798141 -t 'Hello Edited!'",
+  );
   process.exit(1);
 }
 


### PR DESCRIPTION
Implements message edit with optimistic UI updates and rollback on failure.

- edit-message-dialog.tsx: new edit dialog component
- message-bubble.tsx: edit context menu + edited badge + show-original toggle
- message-input.tsx: mute-send (NOTIFICATION_DISABLED) toggle button
- mappers.ts: edited/editedAt/originalText/showOriginal mapping  
- store.ts: optimistic editMessage with rollback + toggleShowOriginal
- lineService.ts: editMessage error handling (NOT_PREMIUM, TOO_OLD)
- types/index.ts: isEdited/updatedTime/originalText types
- docs/analysis/desktop-edit-premium.md: analysis notes

Refs: desktop.edit.premium