### PR TITLE
feat: run Vite dev server on Bun runtime

### DIFF
--- a/Vyline/apps/desktop/package.json
+++ b/Vyline/apps/desktop/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "bun ./node_modules/vite/bin/vite.js",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit"


### PR DESCRIPTION
Run Vite dev server on Bun runtime instead of Node.js.

- Vyline/apps/desktop/package.json: dev script changed
- Eliminates node processes for Vite dev server