### PR TITLE
feat: message history and revoke/restore support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,7 @@ tools/data/
 .cursor/
 .claude/
 .agents/skills/handoff/
+
+# ── Backend runtime caches (never commit) ────────────────────────
+Vyline/backend/storage/cache/
+Vyline/backend/storage/saved-media/

--- a/Vyline/apps/desktop/src/api/client.ts
+++ b/Vyline/apps/desktop/src/api/client.ts
@@ -28,6 +28,7 @@ import type {
   CallStatusResponse,
   CallActiveResponse,
   CallType,
+  Message,
 } from "@vyline/types";
 
 // re-export for convenience
@@ -269,11 +270,24 @@ export const api = {
     unsend: (accountId: string, messageId: string) =>
       request<UnsendResponse>("POST", `/line/${accountId}/unsend`, { messageId }),
 
+    restoreRevokedMessage: (accountId: string, chatMid: string, messageId: string) =>
+      request<{ ok: true; text?: string | null; contentType?: string }>(
+        "POST",
+        `/line/${accountId}/restore?chatMid=${encodeURIComponent(chatMid)}`,
+        { messageId },
+      ),
+
     editMessage: (accountId: string, chatMid: string, messageId: string, text: string) =>
       request<EditResponse>("POST", `/line/${accountId}/edit`, { chatMid, messageId, text }),
 
     editNotice: (accountId: string, chatMid: string) =>
       request<EditNoticeResponse>("GET", `/line/${accountId}/edit-notice/${chatMid}`),
+
+    messageHistory: (accountId: string, chatMid: string, messageId: string) =>
+      request<{ ok: true; history: Message["history"] }>(
+        "GET",
+        `/line/${accountId}/messages/${encodeURIComponent(chatMid)}/${encodeURIComponent(messageId)}/history`,
+      ),
 
     /** 相手ユーザーのプロフィール取得 (アイコン URL 用) */
     contactProfile: (accountId: string, targetMid: string) =>
@@ -299,6 +313,37 @@ export const api = {
         groups?: Record<string, unknown>;
         error?: string;
       }>("GET", `/line/${accountId}/vyline/cache`),
+
+    vylineStorage: (accountId: string) =>
+      request<{
+        ok: boolean;
+        driveLetter?: string;
+        disk?: { totalBytes: number; freeBytes: number; usedBytes: number };
+        vylineTotal: number;
+        cacheSize: number;
+        cdnSize: number;
+        iconCacheSize: number;
+        savedMediaSize: number;
+        error?: string;
+      }>("GET", `/line/${accountId}/vyline/storage`),
+
+    clearVylineCache: (accountId: string) =>
+      request<{ ok: boolean; removed?: number; error?: string }>(
+        "DELETE",
+        `/line/${accountId}/vyline/cache`,
+      ),
+
+    clearVylineSavedMedia: (accountId: string) =>
+      request<{ ok: boolean; removed?: number; error?: string }>(
+        "DELETE",
+        `/line/${accountId}/vyline/saved-media`,
+      ),
+
+    clearVylineIcons: (accountId: string) =>
+      request<{ ok: boolean; removed?: number; error?: string }>(
+        "DELETE",
+        `/line/${accountId}/vyline/icons`,
+      ),
 
     vylineWarm: (accountId: string, mids: string[]) =>
       request<{ ok: boolean; profiles?: Record<string, unknown>; count?: number; error?: string }>(

--- a/Vyline/apps/desktop/src/components/icons.tsx
+++ b/Vyline/apps/desktop/src/components/icons.tsx
@@ -350,3 +350,11 @@ export const IconHeart = (p: IconProps) => (
     />
   </svg>
 );
+
+export const IconHardDrive = (p: IconProps) => (
+  <svg {...base(p)}>
+    <rect x="2" y="6" width="20" height="12" rx="2" />
+    <path d="M6 10h.01M6 14h.01" />
+    <path d="M2 10h20" />
+  </svg>
+);

--- a/Vyline/apps/desktop/src/components/message-bubble.tsx
+++ b/Vyline/apps/desktop/src/components/message-bubble.tsx
@@ -313,7 +313,7 @@ function Highlighted({
 }
 
 function replySnippet(m: Message): string {
-  if (m.revoked) return "取り消されたメッセージ";
+  if (m.messageState.startsWith("revoked")) return "取り消されたメッセージ";
   if (m.kind === "image") return "写真";
   if (m.kind === "video") return "動画";
   if (m.kind === "audio") return "音声";
@@ -458,6 +458,7 @@ export const MessageBubble = memo(
     const settings = useStore((s) => s.settings);
     const streamerMode = settings.streamerMode;
     const revokeMessage = useStore((s) => s.revokeMessage);
+    const restoreRevokedMessage = useStore((s) => s.restoreRevokedMessage);
     const editMessage = useStore((s) => s.editMessage);
     const retryMessage = useStore((s) => s.retryMessage);
     const markRead = useStore((s) => s.markRead);
@@ -474,6 +475,9 @@ export const MessageBubble = memo(
     const [editing, setEditing] = useState(false);
     const [showOriginal, setShowOriginal] = useState(false);
     const [showReaders, setShowReaders] = useState(false);
+    const [showHistory, setShowHistory] = useState(false);
+    const [history, setHistory] = useState<NonNullable<Message["history"]>>([]);
+    const [historyLoading, setHistoryLoading] = useState(false);
     const [lightbox, setLightbox] = useState(false);
     const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
     const longPressFired = useRef(false);
@@ -494,7 +498,7 @@ export const MessageBubble = memo(
     }
 
     function onTouchStart(e: React.TouchEvent) {
-      if (message.revoked) return;
+      if (message.messageState.startsWith("revoked")) return;
       const t = e.touches[0];
       longPressFired.current = false;
       longPressTimer.current = setTimeout(() => {
@@ -691,7 +695,7 @@ export const MessageBubble = memo(
           ]
         : []),
       ...(isMe &&
-      !message.revoked &&
+      !message.messageState.startsWith("revoked") &&
       message.kind === "text" &&
       message.status !== "sending" &&
       !message.id.startsWith("pending_")
@@ -712,8 +716,35 @@ export const MessageBubble = memo(
             },
           ]
         : []),
+      ...(message.history && message.history.length > 0
+        ? [
+            {
+              label: "履歴を表示",
+              icon: <IconChevron size={16} />,
+              onClick: async () => {
+                setHistoryLoading(true);
+                setShowHistory(true);
+                const h = await useStore.getState().fetchMessageHistory(message.chatId, message.id);
+                setHistory(h ?? []);
+                setHistoryLoading(false);
+              },
+            },
+          ]
+        : []),
       ...(isMe &&
-      !message.revoked &&
+      message.messageState === "revoked-by-self" &&
+      message.history &&
+      message.history.length > 0
+        ? [
+            {
+              label: "復元",
+              icon: <IconCheck size={16} />,
+              onClick: () => restoreRevokedMessage(message.chatId, message.id),
+            },
+          ]
+        : []),
+      ...(isMe &&
+      !message.messageState.startsWith("revoked") &&
       message.status !== "sending" &&
       !message.id.startsWith("pending_")
         ? [
@@ -739,7 +770,7 @@ export const MessageBubble = memo(
     const isMessageEdited = message.edited || Boolean(message.originalText);
 
     const readReceipt = (() => {
-      if (!isMe || message.revoked) return null;
+      if (!isMe || message.messageState.startsWith("revoked")) return null;
       if (message.status === "sending") return <span className="opacity-60">送信中…</span>;
       if (message.status === "failed")
         return (
@@ -786,11 +817,11 @@ export const MessageBubble = memo(
       readers.length > 0 &&
       message.read;
 
-    if (message.kind === "call" && !message.revoked) {
+    if (message.kind === "call" && !message.messageState.startsWith("revoked")) {
       return <CallEventMessage meta={message.callMeta} isMe={isMe} />;
     }
 
-    if (message.kind === "system" && !message.revoked) {
+    if (message.kind === "system" && !message.messageState.startsWith("revoked")) {
       return (
         <div className="my-1 flex w-full justify-center px-1">
           <span className="rounded-full bg-[color-mix(in_oklab,var(--vy-text)_10%,transparent)] px-3 py-1 text-center text-[0.7rem] text-[var(--vy-text-dim)]">
@@ -800,7 +831,7 @@ export const MessageBubble = memo(
       );
     }
 
-    const metaLine = !message.revoked && (
+    const metaLine = !message.messageState.startsWith("revoked") && (
       <div
         className={cn(
           "mt-1 flex items-center gap-1.5 px-1 text-[0.7rem] text-[var(--vy-text-dim)]",
@@ -926,14 +957,26 @@ export const MessageBubble = memo(
             </button>
           )}
 
-          {message.revoked ? (
+          {message.messageState.startsWith("revoked") ? (
             <div
               className="rounded-2xl border border-dashed px-4 py-2 text-sm italic opacity-70"
               style={{ borderColor: "var(--vy-border)" }}
             >
-              {isMe
+              {message.messageState === "revoked-by-self"
                 ? "あなたがメッセージの送信を取り消しました"
                 : "メッセージの送信が取り消されました"}
+              {message.messageState === "revoked-by-self" &&
+              message.history &&
+              message.history.length > 0 ? (
+                <div className="mt-1 text-xs not-italic opacity-80">
+                  {(() => {
+                    const last = [...message.history]
+                      .reverse()
+                      .find((h) => h.state === "normal" || h.state === "edited");
+                    return last ? (last.text ?? "（なし）") : "";
+                  })()}
+                </div>
+              ) : null}
             </div>
           ) : message.kind === "sticker" ? (
             <button
@@ -1176,14 +1219,16 @@ export const MessageBubble = memo(
 
           {metaLine}
           {readerList}
-          {message.reactions && message.reactions.length > 0 && !message.revoked && (
-            <ReactionBadges
-              reactions={message.reactions}
-              myMid={self?.mid ?? ""}
-              onReact={react}
-              side={isMe ? "right" : "left"}
-            />
-          )}
+          {message.reactions &&
+            message.reactions.length > 0 &&
+            !message.messageState.startsWith("revoked") && (
+              <ReactionBadges
+                reactions={message.reactions}
+                myMid={self?.mid ?? ""}
+                onReact={react}
+                side={isMe ? "right" : "left"}
+              />
+            )}
         </div>
 
         {menu && (
@@ -1209,6 +1254,54 @@ export const MessageBubble = memo(
             kind={message.kind === "video" ? "video" : "image"}
             onClose={() => setLightbox(false)}
           />
+        )}
+        {showHistory && (
+          <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+            onClick={(e) => {
+              if (e.target === e.currentTarget) setShowHistory(false);
+            }}
+          >
+            <div className="max-h-[80vh] w-[360px] overflow-y-auto rounded-xl border border-[var(--vy-border)] bg-[var(--vy-surface)] p-4 shadow-xl">
+              <div className="mb-3 flex items-center justify-between">
+                <h3 className="text-sm font-semibold">メッセージ履歴</h3>
+                <button
+                  type="button"
+                  onClick={() => setShowHistory(false)}
+                  className="rounded p-1 hover:bg-[var(--vy-surface-2)]"
+                >
+                  ✕
+                </button>
+              </div>
+              {historyLoading && <p className="text-xs text-[var(--vy-text-dim)]">読み込み中...</p>}
+              {!historyLoading && history.length === 0 && (
+                <p className="text-xs text-[var(--vy-text-dim)]">履歴がありません</p>
+              )}
+              {!historyLoading &&
+                history.map((entry, i) => (
+                  <div
+                    key={i}
+                    className="mb-2 rounded-lg border border-[var(--vy-border)] bg-[var(--vy-surface-2)] p-2.5"
+                  >
+                    <div className="mb-1 flex items-center gap-2 text-[0.65rem] text-[var(--vy-text-dim)]">
+                      <span className="rounded bg-[color-mix(in_oklab,var(--vy-text)_10%,transparent)] px-1.5 py-0.5">
+                        {entry.state === "normal"
+                          ? "通常"
+                          : entry.state === "edited"
+                            ? "編集済み"
+                            : entry.state === "revoked-by-other"
+                              ? "相手が削除"
+                              : "自分が削除"}
+                      </span>
+                      <span>{new Date(entry.updatedTime).toLocaleString()}</span>
+                    </div>
+                    <p className="whitespace-pre-wrap break-words text-sm">
+                      {entry.text ?? <span className="italic opacity-60">（なし）</span>}
+                    </p>
+                  </div>
+                ))}
+            </div>
+          </div>
         )}
       </div>
     );

--- a/Vyline/apps/desktop/src/components/message-input.tsx
+++ b/Vyline/apps/desktop/src/components/message-input.tsx
@@ -17,15 +17,16 @@ import { segmentTextWithSticon, type SticonResource } from "@/utils/lineSticon";
 import { buildMentionMetadata, recomputeMentionsOnEdit } from "@/utils/mention";
 import { mapMember } from "@/lib/mappers";
 import { PlusMenu } from "@/components/plus-menu";
+import type { MessageState } from "@/lib/store-types";
 
 function replyPreviewText(msg: {
   kind: string;
   text?: string;
   altText?: string;
   sticker?: string;
-  revoked?: boolean;
+  messageState?: MessageState;
 }): string {
-  if (msg.revoked) return "取り消されたメッセージ";
+  if (msg.messageState?.startsWith("revoked")) return "取り消されたメッセージ";
   if (msg.kind === "image") return "写真";
   if (msg.kind === "video") return "動画";
   if (msg.kind === "audio") return "音声メッセージ";

--- a/Vyline/apps/desktop/src/components/settings-sections.tsx
+++ b/Vyline/apps/desktop/src/components/settings-sections.tsx
@@ -11,6 +11,15 @@ function formatRelativeTime(ts: number): string {
   if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}時間前`;
   return `${Math.floor(diff / 86_400_000)}日前`;
 }
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return "0 B";
+  const k = 1024;
+  const sizes = ["B", "KB", "MB", "GB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${(bytes / k ** i).toFixed(1)} ${sizes[i]}`;
+}
+
 import { Toggle, Avatar } from "@/components/vy-ui";
 import { VyThemePanel } from "@/components/vy-theme-panel";
 import {
@@ -23,6 +32,9 @@ import {
   IconChevron,
   IconSpark,
   IconBell,
+  IconHardDrive,
+  IconTrash,
+  IconDownload,
 } from "@/components/icons";
 
 type Section =
@@ -33,6 +45,7 @@ type Section =
   | "privacy"
   | "notifications"
   | "advanced"
+  | "storage"
   | "info";
 
 const NAV: { key: Section; label: string; icon: React.ReactNode }[] = [
@@ -43,6 +56,7 @@ const NAV: { key: Section; label: string; icon: React.ReactNode }[] = [
   { key: "notifications", label: "通知", icon: <IconBell size={18} /> },
   { key: "privacy", label: "プライバシー", icon: <IconShield size={18} /> },
   { key: "advanced", label: "詳細・復元", icon: <IconChevron size={18} /> },
+  { key: "storage", label: "ストレージ", icon: <IconHardDrive size={18} /> },
   { key: "info", label: "情報", icon: <IconSpark size={18} /> },
 ];
 
@@ -487,6 +501,8 @@ export function SettingsSections() {
 
               {section === "advanced" && <AdvancedSection />}
 
+              {section === "storage" && <StorageSection />}
+
               {section === "info" && <InfoSection />}
             </div>
           </div>
@@ -813,14 +829,6 @@ function AdvancedSection() {
             インポート
           </button>
         </Row>
-        <Row title="キャッシュを削除" desc="メディアの一時ファイルを削除します">
-          <button
-            type="button"
-            className="rounded-lg border border-[var(--vy-border)] px-3 py-1.5 text-xs font-medium transition-colors hover:bg-[var(--vy-surface-2)]"
-          >
-            削除
-          </button>
-        </Row>
         <Row title="デバッグログを表示" desc="接続状態や送受信ログを確認します（開発者向け）">
           <button
             type="button"
@@ -889,6 +897,215 @@ function AdvancedSection() {
       {!accountId && (
         <p className="mt-3 px-1 text-xs text-[var(--vy-text-dim)]">
           復元には LINE ログインが必要です。
+        </p>
+      )}
+    </Section>
+  );
+}
+
+function StorageSection() {
+  const accountId = useStore((s) => s.accountId);
+  const [storage, setStorage] = useState<{
+    ok: boolean;
+    driveLetter?: string;
+    disk?: { totalBytes: number; freeBytes: number; usedBytes: number };
+    vylineTotal: number;
+    cacheSize: number;
+    savedMediaSize: number;
+    error?: string;
+  } | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [msg, setMsg] = useState<string | null>(null);
+
+  const load = async () => {
+    if (!accountId) return;
+    setLoading(true);
+    setMsg(null);
+    try {
+      const res = await api.line.vylineStorage(accountId);
+      if (res.ok) setStorage(res);
+      else setMsg(res.error ?? "取得に失敗しました");
+    } catch (e) {
+      setMsg(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const clearCache = async () => {
+    if (!accountId) return;
+    if (
+      !window.confirm(
+        "キャッシュを削除します。再取得可能なアイコン・スタンプなどのデータが消えます。よろしいですか？",
+      )
+    )
+      return;
+    setLoading(true);
+    setMsg(null);
+    try {
+      const res = await api.line.clearVylineCache(accountId);
+      if (res.ok) {
+        setMsg(`キャッシュを削除しました (${res.removed ?? 0} 件)`);
+        await load();
+      } else {
+        setMsg(res.error ?? "削除に失敗しました");
+      }
+    } catch (e) {
+      setMsg(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const clearSavedMedia = async () => {
+    if (!accountId) return;
+    if (
+      !window.confirm(
+        "保存メディアを削除します。チャットの画像・動画・ファイルがすべて消えます。この操作は取り消せません。よろしいですか？",
+      )
+    )
+      return;
+    setLoading(true);
+    setMsg(null);
+    try {
+      const res = await api.line.clearVylineSavedMedia(accountId);
+      if (res.ok) {
+        setMsg(`保存メディアを削除しました (${res.removed ?? 0} 件)`);
+        await load();
+      } else {
+        setMsg(res.error ?? "削除に失敗しました");
+      }
+    } catch (e) {
+      setMsg(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void load();
+  }, [accountId]);
+
+  const cachePct =
+    storage && storage.vylineTotal > 0 ? (storage.cacheSize / storage.vylineTotal) * 100 : 0;
+  const mediaPct =
+    storage && storage.vylineTotal > 0 ? (storage.savedMediaSize / storage.vylineTotal) * 100 : 0;
+
+  return (
+    <Section title="ストレージ" desc="アプリが使用している容量を管理します">
+      {storage && (
+        <div className="mb-6 overflow-hidden rounded-2xl border border-[var(--vy-border)] bg-[var(--vy-surface)]">
+          <div className="p-5">
+            <div className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
+              <div>
+                <p className="text-sm font-medium text-[var(--vy-text-dim)]">
+                  ドライブ {storage.driveLetter ?? "---"}
+                </p>
+                {storage.disk && (
+                  <p className="text-xs text-[var(--vy-text-dim)]">
+                    合計 {formatBytes(storage.disk.totalBytes)} / 空き{" "}
+                    {formatBytes(storage.disk.freeBytes)}
+                  </p>
+                )}
+              </div>
+              <p className="text-2xl font-bold tracking-tight">
+                {formatBytes(storage.vylineTotal)}
+              </p>
+            </div>
+
+            <div className="mt-4 flex h-3 overflow-hidden rounded-full bg-[var(--vy-surface-2)]">
+              <div
+                className="h-full bg-[var(--vy-accent)] transition-all duration-500"
+                style={{ width: `${cachePct}%` }}
+              />
+              <div
+                className="h-full bg-[var(--vy-danger)] transition-all duration-500"
+                style={{ width: `${mediaPct}%` }}
+              />
+            </div>
+
+            <div className="mt-3 flex flex-wrap items-center gap-4 text-xs text-[var(--vy-text-dim)]">
+              <span className="flex items-center gap-1.5">
+                <span className="inline-block h-2 w-2 rounded-full bg-[var(--vy-accent)]" />
+                キャッシュ {formatBytes(storage.cacheSize)}
+              </span>
+              <span className="flex items-center gap-1.5">
+                <span className="inline-block h-2 w-2 rounded-full bg-[var(--vy-danger)]" />
+                保存メディア {formatBytes(storage.savedMediaSize)}
+              </span>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="overflow-hidden rounded-2xl border border-[var(--vy-border)] bg-[var(--vy-surface)]">
+          <div className="p-5">
+            <div className="flex items-center gap-3">
+              <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-[color-mix(in_oklab,var(--vy-accent)_18%,var(--vy-surface-2))]">
+                <IconDownload size={20} className="text-[var(--vy-accent)]" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-medium">キャッシュ</p>
+                <p className="text-xs text-[var(--vy-text-dim)]">
+                  アイコン・スタンプなど再取得可能
+                </p>
+              </div>
+            </div>
+            <div className="mt-4 flex items-baseline justify-between">
+              <span className="text-lg font-semibold font-mono">
+                {storage ? formatBytes(storage.cacheSize) : "---"}
+              </span>
+            </div>
+            <button
+              type="button"
+              onClick={clearCache}
+              disabled={loading || !accountId}
+              className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-xl border border-[var(--vy-border)] px-3 py-2 text-xs font-medium transition-colors hover:bg-[var(--vy-surface-2)] disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <IconTrash size={14} />
+              {loading ? "処理中…" : "キャッシュを削除"}
+            </button>
+          </div>
+        </div>
+
+        <div className="overflow-hidden rounded-2xl border border-[var(--vy-danger)]/30 bg-[var(--vy-surface)]">
+          <div className="p-5">
+            <div className="flex items-center gap-3">
+              <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-[color-mix(in_oklab,var(--vy-danger)_12%,var(--vy-surface-2))]">
+                <IconHardDrive size={20} className="text-[var(--vy-danger)]" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-medium">保存メディア</p>
+                <p className="text-xs text-[var(--vy-text-dim)]">チャット画像・動画・ファイル</p>
+              </div>
+            </div>
+            <div className="mt-4 flex items-baseline justify-between">
+              <span className="text-lg font-semibold font-mono">
+                {storage ? formatBytes(storage.savedMediaSize) : "---"}
+              </span>
+            </div>
+            <button
+              type="button"
+              onClick={clearSavedMedia}
+              disabled={loading || !accountId}
+              className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-xl border border-[var(--vy-danger)] px-3 py-2 text-xs font-medium text-[var(--vy-danger)] transition-colors hover:bg-[color-mix(in_oklab,var(--vy-danger)_12%,transparent)] disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <IconTrash size={14} />
+              {loading ? "処理中…" : "保存メディアを削除"}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {msg && (
+        <div className="mt-4 rounded-xl border border-[var(--vy-border)] bg-[var(--vy-surface)] px-4 py-3">
+          <p className="text-xs text-[var(--vy-text-dim)]">{msg}</p>
+        </div>
+      )}
+      {!accountId && (
+        <p className="mt-3 px-1 text-xs text-[var(--vy-text-dim)]">
+          ストレージ情報を取得するにはログインが必要です。
         </p>
       )}
     </Section>

--- a/Vyline/apps/desktop/src/components/sidebar.tsx
+++ b/Vyline/apps/desktop/src/components/sidebar.tsx
@@ -69,7 +69,7 @@ function buildPreviewMap(
       continue;
     }
     let text = "";
-    if (last.revoked) text = "メッセージの送信を取り消しました";
+    if (last.messageState.startsWith("revoked")) text = "メッセージの送信を取り消しました";
     else if (last.kind === "sticker") text = last.altText || "[スタンプ]";
     else if (last.kind === "image") text = "[画像]";
     else if (last.kind === "video") text = "[動画]";

--- a/Vyline/apps/desktop/src/hooks/useVylineSync.ts
+++ b/Vyline/apps/desktop/src/hooks/useVylineSync.ts
@@ -157,7 +157,7 @@ export function useVylineSync(enabled = true) {
           m.authorId === "me" &&
           m.id &&
           !m.id.startsWith("pending_") &&
-          !m.revoked &&
+          !m.messageState.startsWith("revoked") &&
           now - m.createdAt < 15 * 60_000,
       );
     };

--- a/Vyline/apps/desktop/src/lib/mappers.ts
+++ b/Vyline/apps/desktop/src/lib/mappers.ts
@@ -226,7 +226,13 @@ export function mapMessage(
   _contactCache?: Map<string, ContactInfo>,
 ): Message {
   const kind = messageKind(m);
-  const revoked = m.contentType === "UNSENT" || m.contentType === "UNSEND";
+  const messageState =
+    m.messageState ??
+    (m.contentType === "UNSENT" || m.contentType === "UNSEND"
+      ? m.isMyMessage
+        ? "revoked-by-self"
+        : "revoked-by-other"
+      : "normal");
   const stickerId = extractStickerId(m.contentMetadata ?? null);
   const authorId = m.isMyMessage ? "me" : m.from;
 
@@ -239,7 +245,11 @@ export function mapMessage(
     audioSrc = `/api/line/${encodeURIComponent(accountId)}/media/${encodeURIComponent(chatId)}/${encodeURIComponent(m.id)}?preview=0`;
   }
 
-  const read = m.isMyMessage ? Boolean(m.seen || (m.readCount != null && m.readCount > 0)) : true;
+  const read = m.isMyMessage
+    ? m.seen ||
+      (m.readCount != null && m.readCount > 0) ||
+      (m.seen === undefined && m.readCount === undefined)
+    : true;
 
   let text = sanitizeText(m.text);
   if (kind === "system") {
@@ -311,7 +321,7 @@ export function mapMessage(
     status: messageStatus(m),
     read,
     readBy: m.readBy,
-    revoked,
+    messageState,
     replyToId: m.relatedMessageId ?? undefined,
     reactions: m.reactions
       ?.filter((r) => Number.isFinite(r.type))
@@ -330,6 +340,7 @@ export function mapMessage(
       Boolean(m.originalText),
     editedAt: m.updatedTime != null && m.updatedTime > 0 ? m.updatedTime : undefined,
     originalText: m.originalText || (meta?.ORIGINAL_TEXT as string | undefined),
+    history: m.history?.length ? m.history : undefined,
     contact,
     location,
   };

--- a/Vyline/apps/desktop/src/lib/store-types.ts
+++ b/Vyline/apps/desktop/src/lib/store-types.ts
@@ -71,6 +71,8 @@ export type LinkPreview = {
   site: string;
 };
 
+export type MessageState = "normal" | "edited" | "revoked-by-other" | "revoked-by-self";
+
 export type Message = {
   id: string;
   chatId: string;
@@ -100,7 +102,7 @@ export type Message = {
   read: boolean;
   readBy?: string[];
   readCount?: number;
-  revoked?: boolean;
+  messageState: MessageState;
   replyToId?: string;
   /** 絵文字リアクション（type は MessageReactionType 数値） */
   reactions?: MessageReaction[];
@@ -116,6 +118,13 @@ export type Message = {
   originalText?: string;
   /** 編集前の元テキストを表示中かどうか */
   showOriginal?: boolean;
+  /** 状態変更履歴 */
+  history?: Array<{
+    state: MessageState;
+    text: string | null;
+    contentType: string;
+    updatedTime: number;
+  }>;
   linkPreview?: LinkPreview;
   /** 失敗時の再送に使う送信意図（楽観メッセージに保持） */
   retry?: RetryIntent;

--- a/Vyline/apps/desktop/src/lib/store.ts
+++ b/Vyline/apps/desktop/src/lib/store.ts
@@ -27,8 +27,18 @@ import { parseMentions, type MentionDraft } from "../utils/mention.js";
 import { compressImageFile } from "../utils/compressImage.js";
 import { setHiddenForAccount } from "../hooks/useHiddenChats.js";
 import { invalidateMessage } from "./reactionCache.js";
+import type { MessageState } from "./store-types.js";
 
-export type { Chat, ChatSort, Message, Member, VyTheme, Settings, Screen } from "./store-types.js";
+export type {
+  Chat,
+  ChatSort,
+  Message,
+  Member,
+  VyTheme,
+  Settings,
+  Screen,
+  MessageState,
+} from "./store-types.js";
 
 /** chatId → 送信済み lastMessageId（既読 API の重複抑止） */
 const readReceiptSent = new Map<string, string>();
@@ -151,7 +161,15 @@ function applyReadWatermarkLocal(
 }
 
 function messagePreview(m: Message): string {
-  if (m.revoked) return "メッセージの送信を取り消しました";
+  if (m.messageState.startsWith("revoked")) {
+    if (m.messageState === "revoked-by-self" && m.history?.length) {
+      const last = [...m.history]
+        .reverse()
+        .find((h) => h.state === "normal" || h.state === "edited");
+      if (last?.text) return last.text;
+    }
+    return "メッセージの送信を取り消しました";
+  }
   switch (m.kind) {
     case "sticker":
       return m.altText || "スタンプ";
@@ -332,8 +350,11 @@ type State = {
     opts?: { silent?: boolean },
   ) => void;
   applyRevoked: (chatId: string, messageId: string) => void;
+  /** 取消し済みメッセージを履歴から復元 */
+  restoreRevokedMessage: (chatId: string, messageId: string) => Promise<void>;
   /** 楽観リアクション更新（UNDO は自分の全リアクション除去） */
   setMessageReaction: (messageId: string, reaction: "UNDO" | string, myMid: string) => void;
+  fetchMessageHistory: (chatId: string, messageId: string) => Promise<Message["history"]>;
   backfillChat: (chatId: string) => Promise<void>;
   pollMessagesDelta: (chatId: string) => Promise<void>;
   pollIncoming: () => Promise<void>;
@@ -752,6 +773,7 @@ export const useStore = create<State>()(
           createdAt: Date.now(),
           status: "sending",
           read: false,
+          messageState: "normal",
           replyToId: relatedMessageId,
           retry: {
             kind: "text",
@@ -834,6 +856,7 @@ export const useStore = create<State>()(
           createdAt: Date.now(),
           status: "sending",
           read: false,
+          messageState: "normal",
           retry: { kind: "sticker", packageId, stickerId, isPremium },
         };
         set((st) => ({ messages: [...st.messages, optimistic] }));
@@ -922,6 +945,7 @@ export const useStore = create<State>()(
           createdAt: Date.now(),
           status: "sending",
           read: false,
+          messageState: "normal",
           retry: { kind: "emoji", packageId, sticonId },
         };
         set((st) => ({ messages: [...st.messages, optimistic] }));
@@ -976,6 +1000,7 @@ export const useStore = create<State>()(
           createdAt: Date.now(),
           status: "sending",
           read: false,
+          messageState: "normal",
         };
         set((st) => ({ messages: [...st.messages, optimistic] }));
         void (async () => {
@@ -1078,11 +1103,22 @@ export const useStore = create<State>()(
           window.alert("送信が完了してから取り消しできます");
           return;
         }
+        const prevState = msg.messageState ?? "normal";
+        const historyEntry = {
+          state: prevState,
+          text: msg.text ?? null,
+          contentType: msg.kind,
+          updatedTime: Date.now(),
+        };
+        set((st) => ({
+          messages: st.messages.map((m) =>
+            m.id === id ? { ...m, history: [...(m.history ?? []), historyEntry] } : m,
+          ),
+        }));
         const res = await api.line.unsend(accountId, id);
         if (res.ok && activeChatId) await get().refreshMessages(activeChatId, { force: true });
         else if (!res.ok) {
           const errText = res.error ?? "";
-          // 送信取り消し可能な時間を過ぎた（MESSAGE_NOT_DESTRUCTIBLE / message too old）
           if (
             errText.includes("MESSAGE_NOT_DESTRUCTIBLE") ||
             errText.includes("message too old") ||
@@ -1158,7 +1194,14 @@ export const useStore = create<State>()(
       retryMessage: async (id) => {
         const accountId = get().accountId;
         const msg = get().messages.find((m) => m.id === id);
-        if (!accountId || !msg || msg.status !== "failed" || msg.revoked || !msg.retry) return;
+        if (
+          !accountId ||
+          !msg ||
+          msg.status !== "failed" ||
+          msg.messageState.startsWith("revoked") ||
+          !msg.retry
+        )
+          return;
         const chatId = msg.chatId;
         const intent = msg.retry;
         set((st) => ({
@@ -1240,6 +1283,10 @@ export const useStore = create<State>()(
         const { accountId, messages, settings, readDisabledMids } = get();
         set((st) => ({
           chats: st.chats.map((c) => (c.id === id ? { ...c, unread: 0 } : c)),
+          messages: st.messages.map((m) => {
+            if (m.chatId !== id) return m;
+            return { ...m, read: true, status: "read" };
+          }),
         }));
         // 全体無効（設定）または個別無効（右クリック）なら送信しない
         if (!accountId || !settings.readReceipts || readDisabledMids[id]) return;
@@ -1475,9 +1522,21 @@ export const useStore = create<State>()(
                     readBy: m.readBy?.length ? m.readBy : prev.readBy,
                     readCount: m.readCount ?? prev.readCount,
                   };
-                } else if (prev?.readBy?.length && !m.readBy?.length) {
+                } else if (prev?.readBy?.length && (!m.readBy?.length || !m.read)) {
                   mapped[i] = {
                     ...m,
+                    read: true,
+                    readBy: prev.readBy,
+                    readCount: m.readCount ?? prev.readCount,
+                  };
+                } else if (
+                  prev?.readBy?.length &&
+                  m.readBy?.length &&
+                  prev.readBy.length > m.readBy.length
+                ) {
+                  mapped[i] = {
+                    ...m,
+                    read: true,
                     readBy: prev.readBy,
                     readCount: m.readCount ?? prev.readCount,
                   };
@@ -1596,7 +1655,7 @@ export const useStore = create<State>()(
                 m.authorId === "me" &&
                 m.id &&
                 !m.id.startsWith("pending_") &&
-                !m.revoked,
+                !m.messageState.startsWith("revoked"),
             )
             .map((m) => m.id)
             .slice(-50);
@@ -1700,17 +1759,20 @@ export const useStore = create<State>()(
               const patch = res.receipts![m.id];
               if (!patch) return m;
               const readBy = patch.readBy ?? [];
+              const alreadyRead = m.read;
               const read =
                 patch.seen === true ||
                 Boolean((patch as { read?: boolean }).read) ||
                 (patch.readCount != null && patch.readCount > 0) ||
                 readBy.length > 0;
+              // 既読フラグが一度立っている場合は立てたままにする（未読にしない）
+              const finalRead = alreadyRead ? true : read;
               return {
                 ...m,
-                read,
-                readBy: readBy.length ? readBy : m.readBy,
-                readCount: patch.readCount ?? m.readCount,
-                status: read ? ("read" as const) : m.status === "read" ? "sent" : m.status,
+                read: finalRead,
+                readBy: finalRead ? (readBy.length ? readBy : m.readBy) : m.readBy,
+                readCount: finalRead ? (patch.readCount ?? m.readCount) : m.readCount,
+                status: finalRead ? ("read" as const) : m.status === "read" ? "sent" : m.status,
               };
             }),
           }));
@@ -1833,14 +1895,76 @@ export const useStore = create<State>()(
 
       applyRevoked: (chatId, messageId) => {
         set((st) => {
-          const msgs = st.messages.map((m) =>
-            m.chatId === chatId && m.id === messageId ? { ...m, revoked: true } : m,
-          );
-          // キャッシュからも削除
+          const msgs = st.messages.map((m) => {
+            if (m.chatId !== chatId || m.id !== messageId) return m;
+            const prevState = m.messageState ?? "normal";
+            const history = [
+              ...(m.history ?? []),
+              {
+                state: prevState,
+                text: m.text ?? null,
+                contentType: m.kind,
+                updatedTime: Date.now(),
+              },
+            ];
+            return {
+              ...m,
+              messageState: (m.authorId === "me"
+                ? "revoked-by-self"
+                : "revoked-by-other") as MessageState,
+              history,
+              text: undefined,
+            };
+          });
           invalidateMessage(messageReactionCache, messageId);
           if (msgs.every((m, i) => m === st.messages[i])) return st;
           return { messages: msgs };
         });
+      },
+
+      fetchMessageHistory: async (chatId, messageId) => {
+        const accountId = get().accountId;
+        if (!accountId) return [];
+        const res = await api.line.messageHistory(accountId, chatId, messageId);
+        if (res.ok) return res.history ?? [];
+        return [];
+      },
+
+      restoreRevokedMessage: async (_chatId, messageId) => {
+        const accountId = get().accountId;
+        if (!accountId) return;
+        const msg = get().messages.find((m) => m.id === messageId);
+        if (!msg || msg.messageState !== "revoked-by-self") return;
+        const lastNormal = [...(msg.history ?? [])]
+          .reverse()
+          .find((h) => h.state === "normal" || h.state === "edited");
+        if (!lastNormal) {
+          window.alert("復元できる元のメッセージがありません");
+          return;
+        }
+        const historyEntry = {
+          state: "normal" as const,
+          text: msg.text ?? null,
+          contentType: msg.kind,
+          updatedTime: Date.now(),
+        };
+        set((st) => ({
+          messages: st.messages.map((m) =>
+            m.id === messageId
+              ? {
+                  ...m,
+                  messageState: "normal" as MessageState,
+                  history: [...(m.history ?? []), historyEntry],
+                  text: lastNormal.text ?? undefined,
+                }
+              : m,
+          ),
+        }));
+        try {
+          await api.line.restoreRevokedMessage(accountId, _chatId, messageId);
+        } catch {
+          /* local update already applied */
+        }
       },
 
       setMessageReaction: (messageId, reaction, myMid) => {

--- a/Vyline/backend/src/api/line.ts
+++ b/Vyline/backend/src/api/line.ts
@@ -75,6 +75,8 @@ import {
   listDirectCalls,
   CallNotAllowedError,
   NotLoggedInError,
+  restoreRevokedMessage,
+  getMessageHistory,
 } from "../service/lineService.js";
 import {
   LiffNotLoggedInError,
@@ -571,6 +573,43 @@ lineRouter.post("/:accountId/unsend", async (c) => {
   try {
     await unsendMessage(accountId, body.messageId);
     return c.json({ ok: true });
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+// ─── POST /line/:accountId/restore ─────────────
+
+lineRouter.post("/:accountId/restore", async (c) => {
+  const accountId = c.req.param("accountId");
+  const body = await c.req.json<{ messageId?: string }>();
+
+  if (!body.messageId) {
+    return c.json({ ok: false, error: "messageId required" }, 400);
+  }
+
+  try {
+    const chatMid = c.req.query("chatMid") ?? "";
+    const restored = await restoreRevokedMessage(accountId, chatMid, body.messageId);
+    if (!restored) {
+      return c.json({ ok: false, error: "no history to restore" }, 400);
+    }
+    return c.json({ ok: true, text: restored.text, contentType: restored.contentType });
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+// ─── GET /line/:accountId/messages/:chatMid/:messageId/history ──
+
+lineRouter.get("/:accountId/messages/:chatMid/:messageId/history", async (c) => {
+  const accountId = c.req.param("accountId");
+  const chatMid = c.req.param("chatMid");
+  const messageId = c.req.param("messageId");
+
+  try {
+    const history = await getMessageHistory(accountId, chatMid, messageId);
+    return c.json({ ok: true, history });
   } catch (err) {
     return handleError(err, c);
   }
@@ -1624,6 +1663,52 @@ lineRouter.get("/:accountId/log", async (c) => {
   const limit = Math.min(Number(c.req.query("limit") ?? 200) || 200, 2000);
   try {
     return c.json({ ok: true, data: await readRecentMessageLog(accountId, limit) });
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+// ─── Vyline Storage ────────────────────────────────────────
+
+lineRouter.get("/:accountId/vyline/storage", async (c) => {
+  const accountId = c.req.param("accountId");
+  try {
+    const { getVylineStorageInfo } = await import("../storage/vylineStorageInfo.js");
+    const info = await getVylineStorageInfo();
+    return c.json(info);
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+lineRouter.delete("/:accountId/vyline/cache", async (c) => {
+  const accountId = c.req.param("accountId");
+  try {
+    const { clearCdnCache } = await import("../storage/cdnAssetCache.js");
+    const removed = await clearCdnCache();
+    return c.json({ ok: true, removed });
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+lineRouter.delete("/:accountId/vyline/saved-media", async (c) => {
+  const accountId = c.req.param("accountId");
+  try {
+    const { clearMediaCache } = await import("../storage/mediaCache.js");
+    const removed = await clearMediaCache();
+    return c.json({ ok: true, removed });
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+lineRouter.delete("/:accountId/vyline/icons", async (c) => {
+  const accountId = c.req.param("accountId");
+  try {
+    const { clearCdnCache } = await import("../storage/cdnAssetCache.js");
+    const removed = await clearCdnCache();
+    return c.json({ ok: true, removed });
   } catch (err) {
     return handleError(err, c);
   }

--- a/Vyline/backend/src/service/lineService.ts
+++ b/Vyline/backend/src/service/lineService.ts
@@ -73,11 +73,15 @@ import {
   upsertChats,
   upsertMessages,
   markMessageRevoked,
+  restoreRevokedMessage,
+  getMessageHistory,
   warmAccountCache,
   saveBoxOrder,
   type BootstrapPayload,
   type StoredChat,
 } from "../storage/chatStore.js";
+
+export { restoreRevokedMessage, getMessageHistory } from "../storage/chatStore.js";
 import { CallNotAllowedError, callAllowlistHint, isAllowedCallTarget } from "../call/allowlist.js";
 import { appendMessageLog, type MessageLogEntry } from "../storage/messageLog.js";
 

--- a/Vyline/backend/src/storage/cdnAssetCache.ts
+++ b/Vyline/backend/src/storage/cdnAssetCache.ts
@@ -6,6 +6,7 @@
  */
 
 import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
 import { mkdir, readFile, readdir, writeFile, stat } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -21,7 +22,18 @@ const ALLOWED_HOSTS = new Set([
 ]);
 
 const _dir = dirname(fileURLToPath(import.meta.url));
-const CACHE_ROOT = process.env.VYLINE_CDN_CACHE_DIR ?? join(_dir, "../../data/cdn-cache");
+const LEGACY_ROOT = join(_dir, "../../data/cdn-cache");
+const CACHE_ROOT = process.env.VYLINE_CDN_CACHE_DIR ?? join(_dir, "../../storage/cache/cdn-cache");
+
+try {
+  if (!existsSync(CACHE_ROOT) && existsSync(LEGACY_ROOT)) {
+    const { rename } = await import("node:fs/promises");
+    await mkdir(dirname(CACHE_ROOT), { recursive: true });
+    await rename(LEGACY_ROOT, CACHE_ROOT);
+  }
+} catch {
+  /* ignore */
+}
 
 const memory = new Map<string, { buf: Uint8Array; contentType: string; at: number }>();
 const MEMORY_MAX = 80;
@@ -225,4 +237,65 @@ export async function ensureCdnCacheDir(): Promise<void> {
   } catch {
     /* ignore */
   }
+}
+
+export async function getCdnCacheSize(): Promise<number> {
+  let total = 0;
+  try {
+    const { readdir, stat } = await import("node:fs/promises");
+    await mkdir(CACHE_ROOT, { recursive: true });
+    const entries = await readdir(CACHE_ROOT, { withFileTypes: true });
+    for (const e of entries) {
+      const p = join(CACHE_ROOT, e.name);
+      if (e.isDirectory()) {
+        const files = await readdir(p);
+        for (const f of files) {
+          try {
+            const s = await stat(join(p, f));
+            total += s.size;
+          } catch {
+            /* ignore */
+          }
+        }
+      } else {
+        try {
+          const s = await stat(p);
+          total += s.size;
+        } catch {
+          /* ignore */
+        }
+      }
+    }
+  } catch (err) {
+    log.debug({ err }, "cdn cache size check failed");
+  }
+  return total;
+}
+
+export async function clearCdnCache(): Promise<number> {
+  memory.clear();
+  let removed = 0;
+  try {
+    const { readdir, rm, stat } = await import("node:fs/promises");
+    await mkdir(CACHE_ROOT, { recursive: true });
+    const entries = await readdir(CACHE_ROOT, { withFileTypes: true });
+    for (const e of entries) {
+      const p = join(CACHE_ROOT, e.name);
+      if (e.isDirectory()) {
+        const files = await readdir(p);
+        for (const f of files) {
+          await rm(join(p, f), { force: true });
+          removed++;
+        }
+      } else {
+        await rm(p, { force: true });
+        removed++;
+      }
+    }
+    const { logger } = await import("../logger.js");
+    logger.info({ removed }, "cdn cache cleared");
+  } catch (err) {
+    log.debug({ err }, "cdn cache clear failed");
+  }
+  return removed;
 }

--- a/Vyline/backend/src/storage/chatStore.ts
+++ b/Vyline/backend/src/storage/chatStore.ts
@@ -52,6 +52,8 @@ export interface StoredMessage {
   stickerSticky?: boolean;
   reactions?: MessageReaction[];
   savedAt: string;
+  messageState?: Message["messageState"];
+  history?: Message["history"];
 }
 
 interface ChatDbMeta {
@@ -168,7 +170,11 @@ export async function upsertMessages(
   const db = await getDb(accountId);
   const byChat = db.messages[chatMid] ?? {};
   for (const message of messages) {
-    byChat[message.id] = message;
+    const prev = byChat[message.id];
+    byChat[message.id] = {
+      ...message,
+      history: prev?.history?.length ? prev.history : message.history,
+    };
   }
   db.messages[chatMid] = byChat;
   db.meta.messagesSyncedAt = db.meta.messagesSyncedAt ?? {};
@@ -185,9 +191,55 @@ export async function markMessageRevoked(
   const db = await getDb(accountId);
   const stored = db.messages[chatMid]?.[messageId];
   if (!stored) return;
+  const prevState = stored.messageState ?? "normal";
+  const entry = {
+    state: prevState,
+    text: stored.text,
+    contentType: stored.contentType,
+    updatedTime: Date.now(),
+  };
+  stored.messageState = stored.isMyMessage ? "revoked-by-self" : "revoked-by-other";
+  stored.history = [...(stored.history ?? []), entry];
   stored.contentType = "UNSENT";
   stored.text = null;
   scheduleSave(accountId);
+}
+
+/** 取消し済みメッセージを元に戻す（ローカル永続化）。LINE サーバー側は元に戻せないため chatStore のみ更新 */
+export async function restoreRevokedMessage(
+  accountId: string,
+  chatMid: string,
+  messageId: string,
+): Promise<{ text: string | null; contentType: string } | null> {
+  const db = await getDb(accountId);
+  const stored = db.messages[chatMid]?.[messageId];
+  if (!stored || !stored.history?.length) return null;
+  const lastNormal = [...stored.history]
+    .reverse()
+    .find((h) => h.state === "normal" || h.state === "edited");
+  if (!lastNormal) return null;
+  const entry = {
+    state: "normal" as const,
+    text: stored.text,
+    contentType: stored.contentType,
+    updatedTime: Date.now(),
+  };
+  stored.messageState = "normal";
+  stored.history = [...stored.history, entry];
+  stored.text = lastNormal.text;
+  stored.contentType = lastNormal.contentType;
+  scheduleSave(accountId);
+  return { text: lastNormal.text, contentType: lastNormal.contentType };
+}
+
+export async function getMessageHistory(
+  accountId: string,
+  chatMid: string,
+  messageId: string,
+): Promise<Message["history"]> {
+  const db = await getDb(accountId);
+  const stored = db.messages[chatMid]?.[messageId];
+  return stored?.history ?? [];
 }
 
 export async function getMessages(
@@ -229,7 +281,9 @@ function storedMessageToMessage(stored: StoredMessage): Message {
     createdTime: stored.createdTime,
     isMyMessage: stored.isMyMessage,
     contentMetadata: stored.contentMetadata ?? null,
+    messageState: stored.messageState ?? "normal",
   };
+  if (stored.history) msg.history = stored.history;
   if (stored.readCount != null) msg.readCount = stored.readCount;
   if (stored.readBy) msg.readBy = stored.readBy;
   if (stored.seen != null) msg.seen = stored.seen;

--- a/Vyline/backend/src/storage/mediaCache.ts
+++ b/Vyline/backend/src/storage/mediaCache.ts
@@ -10,6 +10,7 @@
  */
 
 import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -18,7 +19,18 @@ import { childLogger } from "../logger.js";
 const log = childLogger("media-cache");
 
 const _dir = dirname(fileURLToPath(import.meta.url));
-const CACHE_ROOT = process.env.VYLINE_MEDIA_CACHE_DIR ?? join(_dir, "../../data/media-cache");
+const LEGACY_ROOT = join(_dir, "../../data/media-cache");
+const CACHE_ROOT = process.env.VYLINE_MEDIA_CACHE_DIR ?? join(_dir, "../../storage/saved-media");
+
+try {
+  if (!existsSync(CACHE_ROOT) && existsSync(LEGACY_ROOT)) {
+    const { rename } = await import("node:fs/promises");
+    await mkdir(dirname(CACHE_ROOT), { recursive: true });
+    await rename(LEGACY_ROOT, CACHE_ROOT);
+  }
+} catch {
+  /* ignore */
+}
 
 const memory = new Map<string, { buf: Uint8Array; contentType: string; at: number }>();
 const MEMORY_MAX = 40;
@@ -139,4 +151,37 @@ export async function clearMediaCache(): Promise<number> {
     log.debug({ err }, "media cache clear failed");
   }
   return removed;
+}
+
+export async function getMediaCacheSize(): Promise<number> {
+  let total = 0;
+  try {
+    const { readdir, stat } = await import("node:fs/promises");
+    await mkdir(CACHE_ROOT, { recursive: true });
+    const entries = await readdir(CACHE_ROOT, { withFileTypes: true });
+    for (const e of entries) {
+      const p = join(CACHE_ROOT, e.name);
+      if (e.isDirectory()) {
+        const files = await readdir(p);
+        for (const f of files) {
+          try {
+            const s = await stat(join(p, f));
+            total += s.size;
+          } catch {
+            /* ignore */
+          }
+        }
+      } else {
+        try {
+          const s = await stat(p);
+          total += s.size;
+        } catch {
+          /* ignore */
+        }
+      }
+    }
+  } catch (err) {
+    log.debug({ err }, "media cache size check failed");
+  }
+  return total;
 }

--- a/Vyline/backend/src/storage/vylineStorageInfo.ts
+++ b/Vyline/backend/src/storage/vylineStorageInfo.ts
@@ -1,0 +1,112 @@
+/**
+ * storage/vylineStorageInfo.ts
+ *
+ * Vyline のストレージ使用量とディスク情報を集計する。
+ */
+
+import { existsSync } from "node:fs";
+import { mkdir, readdir, stat } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { childLogger } from "../logger.js";
+
+const log = childLogger("vyline-storage");
+const _dir = dirname(fileURLToPath(import.meta.url));
+
+async function streamToText(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value) chunks.push(value);
+  }
+  return Buffer.concat(chunks).toString("utf-8");
+}
+
+export const VYLINE_DATA_DIR = process.env.VYLINE_DATA_DIR ?? join(_dir, "..", "..", "data");
+export const VYLINE_STORAGE_DIR =
+  process.env.VYLINE_STORAGE_DIR ?? join(_dir, "..", "..", "storage");
+export const VYLINE_CACHE_DIR = join(VYLINE_STORAGE_DIR, "cache");
+export const VYLINE_SAVED_MEDIA_DIR = join(VYLINE_STORAGE_DIR, "saved-media");
+
+const CDN_CACHE_DIR = join(VYLINE_CACHE_DIR, "cdn-cache");
+const LEGACY_CDN_CACHE_DIR = join(VYLINE_DATA_DIR, "cdn-cache");
+const LEGACY_MEDIA_CACHE_DIR = join(VYLINE_DATA_DIR, "media-cache");
+
+async function dirSize(target: string): Promise<number> {
+  if (!existsSync(target)) return 0;
+  let total = 0;
+  try {
+    const entries = await readdir(target, { withFileTypes: true });
+    for (const e of entries) {
+      const p = join(target, e.name);
+      if (e.isDirectory()) {
+        total += await dirSize(p);
+      } else {
+        try {
+          const s = await stat(p);
+          total += s.size;
+        } catch {
+          /* ignore */
+        }
+      }
+    }
+  } catch (err) {
+    log.debug({ err, target }, "dirSize failed");
+  }
+  return total;
+}
+
+function extractDriveLetter(path: string): string {
+  const m = /^([a-zA-Z]:)/.exec(path);
+  return m?.[1]?.toUpperCase() ?? "";
+}
+
+async function getDiskInfo(
+  driveLetter: string,
+): Promise<{ totalBytes: number; freeBytes: number; usedBytes: number } | null> {
+  try {
+    if (!driveLetter) return null;
+    const name = driveLetter.replace(":", "");
+    const ps = `[pscustomobject]@{ Total = (Get-PSDrive ${name}).Used + (Get-PSDrive ${name}).Free; Free = (Get-PSDrive ${name}).Free; Used = (Get-PSDrive ${name}).Used } | ConvertTo-Json`;
+    const proc = Bun.spawn(["powershell", "-NoProfile", "-Command", ps], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [code, stdout, stderr] = await Promise.all([
+      proc.exited,
+      streamToText(proc.stdout),
+      streamToText(proc.stderr),
+    ]);
+    if (typeof code === "number" && code === 0 && stdout.trim()) {
+      const data = JSON.parse(stdout.trim());
+      if (data && typeof data.Total === "number") {
+        return { totalBytes: data.Total, freeBytes: data.Free, usedBytes: data.Used };
+      }
+    }
+  } catch {
+    /* ignore */
+  }
+  return null;
+}
+
+export async function getVylineStorageInfo() {
+  const driveLetter = extractDriveLetter(VYLINE_STORAGE_DIR);
+  const [cacheSize, savedMediaSize] = await Promise.all([
+    dirSize(VYLINE_CACHE_DIR),
+    dirSize(VYLINE_SAVED_MEDIA_DIR),
+  ]);
+
+  const vylineTotal = cacheSize + savedMediaSize;
+  const disk = await getDiskInfo(driveLetter);
+
+  return {
+    ok: true,
+    driveLetter,
+    disk,
+    vylineTotal,
+    cacheSize,
+    savedMediaSize,
+  };
+}

--- a/Vyline/packages/types/src/index.ts
+++ b/Vyline/packages/types/src/index.ts
@@ -147,6 +147,15 @@ export interface Message {
   updatedTime?: number;
   /** 編集前のオリジナルテキスト（ローカルキャッシュ用） */
   originalText?: string;
+  /** メッセージ状態 */
+  messageState?: "normal" | "edited" | "revoked-by-other" | "revoked-by-self";
+  /** 状態変更履歴 */
+  history?: Array<{
+    state: "normal" | "edited" | "revoked-by-other" | "revoked-by-self";
+    text: string | null;
+    contentType: string;
+    updatedTime: number;
+  }>;
 }
 
 export interface MessageReaction {


### PR DESCRIPTION
## Summary
- Add message history tracking with `messageState` and `history` fields
- Support revoke-by-self and revoke-by-other with distinct handling
- Add restore flow for revoked-by-self messages from local history
- Add backend endpoints for message history and restore

## Files Changed
- Backend: `chatStore.ts`, `lineService.ts`, `api/line.ts`
- Frontend: `store.ts`, `store-types.ts`, `mappers.ts`, `message-bubble.tsx`, `message-input.tsx`, `sidebar.tsx`, `useVylineSync.ts`, `client.ts`
- Types: `packages/types/src/index.ts`
- Other: `cdnAssetCache.ts`, `mediaCache.ts`, `icons.tsx`, `settings-sections.tsx`