### PR TITLE
fix: Docker環境のログ保存と初回同期の不具合を修正

### DIFF
--- a/Vyline/backend/src/line/clientManager.ts
+++ b/Vyline/backend/src/line/clientManager.ts
@@ -260,7 +260,16 @@ function startFetchOpsLoop(client: VylineClient, accountId: string): void {
       } catch (err) {
         if (abort.signal.aborted) break;
         const msg = err instanceof Error ? err.message : String(err);
-        log.warn({ accountId, msg }, "ops loop error, retrying in 5s");
+        const isTimeout =
+          err instanceof Error &&
+          (err.name === "TimeoutError" || err.message === "The operation timed out.");
+        if (isTimeout) {
+          // /SYNC4 は長ポール。新着がないままクライアント側の
+          // 期限を迎えるのは通常の待機終了なので、警告にしない。
+          log.debug({ accountId, msg }, "ops long poll timed out, retrying in 5s");
+        } else {
+          log.warn({ accountId, msg }, "ops loop error, retrying in 5s");
+        }
         await new Promise<void>((resolve) => setTimeout(resolve, 5_000));
       }
     }

--- a/Vyline/backend/src/service/lineService.ts
+++ b/Vyline/backend/src/service/lineService.ts
@@ -2383,12 +2383,10 @@ export async function fetchBootstrap(accountId: string): Promise<BootstrapPayloa
 export async function warmLineCache(accountId: string): Promise<void> {
   await warmAccountCache(accountId);
   // 初回インデックス（裏）— 履歴・プロフィールを chatdb / VylineCache へ
-  void enqueueTalkRpcBackground(accountId, async () => {
-    try {
-      await runAccountIndex(accountId, { topChats: 16, messagesPerChat: 30 });
-    } catch (err) {
-      log.debug({ accountId, err }, "background account index failed");
-    }
+  // runAccountIndex 内の fetchChats が必要な RPC を同じキューに入れるため、
+  // ここで外側まで enqueue すると初回起動時に自己待機になる。
+  void runAccountIndex(accountId, { topChats: 16, messagesPerChat: 30 }).catch((err) => {
+    log.debug({ accountId, err }, "background account index failed");
   });
 }
 

--- a/Vyline/backend/src/storage/messageLog.ts
+++ b/Vyline/backend/src/storage/messageLog.ts
@@ -7,8 +7,8 @@
  * ローテーション: 10MB を超えたら .1 / .2 へ shift。
  */
 
-import { createWriteStream, existsSync, type WriteStream } from "node:fs";
-import { mkdir, readFile, rename, stat } from "node:fs/promises";
+import { createWriteStream, existsSync, mkdirSync, type WriteStream } from "node:fs";
+import { readFile, rename, stat } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { childLogger } from "../logger.js";
@@ -16,7 +16,8 @@ import { childLogger } from "../logger.js";
 const log = childLogger("message-log");
 
 const _dir = dirname(fileURLToPath(import.meta.url));
-const LOG_DIR = process.env.VYLINE_LOG_DIR ?? join(_dir, "../../data/logs");
+const DATA_DIR = process.env.VYLINE_DATA_DIR ?? join(_dir, "../../data");
+const LOG_DIR = process.env.VYLINE_LOG_DIR ?? join(DATA_DIR, "logs");
 const ROTATE_BYTES = Number(process.env.VYLINE_MESSAGE_LOG_MAX_BYTES ?? 10 * 1024 * 1024);
 
 export interface MessageLogEntry {
@@ -53,17 +54,19 @@ function logPath(accountId: string): string {
 }
 
 function streamFor(accountId: string): WriteStream {
-  let s = streams.get(accountId);
-  if (s) return s;
-  if (!existsSync(LOG_DIR)) {
-    // mkdir は非同期なので write 側で再試行させるため先に作成
-    import("node:fs/promises").then(({ mkdir }) =>
-      mkdir(LOG_DIR, { recursive: true }).catch(() => undefined),
-    );
-  }
-  s = createWriteStream(logPath(accountId), { flags: "a", encoding: "utf8" });
-  streams.set(accountId, s);
-  return s;
+  const existing = streams.get(accountId);
+  if (existing) return existing;
+
+  // createWriteStream は親ディレクトリを作成しない。
+  // 非同期 mkdir と open の競合を避け、ストリームを開く前に必ず作成する。
+  mkdirSync(LOG_DIR, { recursive: true });
+  const stream = createWriteStream(logPath(accountId), { flags: "a", encoding: "utf8" });
+  streams.set(accountId, stream);
+  stream.on("error", (err) => {
+    if (streams.get(accountId) === stream) streams.delete(accountId);
+    log.debug({ accountId, err }, "message log stream error");
+  });
+  return stream;
 }
 
 async function maybeRotate(accountId: string): Promise<void> {


### PR DESCRIPTION
## Summary

Dockerセルフホスト環境で発生していた、詳細ログ書き込み時の `ENOENT`、初回インデックスの停止、`/SYNC4` の不要なタイムアウト警告を修正します。

## Changes

- 詳細ログの保存先を `VYLINE_DATA_DIR/logs` に統一
  - `VYLINE_LOG_DIR` が指定されている場合は引き続きそちらを優先
- ログ用ディレクトリを作成してからストリームを開くよう修正
- WriteStreamのエラーを処理し、ログ書き込み失敗でプロセスが終了しないよう修正
- `warmLineCache` と `fetchChats` が同じRPCキューで自己待機するデッドロックを解消
- `/SYNC4` の正常な長ポールタイムアウトを `warn` ではなく `debug` として処理
- タイムアウト以外の受信ループエラーは従来どおり警告として記録

## Test Plan

<!-- テスト項目 -->

- [x] `bun run typecheck` が通る
- [x] `bun run dev` で起動確認
- [x] Docker上のBun 1.2.23でバックエンドの型チェックが通る
- [x] Dockerイメージを再ビルドできる
- [x] コンテナが `healthy` になる
- [x] 保存済みセッションが正常に復元される
- [x] 初回アカウントインデックスが完了する
- [x] 通常・強制のチャット一覧取得が応答する
- [x] 詳細ログが `/data/logs` に作成される
- [x] 書き込み先が利用できない場合もプロセスが終了しない
- [x] `ENOENT` および長ポールのタイムアウト警告が再発しない

## Screenshots

