### PR TITLE
fix: read receipt status stabilization

### DIFF
--- a/.kilo/pr-body.md
+++ b/.kilo/pr-body.md
@@ -1,0 +1,11 @@
+## Summary
+- Add message history tracking with `messageState` and `history` fields
+- Support revoke-by-self and revoke-by-other with distinct handling
+- Add restore flow for revoked-by-self messages from local history
+- Add backend endpoints for message history and restore
+
+## Files Changed
+- Backend: `chatStore.ts`, `lineService.ts`, `api/line.ts`
+- Frontend: `store.ts`, `store-types.ts`, `mappers.ts`, `message-bubble.tsx`, `message-input.tsx`, `sidebar.tsx`, `useVylineSync.ts`, `client.ts`
+- Types: `packages/types/src/index.ts`
+- Other: `cdnAssetCache.ts`, `mediaCache.ts`, `icons.tsx`, `settings-sections.tsx`

--- a/Vyline/apps/desktop/src/api/client.ts
+++ b/Vyline/apps/desktop/src/api/client.ts
@@ -321,8 +321,6 @@ export const api = {
         disk?: { totalBytes: number; freeBytes: number; usedBytes: number };
         vylineTotal: number;
         cacheSize: number;
-        cdnSize: number;
-        iconCacheSize: number;
         savedMediaSize: number;
         error?: string;
       }>("GET", `/line/${accountId}/vyline/storage`),
@@ -337,12 +335,6 @@ export const api = {
       request<{ ok: boolean; removed?: number; error?: string }>(
         "DELETE",
         `/line/${accountId}/vyline/saved-media`,
-      ),
-
-    clearVylineIcons: (accountId: string) =>
-      request<{ ok: boolean; removed?: number; error?: string }>(
-        "DELETE",
-        `/line/${accountId}/vyline/icons`,
       ),
 
     vylineWarm: (accountId: string, mids: string[]) =>

--- a/Vyline/backend/src/api/line.ts
+++ b/Vyline/backend/src/api/line.ts
@@ -1702,14 +1702,3 @@ lineRouter.delete("/:accountId/vyline/saved-media", async (c) => {
     return handleError(err, c);
   }
 });
-
-lineRouter.delete("/:accountId/vyline/icons", async (c) => {
-  const accountId = c.req.param("accountId");
-  try {
-    const { clearCdnCache } = await import("../storage/cdnAssetCache.js");
-    const removed = await clearCdnCache();
-    return c.json({ ok: true, removed });
-  } catch (err) {
-    return handleError(err, c);
-  }
-});


### PR DESCRIPTION
- refreshMessages: preserve read:true when prev.readBy has data
- refreshReadReceipts: add alreadyRead check to prevent reset
- markChatRead: update message-level read fields
- mapMessage: fallback to read:true when server data is missing
- add MessageState type and history field

## Summary

<!-- 変更内容を1-3行で -->

## Changes

<!-- 具体的な変更点 -->

-
-

## Test Plan

<!-- テスト項目 -->

- [x] `bun run typecheck` が通る
- [x] `bun run dev` で起動確認
- [ ]

## Screenshots

<!-- UI変更がある場合 -->

🤖 Generated with [Claude Code](https://claude.ai/code)
