### PR TITLE
Fix/e2ee extractor account token

### DIFF
--- a/Vyline/packages/protocol/src/tools/extractDesktopE2EEKeys.ts
+++ b/Vyline/packages/protocol/src/tools/extractDesktopE2EEKeys.ts
@@ -80,6 +80,8 @@ function parseKeys(raw: string): Map<number, DesktopE2EEKey> {
 
 async function main(): Promise<void> {
   const tokensPath = join(DATA, "tokens.json");
+  if (!existsSync(tokensPath)) throw new Error(`missing ${tokensPath}`);
+
   const tokens = JSON.parse(readFileSync(tokensPath, "utf8")) as Record<
     string,
     {
@@ -88,11 +90,41 @@ async function main(): Promise<void> {
     }
   >;
 
-  const selected = Object.entries(tokens).find(
+  const accountArgIndex = process.argv.indexOf("--account");
+  const requestedAccount =
+    accountArgIndex >= 0 ? process.argv[accountArgIndex + 1] : undefined;
+
+  if (accountArgIndex >= 0 && !requestedAccount) {
+    throw new Error("--account requires an account ID");
+  }
+
+  const availableAccounts = Object.entries(tokens).filter(
     ([, entry]) =>
       typeof entry?.authToken === "string" &&
       entry.authToken.length > 0,
   );
+
+  let selected:
+    | [string, { authToken?: string; storageFile?: string }]
+    | undefined;
+
+  if (requestedAccount) {
+    selected = availableAccounts.find(
+      ([accountId]) => accountId === requestedAccount,
+    );
+
+    if (!selected) {
+      throw new Error(
+        `account "${requestedAccount}" not found. available: ${availableAccounts
+          .map(([accountId]) => accountId)
+          .join(", ")}`,
+      );
+    }
+  } else {
+    selected =
+      availableAccounts.find(([accountId]) => accountId === "main") ??
+      availableAccounts[0];
+  }
 
   if (!selected) throw new Error("no authToken");
 

--- a/Vyline/packages/protocol/src/tools/extractDesktopE2EEKeys.ts
+++ b/Vyline/packages/protocol/src/tools/extractDesktopE2EEKeys.ts
@@ -80,11 +80,26 @@ function parseKeys(raw: string): Map<number, DesktopE2EEKey> {
 
 async function main(): Promise<void> {
   const tokensPath = join(DATA, "tokens.json");
-  if (!existsSync(tokensPath)) throw new Error(`missing ${tokensPath}`);
-  const tokens = JSON.parse(readFileSync(tokensPath, "utf8")) as {
-    main?: { authToken: string };
-  };
-  if (!tokens.main?.authToken) throw new Error("no main authToken");
+  const tokens = JSON.parse(readFileSync(tokensPath, "utf8")) as Record<
+    string,
+    {
+      authToken?: string;
+      storageFile?: string;
+    }
+  >;
+
+  const selected = Object.entries(tokens).find(
+    ([, entry]) =>
+      typeof entry?.authToken === "string" &&
+      entry.authToken.length > 0,
+  );
+
+  if (!selected) throw new Error("no authToken");
+
+  const [accountId, tokenEntry] = selected;
+  const authToken = tokenEntry.authToken!;
+
+  console.log(`[extract] using account: ${accountId}`);
 
   console.log("[extract] scanning LINE.exe for privateKey windows...");
   const raw = dumpPrivateKeyWindows();
@@ -99,9 +114,11 @@ async function main(): Promise<void> {
   );
 
   const profile = loadCachedOrFallback(join(DATA, "vyline"));
-  const client = await loginWithToken(tokens.main.authToken, {
+  const client = await loginWithToken(authToken, {
     profile,
-    storagePath: join(DATA, "storage-main.json"),
+    storagePath:
+      tokenEntry.storageFile ??
+      join(DATA, `storage-${accountId}.json`),
   });
   await client.base.talk.getProfile();
   const mid = client.base.profile?.mid;

--- a/Vyline/packages/protocol/src/tools/extractDesktopE2EEKeys.ts
+++ b/Vyline/packages/protocol/src/tools/extractDesktopE2EEKeys.ts
@@ -91,27 +91,20 @@ async function main(): Promise<void> {
   >;
 
   const accountArgIndex = process.argv.indexOf("--account");
-  const requestedAccount =
-    accountArgIndex >= 0 ? process.argv[accountArgIndex + 1] : undefined;
+  const requestedAccount = accountArgIndex >= 0 ? process.argv[accountArgIndex + 1] : undefined;
 
   if (accountArgIndex >= 0 && !requestedAccount) {
     throw new Error("--account requires an account ID");
   }
 
   const availableAccounts = Object.entries(tokens).filter(
-    ([, entry]) =>
-      typeof entry?.authToken === "string" &&
-      entry.authToken.length > 0,
+    ([, entry]) => typeof entry?.authToken === "string" && entry.authToken.length > 0,
   );
 
-  let selected:
-    | [string, { authToken?: string; storageFile?: string }]
-    | undefined;
+  let selected: [string, { authToken?: string; storageFile?: string }] | undefined;
 
   if (requestedAccount) {
-    selected = availableAccounts.find(
-      ([accountId]) => accountId === requestedAccount,
-    );
+    selected = availableAccounts.find(([accountId]) => accountId === requestedAccount);
 
     if (!selected) {
       throw new Error(
@@ -122,8 +115,7 @@ async function main(): Promise<void> {
     }
   } else {
     selected =
-      availableAccounts.find(([accountId]) => accountId === "main") ??
-      availableAccounts[0];
+      availableAccounts.find(([accountId]) => accountId === "main") ?? availableAccounts[0];
   }
 
   if (!selected) throw new Error("no authToken");
@@ -148,9 +140,7 @@ async function main(): Promise<void> {
   const profile = loadCachedOrFallback(join(DATA, "vyline"));
   const client = await loginWithToken(authToken, {
     profile,
-    storagePath:
-      tokenEntry.storageFile ??
-      join(DATA, `storage-${accountId}.json`),
+    storagePath: tokenEntry.storageFile ?? join(DATA, `storage-${accountId}.json`),
   });
   await client.base.talk.getProfile();
   const mid = client.base.profile?.mid;


### PR DESCRIPTION
## Summary

Desktop E2EE 鍵抽出ツールが `tokens.main` を固定参照していたため、実際のアカウント ID で保存された認証トークンを利用できるよう修正します。

従来どおり引数なしでも動作しつつ、`--account <accountId>` で抽出対象のアカウントを明示的に指定できるようにします。

## Changes

* `tokens.main.authToken` の固定参照を廃止し、有効な `authToken` を持つアカウントを動的に選択
* `--account <accountId>` を追加し、複数アカウント環境でも対象アカウントを明示的に指定可能に変更
* `--account` 未指定時は `main` を優先し、存在しない場合は最初の有効なアカウントを使用して従来の実行方法との互換性を維持
* 選択したアカウントの `storageFile` を利用し、未設定時はアカウント ID に応じた storage path にフォールバック
* 存在しないアカウント ID や値なしの `--account` が指定された場合に分かりやすいエラーを返すよう変更

## Test Plan

* [x] `bun run typecheck` が通る
* [x] `bun run dev` で起動確認
* [x] `bun run vyline:extract-e2ee` で `main` 以外のアカウントから E2EE 鍵抽出処理が開始できることを確認
* [x] `bun run vyline:extract-e2ee --account Yosei` で指定したアカウントを使用して E2EE 鍵抽出処理が開始できることを確認

## Screenshots

UI変更なし
