### PR TITLE
fix: bun protocol tests and assert compatibility

### DIFF
--- a/Vyline/packages/protocol/package.json
+++ b/Vyline/packages/protocol/package.json
@@ -9,6 +9,10 @@
       "types": "./stack/_dist/client/mod.d.ts",
       "default": "./stack/client/mod.ts"
     },
+    "./stack/assert": {
+      "types": "./stack/assert.ts",
+      "default": "./stack/assert.ts"
+    },
     "./stack/base": {
       "types": "./stack/_dist/base/mod.d.ts",
       "default": "./stack/base/mod.ts"

--- a/Vyline/packages/protocol/stack/assert.ts
+++ b/Vyline/packages/protocol/stack/assert.ts
@@ -1,0 +1,88 @@
+import { AssertionError, strict as assertStrict } from "node:assert";
+import { inspect, isDeepStrictEqual } from "node:util";
+
+type AsyncOrSync<T> = T | Promise<T>;
+
+function normalizeMessage(message: unknown): string | undefined {
+  return typeof message === "string" && message.length > 0 ? message : undefined;
+}
+
+function formatValue(value: unknown): string {
+  return inspect(value, { depth: 5, breakLength: 120 });
+}
+
+function createAssertionError(message: string): AssertionError {
+  return new AssertionError({
+    message,
+    stackStartFn: assert,
+  });
+}
+
+export function assert(value: unknown, message?: string): asserts value {
+  assertStrict.ok(value, message);
+}
+
+export function assertEquals<T>(actual: T, expected: T, message?: string): void {
+  if (!isDeepStrictEqual(actual, expected)) {
+    throw createAssertionError(message ?? `Values are not equal.\n\nActual: ${formatValue(actual)}\nExpected: ${formatValue(expected)}`);
+  }
+}
+
+export function assertNotEquals<T>(actual: T, expected: T, message?: string): void {
+  if (isDeepStrictEqual(actual, expected)) {
+    throw createAssertionError(message ?? `Expected values to differ, but both were ${formatValue(actual)}`);
+  }
+}
+
+export function assertMatch(actual: string, expected: RegExp, message?: string): void {
+  if (!expected.test(actual)) {
+    throw createAssertionError(message ?? `Expected ${formatValue(actual)} to match ${expected}`);
+  }
+}
+
+export function assertInstanceOf<T>(value: unknown, ctor: new (...args: any[]) => T, message?: string): asserts value is T {
+  if (!(value instanceof ctor)) {
+    throw createAssertionError(message ?? `Expected value to be instance of ${ctor.name}`);
+  }
+}
+
+export function assertThrows(
+  fn: () => unknown,
+  ErrorClass?: new (...args: any[]) => Error,
+  msgIncludes?: string,
+): Error {
+  try {
+    fn();
+  } catch (error) {
+    if (ErrorClass && !(error instanceof ErrorClass)) {
+      throw createAssertionError(`Expected ${ErrorClass.name}, got ${(error as Error)?.constructor?.name ?? typeof error}`);
+    }
+    const expectedMessage = normalizeMessage(msgIncludes);
+    if (expectedMessage && !(error instanceof Error && error.message.includes(expectedMessage))) {
+      throw createAssertionError(`Expected error message to include ${expectedMessage}`);
+    }
+    return error as Error;
+  }
+  throw createAssertionError("Expected function to throw");
+}
+
+export async function assertRejects(
+  fnOrPromise: AsyncOrSync<unknown> | (() => AsyncOrSync<unknown>),
+  ErrorClass?: new (...args: any[]) => Error,
+  msgIncludes?: string,
+): Promise<Error> {
+  try {
+    const result = typeof fnOrPromise === "function" ? fnOrPromise() : fnOrPromise;
+    await result;
+  } catch (error) {
+    if (ErrorClass && !(error instanceof ErrorClass)) {
+      throw createAssertionError(`Expected ${ErrorClass.name}, got ${(error as Error)?.constructor?.name ?? typeof error}`);
+    }
+    const expectedMessage = normalizeMessage(msgIncludes);
+    if (expectedMessage && !(error instanceof Error && error.message.includes(expectedMessage))) {
+      throw createAssertionError(`Expected error message to include ${expectedMessage}`);
+    }
+    return error as Error;
+  }
+  throw createAssertionError("Expected promise to reject");
+}

--- a/Vyline/packages/protocol/stack/base/core/typed-event-emitter/index.test.ts
+++ b/Vyline/packages/protocol/stack/base/core/typed-event-emitter/index.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assertEquals } from "@vyline/protocol/stack/assert";
 import { TypedEventEmitter } from "./index.ts";
 
 Deno.test("promise() should be vaild", async () => {

--- a/Vyline/packages/protocol/stack/base/core/utils/devices.test.ts
+++ b/Vyline/packages/protocol/stack/base/core/utils/devices.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assertEquals } from "@vyline/protocol/stack/assert";
 import { getDeviceDetails } from "./devices.ts";
 
 Deno.test("getDeviceDetails returns current default app profiles", () => {

--- a/Vyline/packages/protocol/stack/base/e2ee/aes_gcm_siv.test.ts
+++ b/Vyline/packages/protocol/stack/base/e2ee/aes_gcm_siv.test.ts
@@ -1,6 +1,6 @@
-import { assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assertEquals } from "@vyline/protocol/stack/assert";
 import { Buffer } from "node:buffer";
-import { gcmsiv } from "npm:/@noble/ciphers@^2.2/aes.js";
+import { gcmsiv } from "@noble/ciphers/aes.js";
 
 // RFC 8452 §C.2 test vector: AES-256-GCM-SIV with non-empty AAD.
 // key=01000000…, nonce=030000000000000000000000, aad=01, plaintext=0200000000000000

--- a/Vyline/packages/protocol/stack/base/e2ee/key_selection.test.ts
+++ b/Vyline/packages/protocol/stack/base/e2ee/key_selection.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assert, assertEquals } from "@vyline/protocol/stack/assert";
 import { Buffer } from "node:buffer";
 import { E2EE } from "./mod.ts";
 

--- a/Vyline/packages/protocol/stack/base/login/mod.test.ts
+++ b/Vyline/packages/protocol/stack/base/login/mod.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assertEquals } from "@vyline/protocol/stack/assert";
 import { registrationAuthEndpoint } from "./mod.ts";
 
 Deno.test("registration auth endpoint uses v4 for Android devices", () => {

--- a/Vyline/packages/protocol/stack/base/login/respond_e2ee.test.ts
+++ b/Vyline/packages/protocol/stack/base/login/respond_e2ee.test.ts
@@ -1,5 +1,5 @@
 import { Buffer } from "node:buffer";
-import { assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assertEquals } from "@vyline/protocol/stack/assert";
 import { Login } from "./mod.ts";
 
 // Minimal stub of BaseClient.request — captures the NestedArray and

--- a/Vyline/packages/protocol/stack/base/obs/upload_e2ee.test.ts
+++ b/Vyline/packages/protocol/stack/base/obs/upload_e2ee.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assert, assertEquals } from "@vyline/protocol/stack/assert";
 import { Buffer } from "node:buffer";
 import { LineObs } from "./mod.ts";
 

--- a/Vyline/packages/protocol/stack/base/push/h2_fetch.test.ts
+++ b/Vyline/packages/protocol/stack/base/push/h2_fetch.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assert, assertEquals } from "@vyline/protocol/stack/assert";
 import { getH2EnabledFetchForNode } from "./h2_fetch.ts";
 
 // On Deno (which is what this test runs under), getH2EnabledFetchForNode

--- a/Vyline/packages/protocol/stack/base/request/auth_token.test.ts
+++ b/Vyline/packages/protocol/stack/base/request/auth_token.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals, assertMatch } from "jsr:@std/assert@^1.0.2";
+import { assert, assertEquals, assertMatch } from "@vyline/protocol/stack/assert";
 import {
   createPrimaryAccessToken,
   isJwt,

--- a/Vyline/packages/protocol/stack/base/request/legy.test.ts
+++ b/Vyline/packages/protocol/stack/base/request/legy.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assertEquals } from "@vyline/protocol/stack/assert";
 import { decodeLegyHeaders, encodeLegyHeaders, xxhash32 } from "./legy.ts";
 import { Buffer } from "node:buffer";
 

--- a/Vyline/packages/protocol/stack/base/service/relation/mod.test.ts
+++ b/Vyline/packages/protocol/stack/base/service/relation/mod.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assertEquals } from "@vyline/protocol/stack/assert";
 import { type NestedArray, Protocols } from "../../thrift/readwrite/declares.ts";
 import { readThrift } from "../../thrift/readwrite/read.ts";
 import { writeThrift } from "../../thrift/readwrite/write.ts";

--- a/Vyline/packages/protocol/stack/base/service/talk/compact.test.ts
+++ b/Vyline/packages/protocol/stack/base/service/talk/compact.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertInstanceOf, assertThrows } from "jsr:@std/assert@^1.0.2";
+import { assertEquals, assertInstanceOf, assertThrows } from "@vyline/protocol/stack/assert";
 import {
   CompactMessageProtocolError,
   decodeCompactMessageResponse,

--- a/Vyline/packages/protocol/stack/base/thrift/readwrite/tmc.test.ts
+++ b/Vyline/packages/protocol/stack/base/thrift/readwrite/tmc.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assertEquals } from "@vyline/protocol/stack/assert";
 import { TMoreCompactProtocol } from "./tmc.ts";
 
 Deno.test("decodeZigZag matches standard thrift zigzag for positive values", () => {

--- a/Vyline/packages/protocol/stack/base/thrift/readwrite/write.test.ts
+++ b/Vyline/packages/protocol/stack/base/thrift/readwrite/write.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assertEquals } from "@vyline/protocol/stack/assert";
 import { writeStruct, writeThrift } from "./write.ts";
 import { readThrift } from "./read.ts";
 import { type NestedArray, Protocols } from "./declares.ts";

--- a/Vyline/packages/protocol/stack/client/features/call/andromeda.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/call/andromeda.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assert, assertEquals } from "@vyline/protocol/stack/assert";
 import { Buffer } from "node:buffer";
 import dgram from "node:dgram";
 import { AndromedaTransport } from "./andromeda.ts";

--- a/Vyline/packages/protocol/stack/client/features/call/audio.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/call/audio.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals, assertRejects, assertThrows } from "jsr:@std/assert@^1.0.2";
+import { assert, assertEquals, assertRejects, assertThrows } from "@vyline/protocol/stack/assert";
 import {
   bufferSink,
   bufferSource,

--- a/Vyline/packages/protocol/stack/client/features/call/e2e.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/call/e2e.test.ts
@@ -1,7 +1,7 @@
 // End-to-end: PCM → codec → SRTP wire → SRTP receive → codec → PCM,
 // using a loopback transport. Proves the audio plumbing carries
 // samples bit-identical without needing a real Opus impl.
-import { assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assertEquals } from "@vyline/protocol/stack/assert";
 import { CallSession, type CallTransport } from "./session.ts";
 import {
   type AudioDecoder,

--- a/Vyline/packages/protocol/stack/client/features/call/full_call.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/call/full_call.test.ts
@@ -2,7 +2,7 @@
 // SDP + SRTP + Opus call against a mock UAS that echoes Opus-encoded
 // audio. Proves every layer in the call stack interoperates.
 
-import { assert, assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assert, assertEquals } from "@vyline/protocol/stack/assert";
 import { Buffer } from "node:buffer";
 import dgram from "node:dgram";
 import { AndromedaTransport } from "./andromeda.ts";

--- a/Vyline/packages/protocol/stack/client/features/call/ice.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/call/ice.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assert, assertEquals } from "@vyline/protocol/stack/assert";
 import { formatCandidate, gatherIceCandidates, icePriority, parseCandidate } from "./ice.ts";
 
 Deno.test("icePriority: host candidate ranks higher than srflx", () => {

--- a/Vyline/packages/protocol/stack/client/features/call/mikey.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/call/mikey.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertRejects } from "jsr:@std/assert@^1.0.2";
+import { assertEquals, assertRejects } from "@vyline/protocol/stack/assert";
 import { Buffer } from "node:buffer";
 import { buildMikeyPke, mikeyFromBase64, mikeyToBase64, parseMikey } from "./mikey.ts";
 

--- a/Vyline/packages/protocol/stack/client/features/call/mod.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/call/mod.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assertEquals } from "@vyline/protocol/stack/assert";
 import {
   createCallClient,
   defaultCallFromEnvInfo,

--- a/Vyline/packages/protocol/stack/client/features/call/opus.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/call/opus.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assert, assertEquals } from "@vyline/protocol/stack/assert";
 import { opusCodecFactory } from "./opus.ts";
 
 Deno.test("opusCodecFactory: encodes + decodes a 20ms 48kHz mono frame", async () => {

--- a/Vyline/packages/protocol/stack/client/features/call/planet/cassini.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/call/planet/cassini.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assertEquals } from "@vyline/protocol/stack/assert";
 import {
   buildExchangeAppStrData,
   buildRelReq,

--- a/Vyline/packages/protocol/stack/client/features/call/planet/crypto.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/call/planet/crypto.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertNotEquals } from "jsr:@std/assert@^1.0.2";
+import { assertEquals, assertNotEquals } from "@vyline/protocol/stack/assert";
 import {
   aesCtrDecrypt,
   aesCtrEncrypt,

--- a/Vyline/packages/protocol/stack/client/features/call/planet/framing.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/call/planet/framing.test.ts
@@ -1,5 +1,5 @@
 /** Unit tests for PLANET framing — match values observed in live wire capture. */
-import { assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assertEquals } from "@vyline/protocol/stack/assert";
 import {
   buildFrameHeader,
   makeChunkHdr,

--- a/Vyline/packages/protocol/stack/client/features/call/planet/schema.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/call/planet/schema.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assertEquals } from "@vyline/protocol/stack/assert";
 import {
   CC_MSG,
   decodeCcConnReq,

--- a/Vyline/packages/protocol/stack/client/features/call/planet/transport.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/call/planet/transport.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assert, assertEquals } from "@vyline/protocol/stack/assert";
 import { Buffer } from "node:buffer";
 import { createSocket, type RemoteInfo, type Socket } from "node:dgram";
 import {

--- a/Vyline/packages/protocol/stack/client/features/call/rtcp.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/call/rtcp.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assert, assertEquals } from "@vyline/protocol/stack/assert";
 import { buildRtcpBye, buildRtcpCompound, nowNtp, parseRtcp } from "./rtcp.ts";
 
 Deno.test("nowNtp returns a value above the 1900-epoch threshold", () => {

--- a/Vyline/packages/protocol/stack/client/features/call/sdp.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/call/sdp.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assert, assertEquals } from "@vyline/protocol/stack/assert";
 import { buildAudioOffer, buildSdp, cryptoAttr, parseSdp, readCrypto, readRtpmap } from "./sdp.ts";
 
 Deno.test("buildSdp + parseSdp round-trip", () => {

--- a/Vyline/packages/protocol/stack/client/features/call/session.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/call/session.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals, assertRejects } from "jsr:@std/assert@^1.0.2";
+import { assert, assertEquals, assertRejects } from "@vyline/protocol/stack/assert";
 import { CallSession, type CallTransport } from "./session.ts";
 import type { AudioDecoder, AudioEncoder, CodecFactory, PcmFrame } from "./audio.ts";
 import { bufferSink, bufferSource } from "./audio.ts";

--- a/Vyline/packages/protocol/stack/client/features/call/sip.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/call/sip.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assertEquals } from "@vyline/protocol/stack/assert";
 import {
   buildSip,
   digestResponse,

--- a/Vyline/packages/protocol/stack/client/features/call/srtp.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/call/srtp.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals, assertRejects } from "jsr:@std/assert@^1.0.2";
+import { assert, assertEquals, assertRejects } from "@vyline/protocol/stack/assert";
 import {
   buildRtp,
   deriveSrtpContext,

--- a/Vyline/packages/protocol/stack/client/features/call/stun.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/call/stun.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assert, assertEquals } from "@vyline/protocol/stack/assert";
 import dgram from "node:dgram";
 import { Buffer } from "node:buffer";
 import { buildBindingRequestAsync, parseStun, readMappedAddress } from "./stun.ts";

--- a/Vyline/packages/protocol/stack/client/features/liff.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/liff.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assertEquals } from "@vyline/protocol/stack/assert";
 import { flex, image, sticker, text } from "./liff.ts";
 
 Deno.test("liff.text — plain", () => {

--- a/Vyline/packages/protocol/stack/client/features/voom.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/voom.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assertEquals } from "@vyline/protocol/stack/assert";
 import { VoomChannelId } from "./voom.ts";
 
 Deno.test("VoomChannelId — TIMELINE id matches LINE Android smali", () => {

--- a/Vyline/packages/protocol/stack/client/features/voom_client.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/voom_client.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assert, assertEquals } from "@vyline/protocol/stack/assert";
 import { createVoomClient, VoomChannelId } from "./voom.ts";
 
 function makeFake() {

--- a/Vyline/packages/protocol/stack/client/fetch_users.test.ts
+++ b/Vyline/packages/protocol/stack/client/fetch_users.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assert, assertEquals } from "@vyline/protocol/stack/assert";
 import { Client } from "./client.ts";
 
 function buildClient(opts: {

--- a/Vyline/packages/protocol/stack/client/login.test.ts
+++ b/Vyline/packages/protocol/stack/client/login.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertRejects } from "jsr:@std/assert@^1.0.2";
+import { assertEquals, assertRejects } from "@vyline/protocol/stack/assert";
 import { loginWithAuthToken } from "./login.ts";
 import { MemoryStorage } from "../base/storage/mod.ts";
 

--- a/Vyline/packages/protocol/stack/test-preload.ts
+++ b/Vyline/packages/protocol/stack/test-preload.ts
@@ -1,0 +1,5 @@
+import { test } from "bun:test";
+
+globalThis.Deno ??= {
+  test,
+};

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./Vyline/packages/protocol/stack/test-preload.ts"]


### PR DESCRIPTION
## Summary
- Added a local assert helper for protocol stack tests and exported it from @vyline/protocol
- Added a Bun test preload that provides Deno.test compatibility
- Switched the AES-GCM-SIV test to a normal package import for @noble/ciphers

## Verification
- bun run typecheck
- bun run lint
- bun test
- git push (pre-push checks passed, including frontend build)