### PR TITLE
feat: add reaction cache for fast message reaction retrieval

### DIFF
--- a/Vyline/apps/desktop/src/lib/reactionCache.ts
+++ b/Vyline/apps/desktop/src/lib/reactionCache.ts
@@ -1,0 +1,54 @@
+export type MessageReaction = {
+  fromMid: string;
+  atMillis: number;
+  type: number;
+};
+
+export type ReactionsCache = Map<string, MessageReaction[]>;
+
+export function createReactionsCache(): ReactionsCache {
+  return new Map<string, MessageReaction[]>();
+}
+
+export function getReactions(
+  cache: ReactionsCache,
+  messageId: string,
+): MessageReaction[] | undefined {
+  return cache.get(messageId);
+}
+
+export function setReactions(
+  cache: ReactionsCache,
+  messageId: string,
+  reactions: MessageReaction[] | undefined,
+): void {
+  if (reactions && reactions.length > 0) {
+    cache.set(messageId, reactions);
+  } else {
+    cache.delete(messageId);
+  }
+}
+
+export function removeReaction(cache: ReactionsCache, messageId: string, reactorMid: string): void {
+  const reactions = cache.get(messageId);
+  if (!reactions) return;
+
+  const filtered = reactions.filter((r) => r.fromMid !== reactorMid);
+  if (filtered.length === 0) {
+    cache.delete(messageId);
+  } else {
+    cache.set(messageId, filtered);
+  }
+}
+
+export function clearReactions(cache: ReactionsCache, messageId: string): void {
+  cache.delete(messageId);
+}
+
+export function getAllReactions(cache: ReactionsCache): Map<string, MessageReaction[]> {
+  return new Map([...cache.entries()]);
+}
+
+export function invalidateMessage(cache: ReactionsCache, messageId: string): void {
+  cache.delete(messageId);
+}

--- a/Vyline/apps/desktop/src/lib/store.ts
+++ b/Vyline/apps/desktop/src/lib/store.ts
@@ -26,7 +26,7 @@ import { getDismissedChatMids } from "../utils/dismissedChats.js";
 import { parseMentions, type MentionDraft } from "../utils/mention.js";
 import { compressImageFile } from "../utils/compressImage.js";
 import { setHiddenForAccount } from "../hooks/useHiddenChats.js";
-import { reactionCache, type MessageReaction, invalidateMessage } from "./reactionCache.js";
+import { type MessageReaction, invalidateMessage } from "./reactionCache.js";
 
 export type { Chat, ChatSort, Message, Member, VyTheme, Settings, Screen } from "./store-types.js";
 
@@ -49,7 +49,7 @@ const refreshDebounce = new Map<string, ReturnType<typeof setTimeout>>();
 /** accountId → delta 実行間隔制御 */
 const lastDeltaPollAt = new Map<string, number>();
 /** messageId → リアクションのキャッシュ（高速読み込み用） */
-const reactionCache = new Map<string, MessageReaction[]>();
+const messageReactionCache = new Map<string, MessageReaction[]>();
 /** chatId → 進行中のギャップ backfill（重複抑止） */
 const backfillInflight = new Map<string, Promise<void>>();
 /** mid → プロフィール取得済み（重複 API 抑止） */
@@ -725,7 +725,7 @@ export const useStore = create<State>()(
             if (pending.length === 0) {
               mappedMessages.forEach((m) => {
                 if (m.id && m.reactions?.length) {
-                  reactionCache.set(m.id, m.reactions);
+                  messageReactionCache.set(m.id, m.reactions);
                 }
               });
               return mappedMessages;
@@ -1840,7 +1840,7 @@ export const useStore = create<State>()(
                 if (!upd || !upd.reactions?.length) return m;
                 if (JSON.stringify(upd.reactions) === JSON.stringify(m.reactions)) return m;
                 // キャッシュも更新
-                reactionCache.set(m.id, upd.reactions);
+                messageReactionCache.set(m.id, upd.reactions);
                 return { ...m, reactions: upd.reactions };
               })
             : st.messages;
@@ -1907,7 +1907,7 @@ export const useStore = create<State>()(
             m.chatId === chatId && m.id === messageId ? { ...m, revoked: true } : m,
           );
           // キャッシュからも削除
-          invalidateMessage(reactionCache, messageId);
+          invalidateMessage(messageReactionCache, messageId);
           if (msgs.every((m, i) => m === st.messages[i])) return st;
           return { messages: msgs };
         });
@@ -1936,9 +1936,9 @@ export const useStore = create<State>()(
           for (const m of msgs) {
             if (m.id && m.reactions) {
               if (reaction !== "UNDO") {
-                reactionCache.set(m.id, m.reactions);
+                messageReactionCache.set(m.id, m.reactions);
               } else {
-                reactionCache.delete(m.id);
+                messageReactionCache.delete(m.id);
               }
             }
           }

--- a/Vyline/apps/desktop/src/lib/store.ts
+++ b/Vyline/apps/desktop/src/lib/store.ts
@@ -26,6 +26,7 @@ import { getDismissedChatMids } from "../utils/dismissedChats.js";
 import { parseMentions, type MentionDraft } from "../utils/mention.js";
 import { compressImageFile } from "../utils/compressImage.js";
 import { setHiddenForAccount } from "../hooks/useHiddenChats.js";
+import { reactionCache, type MessageReaction, invalidateMessage } from "./reactionCache.js";
 
 export type { Chat, ChatSort, Message, Member, VyTheme, Settings, Screen } from "./store-types.js";
 
@@ -47,6 +48,8 @@ const noticeTimer: { current: ReturnType<typeof setTimeout> | null } = { current
 const refreshDebounce = new Map<string, ReturnType<typeof setTimeout>>();
 /** accountId → delta 実行間隔制御 */
 const lastDeltaPollAt = new Map<string, number>();
+/** messageId → リアクションのキャッシュ（高速読み込み用） */
+const reactionCache = new Map<string, MessageReaction[]>();
 /** chatId → 進行中のギャップ backfill（重複抑止） */
 const backfillInflight = new Map<string, Promise<void>>();
 /** mid → プロフィール取得済み（重複 API 抑止） */
@@ -719,7 +722,14 @@ export const useStore = create<State>()(
             const pending = st.messages.filter(
               (m) => m.id.startsWith("pending_") || m.status === "sending" || m.status === "failed",
             );
-            if (pending.length === 0) return mappedMessages;
+            if (pending.length === 0) {
+              mappedMessages.forEach((m) => {
+                if (m.id && m.reactions?.length) {
+                  reactionCache.set(m.id, m.reactions);
+                }
+              });
+              return mappedMessages;
+            }
             const ids = new Set(mappedMessages.map((m) => m.id));
             const keep = pending.filter((p) => !ids.has(p.id));
             return [...mappedMessages, ...keep];
@@ -1829,6 +1839,8 @@ export const useStore = create<State>()(
                 const upd = incomingById.get(m.id);
                 if (!upd || !upd.reactions?.length) return m;
                 if (JSON.stringify(upd.reactions) === JSON.stringify(m.reactions)) return m;
+                // キャッシュも更新
+                reactionCache.set(m.id, upd.reactions);
                 return { ...m, reactions: upd.reactions };
               })
             : st.messages;
@@ -1894,6 +1906,8 @@ export const useStore = create<State>()(
           const msgs = st.messages.map((m) =>
             m.chatId === chatId && m.id === messageId ? { ...m, revoked: true } : m,
           );
+          // キャッシュからも削除
+          invalidateMessage(reactionCache, messageId);
           if (msgs.every((m, i) => m === st.messages[i])) return st;
           return { messages: msgs };
         });
@@ -1918,6 +1932,16 @@ export const useStore = create<State>()(
             }
             return { ...m, reactions: next.length ? next : undefined };
           });
+          // キャッシュも更新
+          for (const m of msgs) {
+            if (m.id && m.reactions) {
+              if (reaction !== "UNDO") {
+                reactionCache.set(m.id, m.reactions);
+              } else {
+                reactionCache.delete(m.id);
+              }
+            }
+          }
           if (msgs.every((m, i) => m === st.messages[i])) return st;
           return { messages: msgs };
         });


### PR DESCRIPTION
feat: add reaction cache for fast message reaction retrieval

- Create reactionCache.ts with cache type and utility functions
- Integrate cache with store: messageReactionCache Map, setMessageReaction,
  mergeIncomingMessages, hydrateLineData, applyRevoked
- Auto-caches reactions on message fetch, auto-invalidates on changes/deletions

Co-authored-by: Kilo