### PR TITLE
fix: avoid unhandled rejection in withTimeout and fetchContactProfile…

### DIFF
--- a/Vyline/backend/src/line/clientManager.ts
+++ b/Vyline/backend/src/line/clientManager.ts
@@ -93,12 +93,21 @@ const sendQueue = new Map<string, Promise<unknown>>();
 const SEND_TIMEOUT_MS = 15_000;
 
 function withSendTimeout<T>(p: Promise<T>, timeoutMs: number): Promise<T> {
-  return Promise.race([
-    p,
-    new Promise<T>((_, reject) => {
-      setTimeout(() => reject(new Error(`send timed out after ${timeoutMs}ms`)), timeoutMs);
-    }),
-  ]);
+  return new Promise<T>((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      reject(new Error(`send timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    p.then(
+      (value) => {
+        clearTimeout(timeoutId);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timeoutId);
+        reject(error);
+      },
+    );
+  });
 }
 
 export function runSendRpc<T>(

--- a/Vyline/backend/src/service/lineService.ts
+++ b/Vyline/backend/src/service/lineService.ts
@@ -810,12 +810,21 @@ function invalidateBoxCursorCache(accountId: string, chatMid?: string): void {
 }
 
 function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
-  return Promise.race([
-    promise,
-    new Promise<T>((_, reject) => {
-      setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
-    }),
-  ]);
+  return new Promise<T>((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      reject(new Error(`${label} timed out after ${ms}ms`));
+    }, ms);
+    promise.then(
+      (value) => {
+        clearTimeout(timeoutId);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timeoutId);
+        reject(error);
+      },
+    );
+  });
 }
 
 async function resolveMyMid(
@@ -1739,9 +1748,10 @@ export async function fetchContactProfile(
   })();
 
   contactProfileInflight.set(cacheKey, task);
-  void task.finally(() => {
+  const cleanup = () => {
     contactProfileInflight.delete(cacheKey);
-  });
+  };
+  task.then(cleanup, cleanup);
   return task;
 }
 


### PR DESCRIPTION
… inflight

- Replace Promise.race in withTimeout/withSendTimeout with manual Promise implementation to prevent unhandled rejections when the original promise rejects after timeout
- Replace void task.finally() in fetchContactProfile with task.then(cleanup, cleanup) to avoid creating unhandled rejection when the task rejects

## Summary

<!-- 変更内容を1-3行で -->

## Changes

<!-- 具体的な変更点 -->

-
-

## Test Plan

<!-- テスト項目 -->

- [ ] `bun run typecheck` が通る
- [ ] `bun run dev` で起動確認
- [ ]

## Screenshots

<!-- UI変更がある場合 -->

🤖 Generated with [Claude Code](https://claude.ai/code)
