### PR TITLE
取り消しメッセージを再起動後も点線バブルで維持

### DIFF
--- a/Vyline/apps/desktop/src/api/client.ts
+++ b/Vyline/apps/desktop/src/api/client.ts
@@ -299,8 +299,7 @@ export const api = {
         items,
         ...(opts?.idOfPreviousVersionOfCombinationSticker
           ? {
-              idOfPreviousVersionOfCombinationSticker:
-                opts.idOfPreviousVersionOfCombinationSticker,
+              idOfPreviousVersionOfCombinationSticker: opts.idOfPreviousVersionOfCombinationSticker,
             }
           : {}),
       }),

--- a/Vyline/apps/desktop/src/api/client.ts
+++ b/Vyline/apps/desktop/src/api/client.ts
@@ -220,6 +220,25 @@ export const api = {
         ...opts,
       }),
 
+    sendMediaBatch: (
+      accountId: string,
+      chatMid: string,
+      items: Array<{
+        dataBase64: string;
+        mimeType?: string;
+        filename?: string;
+        mediaType?: string;
+      }>,
+    ) =>
+      request<{ ok: boolean; count?: number; error?: string }>(
+        "POST",
+        `/line/${accountId}/send-media-batch`,
+        {
+          chatMid,
+          items,
+        },
+      ),
+
     sendSticker: (
       accountId: string,
       chatMid: string,
@@ -228,6 +247,62 @@ export const api = {
       request<SendResponse>("POST", `/line/${accountId}/send-sticker`, {
         chatMid,
         ...opts,
+      }),
+
+    canCreateCombinationSticker: (accountId: string, packageIds: string[]) =>
+      request<{ ok: boolean; canCreate: boolean; usablePackageIds: string[]; error?: string }>(
+        "POST",
+        `/line/${accountId}/combination-stickers/can-create`,
+        { packageIds },
+      ),
+
+    isStickerAvailableForCombinationSticker: (accountId: string, packageId: string) =>
+      request<{ ok: boolean; availableForCombinationSticker: boolean; error?: string }>(
+        "POST",
+        `/line/${accountId}/combination-stickers/available`,
+        { packageId },
+      ),
+
+    createCombinationSticker: (
+      accountId: string,
+      items: Array<{
+        packageId: string;
+        stickerId: string;
+      }>,
+      opts?: { idOfPreviousVersionOfCombinationSticker?: string },
+    ) =>
+      request<{ ok: boolean; id: string; error?: string }>(
+        "POST",
+        `/line/${accountId}/combination-stickers`,
+        opts?.idOfPreviousVersionOfCombinationSticker
+          ? {
+              items,
+              idOfPreviousVersionOfCombinationSticker: opts.idOfPreviousVersionOfCombinationSticker,
+            }
+          : { items },
+      ),
+
+    sendCombinationSticker: (
+      accountId: string,
+      chatMid: string,
+      items: Array<{
+        packageId: string;
+        stickerId: string;
+        x?: number;
+        y?: number;
+        size?: number;
+      }>,
+      opts?: { idOfPreviousVersionOfCombinationSticker?: string },
+    ) =>
+      request<SendResponse>("POST", `/line/${accountId}/send-combination-sticker`, {
+        chatMid,
+        items,
+        ...(opts?.idOfPreviousVersionOfCombinationSticker
+          ? {
+              idOfPreviousVersionOfCombinationSticker:
+                opts.idOfPreviousVersionOfCombinationSticker,
+            }
+          : {}),
       }),
 
     sendEmoji: (
@@ -412,7 +487,6 @@ export const api = {
         statusMessage?: string;
         phoneticName?: string;
         musicProfile?: string;
-        birthday?: { year?: string; day: string; yearEnabled?: boolean; dayEnabled?: boolean };
       },
     ) => request<ProfileResponse>("PATCH", `/line/${accountId}/profile`, body),
 

--- a/Vyline/apps/desktop/src/components/member-profile.tsx
+++ b/Vyline/apps/desktop/src/components/member-profile.tsx
@@ -12,6 +12,12 @@ import { looksLikeMid } from "@/lib/mappers";
 import { Avatar } from "@/components/vy-ui";
 import { IconClose, IconChat, IconPhone, IconVideo, IconUsers } from "@/components/icons";
 
+type RichInfo = {
+  statusMessage?: string;
+  backgroundUrl?: string;
+  userType?: number;
+};
+
 export function MemberProfilePopover({ chat }: { chat: Chat }) {
   const memberProfile = useStore((s) => s.memberProfile);
   const close = useStore((s) => s.closeMemberProfile);
@@ -23,6 +29,7 @@ export function MemberProfilePopover({ chat }: { chat: Chat }) {
   const [busy, setBusy] = useState(false);
   const [msg, setMsg] = useState<string | null>(null);
   const [apiCommonGroups, setApiCommonGroups] = useState<Chat[] | null>(null);
+  const [rich, setRich] = useState<RichInfo>({});
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
@@ -38,10 +45,46 @@ export function MemberProfilePopover({ chat }: { chat: Chat }) {
     [apiCommonGroups, chats, member, chat.id],
   );
 
+  const backgroundUrl = rich.backgroundUrl;
+  const showBackground = Boolean(!streamerMode && backgroundUrl);
+
   useEffect(() => {
     setApiCommonGroups(null);
+    setRich({});
     if (!accountId || !member || streamerMode) return;
     let cancelled = false;
+    void api.line
+      .contactProfile(accountId, member.id)
+      .then((res) => {
+        if (cancelled || !res.ok || !res.profile) return;
+        setRich({
+          statusMessage: res.profile.statusMessage,
+          backgroundUrl: res.profile.backgroundUrl,
+          userType: res.profile.userType,
+        });
+        useStore.setState((st) => ({
+          chats: st.chats.map((c) =>
+            c.id === chat.id
+              ? {
+                  ...c,
+                  members: c.members?.map((m) =>
+                    m.id === member.id
+                      ? {
+                          ...m,
+                          avatarUrl: res.profile?.thumbnailUrl || m.avatarUrl,
+                          name:
+                            res.profile?.displayName && !looksLikeMid(res.profile.displayName)
+                              ? res.profile.displayName
+                              : m.name,
+                        }
+                      : m,
+                  ),
+                }
+              : c,
+          ),
+        }));
+      })
+      .catch(() => undefined);
     void api.line
       .commonGroups(accountId, member.id, chat.id)
       .then((res) => {
@@ -120,7 +163,15 @@ export function MemberProfilePopover({ chat }: { chat: Chat }) {
       >
         <div
           className="relative flex flex-col items-center px-6 pb-5 pt-8"
-          style={{ background: `color-mix(in oklab, ${member.color} 18%, var(--vy-surface))` }}
+          style={
+            showBackground
+              ? {
+                  backgroundImage: `linear-gradient(180deg, color-mix(in oklab, black 10%, transparent), color-mix(in oklab, black 24%, transparent)), url(${backgroundUrl})`,
+                  backgroundSize: "cover",
+                  backgroundPosition: "center",
+                }
+              : { background: `color-mix(in oklab, ${member.color} 18%, var(--vy-surface))` }
+          }
         >
           <button
             type="button"
@@ -145,6 +196,16 @@ export function MemberProfilePopover({ chat }: { chat: Chat }) {
           <p className="mt-0.5 text-xs text-[var(--vy-text-dim)]">
             {streamerMode ? "配信者モードで非表示" : `${chat.name} のメンバー`}
           </p>
+          {!streamerMode && rich.statusMessage && (
+              <div className="mt-4 w-full space-y-2 rounded-2xl border border-white/10 bg-black/10 p-3 text-left text-white backdrop-blur-sm">
+                {rich.statusMessage && <TinyInfo label="ステメ" value={rich.statusMessage} />}
+                {(chat.isOfficial || rich.userType === 2) && (
+                  <span className="inline-flex rounded-full bg-white/15 px-2.5 py-1 text-[0.65rem] font-medium text-white">
+                    公式アカウント
+                  </span>
+                )}
+              </div>
+            )}
         </div>
 
         <div className="grid grid-cols-3 gap-2 p-4">
@@ -213,6 +274,15 @@ export function MemberProfilePopover({ chat }: { chat: Chat }) {
         )}
       </div>
     </div>
+  );
+}
+
+function TinyInfo({ label, value }: { label: string; value: string }) {
+  return (
+    <p className="text-xs leading-relaxed">
+      <span className="text-white/70">{label} · </span>
+      <span>{value}</span>
+    </p>
   );
 }
 

--- a/Vyline/apps/desktop/src/components/member-profile.tsx
+++ b/Vyline/apps/desktop/src/components/member-profile.tsx
@@ -197,15 +197,15 @@ export function MemberProfilePopover({ chat }: { chat: Chat }) {
             {streamerMode ? "配信者モードで非表示" : `${chat.name} のメンバー`}
           </p>
           {!streamerMode && rich.statusMessage && (
-              <div className="mt-4 w-full space-y-2 rounded-2xl border border-white/10 bg-black/10 p-3 text-left text-white backdrop-blur-sm">
-                {rich.statusMessage && <TinyInfo label="ステメ" value={rich.statusMessage} />}
-                {(chat.isOfficial || rich.userType === 2) && (
-                  <span className="inline-flex rounded-full bg-white/15 px-2.5 py-1 text-[0.65rem] font-medium text-white">
-                    公式アカウント
-                  </span>
-                )}
-              </div>
-            )}
+            <div className="mt-4 w-full space-y-2 rounded-2xl border border-white/10 bg-black/10 p-3 text-left text-white backdrop-blur-sm">
+              {rich.statusMessage && <TinyInfo label="ステメ" value={rich.statusMessage} />}
+              {(chat.isOfficial || rich.userType === 2) && (
+                <span className="inline-flex rounded-full bg-white/15 px-2.5 py-1 text-[0.65rem] font-medium text-white">
+                  公式アカウント
+                </span>
+              )}
+            </div>
+          )}
         </div>
 
         <div className="grid grid-cols-3 gap-2 p-4">

--- a/Vyline/apps/desktop/src/components/message-bubble.tsx
+++ b/Vyline/apps/desktop/src/components/message-bubble.tsx
@@ -313,7 +313,10 @@ function Highlighted({
 }
 
 function replySnippet(m: Message): string {
-  if (m.messageState.startsWith("revoked")) return "取り消されたメッセージ";
+  if (m.messageState.startsWith("revoked")) {
+    if (m.revokedSnapshot) return `取り消し済み: ${replySnippet(m.revokedSnapshot)}`;
+    return "取り消し済みのメッセージ";
+  }
   if (m.kind === "image") return "写真";
   if (m.kind === "video") return "動画";
   if (m.kind === "audio") return "音声";
@@ -327,11 +330,18 @@ function replySnippet(m: Message): string {
 }
 
 /** スタンプ URL（/api/cdn/line?u=...android/sticker.png）→ アニメ版 URL */
-function stickerAnimationUrl(url: string): string {
+function stickerAnimationUrl(url?: string): string {
+  if (!url) return "";
   let u = decodeURIComponent(url);
   u = u.replace(/\/sticker\.png$/, "/sticker_animation.png").replace(/\/android\//, "/ANDROID/");
   if (u.startsWith("http")) u = `/api/cdn/line?u=${encodeURIComponent(u)}`;
   return u;
+}
+
+function isStickerImageSrc(src?: string): boolean {
+  return Boolean(
+    src && (src.startsWith("http") || src.startsWith("/api/") || src.startsWith("data:")),
+  );
 }
 
 // MessageReactionType → 表示絵文字（LINE 公式: NICE=2 LOVE=3 FUN=4 AMAZING=5 SAD=6 OMG=7）
@@ -459,6 +469,7 @@ export const MessageBubble = memo(
     const streamerMode = settings.streamerMode;
     const revokeMessage = useStore((s) => s.revokeMessage);
     const restoreRevokedMessage = useStore((s) => s.restoreRevokedMessage);
+    const fetchMessageHistory = useStore((s) => s.fetchMessageHistory);
     const editMessage = useStore((s) => s.editMessage);
     const retryMessage = useStore((s) => s.retryMessage);
     const markRead = useStore((s) => s.markRead);
@@ -479,8 +490,75 @@ export const MessageBubble = memo(
     const [history, setHistory] = useState<NonNullable<Message["history"]>>([]);
     const [historyLoading, setHistoryLoading] = useState(false);
     const [lightbox, setLightbox] = useState(false);
+    const [revokedFallbackText, setRevokedFallbackText] = useState<string | null>(null);
     const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
     const longPressFired = useRef(false);
+    const isRevoked =
+      message.messageState.startsWith("revoked") ||
+      Boolean(message.revokedSnapshot) ||
+      Boolean(
+        message.history?.length &&
+          message.history.some(
+            (h) => h.state === "normal" || h.state === "edited" || h.contentType === "UNSENT",
+          ),
+      );
+    const displayMessage = isRevoked && message.revokedSnapshot ? message.revokedSnapshot : message;
+    const revokedHistoryText =
+      message.history && message.history.length > 0
+        ? ([...message.history]
+            .reverse()
+            .find((h) => h.state === "normal" || h.state === "edited")
+            ?.text?.trim() ?? null)
+        : null;
+    const revokedBodyText =
+      revokedFallbackText ?? revokedHistoryText ?? displayMessage.text?.trim() ?? null;
+    const revokedDisplayMessage =
+      displayMessage.kind === "text" ||
+      displayMessage.kind === "emoji" ||
+      displayMessage.kind === "system"
+        ? {
+            ...displayMessage,
+            text: revokedBodyText || "（内容なし）",
+          }
+        : displayMessage;
+
+    useEffect(() => {
+      let cancelled = false;
+      if (!isRevoked) {
+        setRevokedFallbackText(null);
+        return () => {
+          cancelled = true;
+        };
+      }
+      const snapshotText = message.revokedSnapshot?.text?.trim();
+      if (snapshotText) {
+        setRevokedFallbackText(null);
+        return () => {
+          cancelled = true;
+        };
+      }
+      void (async () => {
+        try {
+          const history = await fetchMessageHistory(message.chatId, message.id);
+          const last = [...(history ?? [])]
+            .reverse()
+            .find((h) => h.state === "normal" || h.state === "edited");
+          if (!cancelled) setRevokedFallbackText(last?.text ?? null);
+        } catch {
+          if (!cancelled) setRevokedFallbackText(null);
+        }
+      })();
+      return () => {
+        cancelled = true;
+      };
+    }, [
+      fetchMessageHistory,
+      message.chatId,
+      message.id,
+      message.messageState,
+      isRevoked,
+      message.revokedSnapshot?.text,
+    ]);
 
     const author = chat.members?.find((m) => m.id === message.authorId);
     const repliedAuthor =
@@ -498,7 +576,7 @@ export const MessageBubble = memo(
     }
 
     function onTouchStart(e: React.TouchEvent) {
-      if (message.messageState.startsWith("revoked")) return;
+      if (isRevoked) return;
       const t = e.touches[0];
       longPressFired.current = false;
       longPressTimer.current = setTimeout(() => {
@@ -642,7 +720,7 @@ export const MessageBubble = memo(
             },
           ]
         : []),
-      ...(message.kind === "sticker" && message.sticker?.startsWith("/api/")
+      ...(message.kind === "sticker" && isStickerImageSrc(message.sticker)
         ? [
             {
               label: "ダウンロード",
@@ -695,7 +773,7 @@ export const MessageBubble = memo(
           ]
         : []),
       ...(isMe &&
-      !message.messageState.startsWith("revoked") &&
+      !isRevoked &&
       message.kind === "text" &&
       message.status !== "sending" &&
       !message.id.startsWith("pending_")
@@ -732,9 +810,9 @@ export const MessageBubble = memo(
           ]
         : []),
       ...(isMe &&
-      message.messageState === "revoked-by-self" &&
-      message.history &&
-      message.history.length > 0
+      isRevoked &&
+      message.authorId === "me" &&
+      (message.revokedSnapshot || (message.history && message.history.length > 0))
         ? [
             {
               label: "復元",
@@ -743,10 +821,7 @@ export const MessageBubble = memo(
             },
           ]
         : []),
-      ...(isMe &&
-      !message.messageState.startsWith("revoked") &&
-      message.status !== "sending" &&
-      !message.id.startsWith("pending_")
+      ...(isMe && !isRevoked && message.status !== "sending" && !message.id.startsWith("pending_")
         ? [
             {
               label: "送信を取り消し",
@@ -756,7 +831,7 @@ export const MessageBubble = memo(
             },
           ]
         : []),
-      ...(chat.type === "group" && (message.text || message.altText)
+      ...(chat.type === "group" && !isRevoked && (message.text || message.altText)
         ? [
             {
               label: "アナウンスを追加",
@@ -770,7 +845,7 @@ export const MessageBubble = memo(
     const isMessageEdited = message.edited || Boolean(message.originalText);
 
     const readReceipt = (() => {
-      if (!isMe || message.messageState.startsWith("revoked")) return null;
+      if (!isMe || isRevoked) return null;
       if (message.status === "sending") return <span className="opacity-60">送信中…</span>;
       if (message.status === "failed")
         return (
@@ -817,11 +892,11 @@ export const MessageBubble = memo(
       readers.length > 0 &&
       message.read;
 
-    if (message.kind === "call" && !message.messageState.startsWith("revoked")) {
+    if (message.kind === "call" && !isRevoked) {
       return <CallEventMessage meta={message.callMeta} isMe={isMe} />;
     }
 
-    if (message.kind === "system" && !message.messageState.startsWith("revoked")) {
+    if (message.kind === "system" && !isRevoked) {
       return (
         <div className="my-1 flex w-full justify-center px-1">
           <span className="rounded-full bg-[color-mix(in_oklab,var(--vy-text)_10%,transparent)] px-3 py-1 text-center text-[0.7rem] text-[var(--vy-text-dim)]">
@@ -831,7 +906,7 @@ export const MessageBubble = memo(
       );
     }
 
-    const metaLine = !message.messageState.startsWith("revoked") && (
+    const metaLine = !isRevoked && (
       <div
         className={cn(
           "mt-1 flex items-center gap-1.5 px-1 text-[0.7rem] text-[var(--vy-text-dim)]",
@@ -915,6 +990,243 @@ export const MessageBubble = memo(
       />
     );
 
+    const renderBubbleContent = (target: Message) => {
+      if (target.kind === "call") {
+        return <CallEventMessage meta={target.callMeta} isMe={target.authorId === "me"} />;
+      }
+
+      if (target.kind === "system") {
+        return (
+          <div className="my-1 flex w-full justify-center px-1">
+            <span className="rounded-full bg-[color-mix(in_oklab,var(--vy-text)_10%,transparent)] px-3 py-1 text-center text-[0.7rem] text-[var(--vy-text-dim)]">
+              {target.text || "システムメッセージ"}
+            </span>
+          </div>
+        );
+      }
+
+      if (target.kind === "sticker") {
+        return (
+          <div
+            className={cn(
+              "vy-pop-in cursor-default",
+              target.stickerSticky && "relative flex w-full justify-center py-2",
+            )}
+            aria-label="スタンプ"
+          >
+            {target.stickerSticky && (
+              <span className="absolute -top-1 left-1 rounded-full bg-[color-mix(in_oklab,var(--vy-text)_15%,transparent)] px-1.5 py-0.5 text-[0.6rem] text-[var(--vy-text-dim)]">
+                くっつき
+              </span>
+            )}
+            {isStickerImageSrc(target.sticker) ? (
+              <img
+                src={target.stickerAnimated ? stickerAnimationUrl(target.sticker) : target.sticker}
+                alt="スタンプ"
+                onError={hideBrokenMedia}
+                className={cn("h-32 w-32 object-contain", target.stickerSticky && "drop-shadow-md")}
+                draggable={false}
+              />
+            ) : (
+              <span className="text-7xl leading-none">{target.sticker || "🎴"}</span>
+            )}
+          </div>
+        );
+      }
+
+      if (target.kind === "emoji") {
+        return (
+          <div className="vy-pop-in cursor-default text-6xl leading-none" aria-label="絵文字">
+            {target.sticons?.length ? (
+              <Highlighted
+                text={target.text ?? ""}
+                sticons={target.sticons}
+                mentions={target.mentions}
+              />
+            ) : (
+              target.text
+            )}
+          </div>
+        );
+      }
+
+      if (target.kind === "flex") {
+        return target.flexJson ? (
+          <FlexMessageView container={target.flexJson} altText={target.altText || target.text} />
+        ) : (
+          <div className="rounded-xl bg-white px-3 py-2 text-sm text-neutral-700 shadow-sm">
+            {target.altText || "Flexメッセージ"}
+          </div>
+        );
+      }
+
+      if (target.kind === "rich") {
+        return (
+          <RichMessageView
+            imageUrl={target.richImageUrl}
+            markup={target.richMarkup}
+            altText={target.altText || target.text}
+          />
+        );
+      }
+
+      if (target.kind === "location") {
+        return (
+          <div className="vy-msg-enter max-w-[280px] overflow-hidden rounded-msg shadow-sm">
+            {target.location?.latitude != null && target.location?.longitude != null ? (
+              <a
+                href={`https://www.google.com/maps/search/?api=1&query=${target.location.latitude},${target.location.longitude}`}
+                target="_blank"
+                rel="noreferrer"
+                className="block h-32 w-full bg-cover bg-center"
+                style={{
+                  backgroundImage: `url(https://maps.googleapis.com/maps/api/staticmap?center=${target.location.latitude},${target.location.longitude}&zoom=15&size=280x128&markers=color:red%7C${target.location.latitude},${target.location.longitude}&key=)`,
+                }}
+                aria-label="地図を開く"
+              />
+            ) : null}
+            <div className="bg-[var(--vy-msg-in)] px-3 py-2 text-[var(--vy-msg-in-text)]">
+              <p className="flex items-center gap-1.5 text-sm font-semibold">
+                <IconPin size={15} /> {target.location?.title || "位置情報"}
+              </p>
+              {target.location?.address && (
+                <p className="mt-0.5 text-xs text-[var(--vy-text-dim)]">
+                  {target.location.address}
+                </p>
+              )}
+              {target.location?.latitude != null && target.location?.longitude != null && (
+                <a
+                  href={`https://www.google.com/maps/search/?api=1&query=${target.location.latitude},${target.location.longitude}`}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="mt-1 inline-block text-xs font-medium"
+                  style={{ color: "var(--vy-accent)" }}
+                >
+                  地図を開く
+                </a>
+              )}
+            </div>
+          </div>
+        );
+      }
+
+      if (target.kind === "contact") {
+        return (
+          <div className="vy-msg-enter w-[240px] overflow-hidden rounded-msg shadow-sm">
+            <div className="flex items-center gap-3 bg-[var(--vy-msg-in)] px-3 py-3 text-[var(--vy-msg-in-text)]">
+              {target.contact?.thumbnailUrl ? (
+                <img
+                  src={target.contact.thumbnailUrl}
+                  alt=""
+                  onError={hideBrokenMedia}
+                  className="h-11 w-11 rounded-full object-cover"
+                />
+              ) : (
+                <span className="flex h-11 w-11 items-center justify-center rounded-full bg-[var(--vy-accent)] text-lg font-bold text-white">
+                  {(target.contact?.name || "?").charAt(0).toUpperCase()}
+                </span>
+              )}
+              <div className="min-w-0">
+                <p className="truncate text-sm font-semibold">{target.contact?.name || "連絡先"}</p>
+                <p className="text-[0.65rem] text-[var(--vy-text-dim)]">連絡先が共有されました</p>
+              </div>
+            </div>
+          </div>
+        );
+      }
+
+      return (
+        <div
+          className={cn(
+            "vy-msg-enter vy-bubble-pad relative select-none rounded-msg text-[length:inherit] leading-relaxed shadow-sm",
+          )}
+          style={{
+            background: isMe ? "var(--vy-msg-out)" : "var(--vy-msg-in)",
+            color: isMe ? "var(--vy-msg-out-text)" : "var(--vy-msg-in-text)",
+            borderTopRightRadius: isMe && settings.bubbleTail ? 6 : undefined,
+            borderTopLeftRadius: !isMe && settings.bubbleTail ? 6 : undefined,
+          }}
+        >
+          {replyQuote}
+          {(target.kind === "image" || target.kind === "video") &&
+            target.imageSrc &&
+            (streamerMode ? (
+              <SpoilerMedia
+                src={target.imageSrc}
+                alt={target.kind === "video" ? "動画サムネイル" : "送信された画像"}
+                video={target.kind === "video"}
+              />
+            ) : (
+              <button
+                type="button"
+                className="group relative block overflow-hidden rounded-xl text-left"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setLightbox(true);
+                }}
+                aria-label={target.kind === "video" ? "動画を拡大" : "画像を拡大"}
+              >
+                {target.kind === "video" ? (
+                  <div className="relative">
+                    <img
+                      src={target.imageSrc}
+                      alt="動画サムネイル"
+                      onError={hideBrokenMedia}
+                      className="h-auto w-[260px] max-w-full object-cover"
+                    />
+                    <span className="absolute inset-0 flex items-center justify-center bg-black/35">
+                      <span className="flex h-12 w-12 items-center justify-center rounded-full bg-black/50 text-white">
+                        <IconPlay size={22} />
+                      </span>
+                    </span>
+                  </div>
+                ) : (
+                  <img
+                    src={target.imageSrc}
+                    alt="送信された画像"
+                    onError={hideBrokenMedia}
+                    className="max-h-[360px] max-w-[240px] object-contain transition-opacity group-hover:opacity-95"
+                  />
+                )}
+              </button>
+            ))}
+          {target.kind === "audio" && target.audioSrc && (
+            <AudioBubble src={target.audioSrc} seconds={target.audioSeconds} />
+          )}
+          {target.kind === "text" && (
+            <div>
+              {showOriginal && target.originalText && (
+                <div className="mb-1 flex items-center justify-between border-b border-current/15 pb-1 text-[0.65rem] opacity-70">
+                  <span>編集前のメッセージ</span>
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setShowOriginal(false);
+                    }}
+                    className="underline hover:opacity-100"
+                  >
+                    戻す
+                  </button>
+                </div>
+              )}
+              <p className="vy-msg-text whitespace-pre-wrap break-words">
+                <Highlighted
+                  text={
+                    showOriginal && target.originalText ? target.originalText : (target.text ?? "")
+                  }
+                  query={highlight}
+                  sticons={target.sticons}
+                  mentions={target.mentions}
+                />
+              </p>
+            </div>
+          )}
+          {target.linkPreview && !streamerMode && <LinkPreviewCard preview={target.linkPreview} />}
+        </div>
+      );
+    };
+
     return (
       <div className={cn("flex w-full gap-2 px-1", isMe ? "flex-row-reverse" : "flex-row")}>
         {!isMe && chat.type === "group" && (
@@ -957,42 +1269,41 @@ export const MessageBubble = memo(
             </button>
           )}
 
-          {message.messageState.startsWith("revoked") ? (
+          {isRevoked ? (
             <div
               className={cn(
-                "relative rounded-2xl border px-4 py-2.5 text-sm",
-                message.messageState === "revoked-by-self"
-                  ? "border-dashed bg-[color-mix(in_oklab,var(--vy-accent)_8%,transparent)] italic"
-                  : "border-dashed bg-[color-mix(in_oklab,var(--vy-text)_6%,transparent)] line-through opacity-80",
-                message.messageState === "revoked-by-self" &&
-                  message.history &&
-                  message.history.length > 0
-                  ? ""
-                  : "opacity-70",
+                "relative overflow-hidden rounded-msg border border-dashed px-3 py-2.5 shadow-sm",
+                isRevoked && message.authorId === "me"
+                  ? "bg-[color-mix(in_oklab,var(--vy-accent)_7%,transparent)]"
+                  : "bg-[color-mix(in_oklab,var(--vy-text)_5%,var(--vy-surface-2))]",
               )}
               style={{
                 borderColor:
-                  message.messageState === "revoked-by-self"
-                    ? "var(--vy-accent)"
+                  isRevoked && message.authorId === "me"
+                    ? "color-mix(in oklab, var(--vy-accent) 55%, transparent)"
                     : "var(--vy-border)",
               }}
             >
-              <span className="flex items-center gap-1.5">
-                <IconTrash className="h-3.5 w-3.5 shrink-0" />
-                {message.messageState === "revoked-by-self"
-                  ? "あなたがメッセージの送信を取り消しました"
-                  : "メッセージの送信が取り消されました"}
+              <span
+                className={cn(
+                  "absolute right-2 top-2 rounded-full border px-2 py-0.5 text-[0.62rem] font-semibold tracking-wide",
+                  isRevoked && message.authorId === "me"
+                    ? "border-[color-mix(in_oklab,var(--vy-accent)_50%,transparent)] bg-[color-mix(in_oklab,var(--vy-accent)_18%,transparent)] text-[var(--vy-accent)]"
+                    : "border-[var(--vy-border)] bg-[color-mix(in_oklab,var(--vy-text)_10%,transparent)] text-[var(--vy-text-dim)]",
+                )}
+              >
+                取り消し済み
               </span>
-              {message.history && message.history.length > 0 ? (
-                <div className="mt-1.5 text-xs not-italic opacity-90">
-                  {(() => {
-                    const last = [...message.history]
-                      .reverse()
-                      .find((h) => h.state === "normal" || h.state === "edited");
-                    return last ? (last.text ?? "（なし）") : "";
-                  })()}
-                </div>
-              ) : null}
+              <div className="pr-16">{renderBubbleContent(revokedDisplayMessage)}</div>
+              <div className="mt-2 flex items-center gap-1.5 text-[0.7rem] text-[var(--vy-text-dim)]">
+                <IconTrash className="h-3.5 w-3.5 shrink-0 opacity-80" />
+                <span>{formatTime(message.createdAt)}</span>
+                <span className="opacity-70">
+                  {isRevoked && message.authorId === "me"
+                    ? "あなたが送信を取り消しました"
+                    : "送信が取り消されました"}
+                </span>
+              </div>
             </div>
           ) : message.kind === "sticker" ? (
             <button
@@ -1010,8 +1321,7 @@ export const MessageBubble = memo(
                   くっつき
                 </span>
               )}
-              {message.sticker &&
-              (message.sticker.startsWith("http") || message.sticker.startsWith("/api/")) ? (
+              {isStickerImageSrc(message.sticker) ? (
                 <img
                   src={
                     message.stickerAnimated ? stickerAnimationUrl(message.sticker) : message.sticker
@@ -1235,16 +1545,14 @@ export const MessageBubble = memo(
 
           {metaLine}
           {readerList}
-          {message.reactions &&
-            message.reactions.length > 0 &&
-            !message.messageState.startsWith("revoked") && (
-              <ReactionBadges
-                reactions={message.reactions}
-                myMid={self?.mid ?? ""}
-                onReact={react}
-                side={isMe ? "right" : "left"}
-              />
-            )}
+          {message.reactions && message.reactions.length > 0 && !isRevoked && (
+            <ReactionBadges
+              reactions={message.reactions}
+              myMid={self?.mid ?? ""}
+              onReact={react}
+              side={isMe ? "right" : "left"}
+            />
+          )}
         </div>
 
         {menu && (

--- a/Vyline/apps/desktop/src/components/message-input.tsx
+++ b/Vyline/apps/desktop/src/components/message-input.tsx
@@ -656,7 +656,7 @@ export function MessageInput({ chatId }: { chatId: string }) {
                     ? undefined
                     : muteNext
                       ? "メッセージを入力（ミュート送信: 通知なし）"
-                      : "メッセージを入力（絵文字は文中に挿入）"
+                      : "メッセージを入力"
                 }
                 aria-label="メッセージを入力"
                 className={cn(

--- a/Vyline/apps/desktop/src/components/premium-badge.tsx
+++ b/Vyline/apps/desktop/src/components/premium-badge.tsx
@@ -1,0 +1,30 @@
+import { cn } from "@/lib/utils";
+
+export function PremiumBadge({
+  className,
+  size = 14,
+  compact = false,
+}: {
+  className?: string;
+  size?: number;
+  compact?: boolean;
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex shrink-0 items-center justify-center rounded-full font-bold text-white shadow-sm",
+        className,
+      )}
+      style={{
+        width: size,
+        height: size,
+        background: "linear-gradient(145deg, #a855f7, #6d28d9)",
+        fontSize: Math.max(8, size * 0.56),
+      }}
+      aria-label="LYP Premium"
+      title="LYP Premium"
+    >
+      {compact ? "" : "P"}
+    </span>
+  );
+}

--- a/Vyline/apps/desktop/src/components/profile-drawer.tsx
+++ b/Vyline/apps/desktop/src/components/profile-drawer.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useStore, displayName, commonGroupsWith, type Chat } from "@/lib/store";
 import { api } from "@/api/client";
 import { Avatar } from "@/components/vy-ui";
+import { PremiumBadge } from "@/components/premium-badge";
 import {
   IconClose,
   IconChat,
@@ -15,7 +16,6 @@ import {
   IconMemo,
 } from "@/components/icons";
 import { looksLikeMid, mapMember } from "@/lib/mappers";
-import { parseMusicProfile } from "@/lib/vyline-cache";
 import { dismissChatMid } from "@/utils/dismissedChats";
 
 type RichInfo = {
@@ -29,25 +29,6 @@ type RichInfo = {
   userType?: number;
 };
 
-function InfoItem({
-  label,
-  value,
-  mono,
-}: {
-  label: string;
-  value: string;
-  mono?: boolean;
-}) {
-  return (
-    <div className="rounded-lg border border-[var(--vy-border)] bg-[var(--vy-surface-2)] px-3 py-2">
-      <p className="text-[0.65rem] font-medium text-[var(--vy-text-dim)]">{label}</p>
-      <p className={mono ? "mt-1 font-mono text-xs break-all" : "mt-1 text-xs break-words"}>
-        {value}
-      </p>
-    </div>
-  );
-}
-
 export function ProfileDrawer({ chat }: { chat: Chat }) {
   const setProfileDrawer = useStore((s) => s.setProfileDrawer);
   const openChat = useStore((s) => s.openChat);
@@ -58,6 +39,7 @@ export function ProfileDrawer({ chat }: { chat: Chat }) {
   const settings = useStore((s) => s.settings);
   const setLocalName = useStore((s) => s.setLocalName);
   const accountId = useStore((s) => s.accountId);
+  const selfPremium = useStore((s) => s.self.premium?.active ?? false);
 
   const [editing, setEditing] = useState(false);
   const [nameInput, setNameInput] = useState(chat.localName ?? chat.name);
@@ -247,7 +229,6 @@ export function ProfileDrawer({ chat }: { chat: Chat }) {
   }, [accountId, chat.id, chat.type, streamerMode, chat.isSelf]);
 
   const name = displayName(chat, streamerMode);
-  const music = parseMusicProfile(rich.musicProfile);
   const backgroundUrl = chat.backgroundUrl ?? rich.backgroundUrl;
   const showBackground = Boolean(!streamerMode && settings.showBackground && backgroundUrl);
 
@@ -437,8 +418,7 @@ export function ProfileDrawer({ chat }: { chat: Chat }) {
               style={
                 showBackground
                   ? {
-                      backgroundImage:
-                        `linear-gradient(180deg, color-mix(in oklab, black 8%, transparent), color-mix(in oklab, black 20%, transparent)), url(${backgroundUrl})`,
+                      backgroundImage: `linear-gradient(180deg, color-mix(in oklab, black 8%, transparent), color-mix(in oklab, black 20%, transparent)), url(${backgroundUrl})`,
                       backgroundSize: "cover",
                       backgroundPosition: "center",
                     }
@@ -476,6 +456,7 @@ export function ProfileDrawer({ chat }: { chat: Chat }) {
               ) : (
                 <div className="mt-3 flex items-center gap-2">
                   <h2 className="text-xl font-bold">{name}</h2>
+                  {chat.isSelf && selfPremium && <PremiumBadge size={14} compact />}
                   {!streamerMode && !chat.isSelf && (
                     <button
                       type="button"
@@ -513,19 +494,11 @@ export function ProfileDrawer({ chat }: { chat: Chat }) {
             </div>
           </div>
 
-          {!streamerMode && (
-            <div className="mt-4 space-y-3 rounded-xl border border-[var(--vy-border)] px-3 py-2.5 text-sm">
-              {music && (
-                <InfoItem
-                  label="音楽"
-                  value={`${music.title || music.raw}${music.artist ? ` — ${music.artist}` : ""}`}
-                />
-              )}
-              {(chat.isOfficial || rich.userType === 2) && (
-                <span className="inline-flex w-fit items-center rounded-full bg-[color-mix(in_oklab,var(--vy-accent)_16%,transparent)] px-2.5 py-1 text-xs font-medium text-[var(--vy-accent)]">
-                  公式アカウント
-                </span>
-              )}
+          {!streamerMode && (chat.isOfficial || rich.userType === 2) && (
+            <div className="mt-4">
+              <span className="inline-flex w-fit items-center rounded-full bg-[color-mix(in_oklab,var(--vy-accent)_16%,transparent)] px-2.5 py-1 text-xs font-medium text-[var(--vy-accent)]">
+                公式アカウント
+              </span>
             </div>
           )}
 

--- a/Vyline/apps/desktop/src/components/profile-drawer.tsx
+++ b/Vyline/apps/desktop/src/components/profile-drawer.tsx
@@ -20,10 +20,33 @@ import { dismissChatMid } from "@/utils/dismissedChats";
 
 type RichInfo = {
   statusMessage?: string;
+  phoneticName?: string;
   musicProfile?: string;
   birthday?: string;
   backgroundUrl?: string;
+  pictureStatus?: string;
+  profileId?: string;
+  userType?: number;
 };
+
+function InfoItem({
+  label,
+  value,
+  mono,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className="rounded-lg border border-[var(--vy-border)] bg-[var(--vy-surface-2)] px-3 py-2">
+      <p className="text-[0.65rem] font-medium text-[var(--vy-text-dim)]">{label}</p>
+      <p className={mono ? "mt-1 font-mono text-xs break-all" : "mt-1 text-xs break-words"}>
+        {value}
+      </p>
+    </div>
+  );
+}
 
 export function ProfileDrawer({ chat }: { chat: Chat }) {
   const setProfileDrawer = useStore((s) => s.setProfileDrawer);
@@ -144,19 +167,27 @@ export function ProfileDrawer({ chat }: { chat: Chat }) {
           ok: boolean;
           profile?: {
             statusMessage?: string;
+            phoneticName?: string;
             musicProfile?: string;
             birthday?: { display?: string };
             backgroundUrl?: string;
             displayName?: string;
             thumbnailUrl?: string;
+            pictureStatus?: string;
+            profileId?: string;
+            userType?: number;
           };
         };
         if (!r.profile) return;
         setRich({
           statusMessage: r.profile.statusMessage,
+          phoneticName: r.profile.phoneticName,
           musicProfile: r.profile.musicProfile,
           birthday: r.profile.birthday?.display,
           backgroundUrl: r.profile.backgroundUrl,
+          pictureStatus: r.profile.pictureStatus,
+          profileId: r.profile.profileId,
+          userType: r.profile.userType,
         });
         const nextName =
           r.profile.displayName && !looksLikeMid(r.profile.displayName)
@@ -217,6 +248,8 @@ export function ProfileDrawer({ chat }: { chat: Chat }) {
 
   const name = displayName(chat, streamerMode);
   const music = parseMusicProfile(rich.musicProfile);
+  const backgroundUrl = chat.backgroundUrl ?? rich.backgroundUrl;
+  const showBackground = Boolean(!streamerMode && settings.showBackground && backgroundUrl);
 
   const handleTalk = () => {
     if (chat.type === "friend") {
@@ -402,11 +435,10 @@ export function ProfileDrawer({ chat }: { chat: Chat }) {
             <div
               className="h-28 bg-[color-mix(in_oklab,var(--vy-accent)_18%,var(--vy-surface-2))]"
               style={
-                !streamerMode &&
-                settings.showBackground &&
-                (chat.backgroundUrl ?? rich.backgroundUrl)
+                showBackground
                   ? {
-                      backgroundImage: `url(${rich.backgroundUrl})`,
+                      backgroundImage:
+                        `linear-gradient(180deg, color-mix(in oklab, black 8%, transparent), color-mix(in oklab, black 20%, transparent)), url(${backgroundUrl})`,
                       backgroundSize: "cover",
                       backgroundPosition: "center",
                     }
@@ -481,20 +513,18 @@ export function ProfileDrawer({ chat }: { chat: Chat }) {
             </div>
           </div>
 
-          {!streamerMode && (music || rich.birthday) && (
-            <div className="mt-4 space-y-2 rounded-xl border border-[var(--vy-border)] px-3 py-2.5 text-sm">
+          {!streamerMode && (
+            <div className="mt-4 space-y-3 rounded-xl border border-[var(--vy-border)] px-3 py-2.5 text-sm">
               {music && (
-                <p>
-                  <span className="text-[var(--vy-text-dim)]">音楽 · </span>
-                  {music.title || music.raw}
-                  {music.artist ? ` — ${music.artist}` : ""}
-                </p>
+                <InfoItem
+                  label="音楽"
+                  value={`${music.title || music.raw}${music.artist ? ` — ${music.artist}` : ""}`}
+                />
               )}
-              {rich.birthday && (
-                <p>
-                  <span className="text-[var(--vy-text-dim)]">誕生日 · </span>
-                  {rich.birthday}
-                </p>
+              {(chat.isOfficial || rich.userType === 2) && (
+                <span className="inline-flex w-fit items-center rounded-full bg-[color-mix(in_oklab,var(--vy-accent)_16%,transparent)] px-2.5 py-1 text-xs font-medium text-[var(--vy-accent)]">
+                  公式アカウント
+                </span>
               )}
             </div>
           )}

--- a/Vyline/apps/desktop/src/components/settings-sections.tsx
+++ b/Vyline/apps/desktop/src/components/settings-sections.tsx
@@ -95,25 +95,6 @@ function Card({ children }: { children: React.ReactNode }) {
   );
 }
 
-function SettingMeta({
-  label,
-  value,
-  mono,
-}: {
-  label: string;
-  value: string;
-  mono?: boolean;
-}) {
-  return (
-    <div className="rounded-xl border border-[var(--vy-border)] bg-[var(--vy-surface-2)] px-3 py-2">
-      <p className="text-[0.65rem] font-medium text-[var(--vy-text-dim)]">{label}</p>
-      <p className={mono ? "mt-1 font-mono text-xs break-all" : "mt-1 text-xs break-words"}>
-        {value}
-      </p>
-    </div>
-  );
-}
-
 export function SettingsSections() {
   const setScreen = useStore((s) => s.setScreen);
   const settings = useStore((s) => s.settings);

--- a/Vyline/apps/desktop/src/components/settings-sections.tsx
+++ b/Vyline/apps/desktop/src/components/settings-sections.tsx
@@ -20,7 +20,14 @@ function formatBytes(bytes: number): string {
   return `${(bytes / k ** i).toFixed(1)} ${sizes[i]}`;
 }
 
+function formatPercent(value: number): string {
+  if (!Number.isFinite(value)) return "0%";
+  const digits = value >= 10 ? 0 : 1;
+  return `${value.toFixed(digits)}%`;
+}
+
 import { Toggle, Avatar } from "@/components/vy-ui";
+import { PremiumBadge } from "@/components/premium-badge";
 import { VyThemePanel } from "@/components/vy-theme-panel";
 import {
   IconArrowLeft,
@@ -88,6 +95,25 @@ function Card({ children }: { children: React.ReactNode }) {
   );
 }
 
+function SettingMeta({
+  label,
+  value,
+  mono,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className="rounded-xl border border-[var(--vy-border)] bg-[var(--vy-surface-2)] px-3 py-2">
+      <p className="text-[0.65rem] font-medium text-[var(--vy-text-dim)]">{label}</p>
+      <p className={mono ? "mt-1 font-mono text-xs break-all" : "mt-1 text-xs break-words"}>
+        {value}
+      </p>
+    </div>
+  );
+}
+
 export function SettingsSections() {
   const setScreen = useStore((s) => s.setScreen);
   const settings = useStore((s) => s.settings);
@@ -98,7 +124,6 @@ export function SettingsSections() {
   const [section, setSection] = useState<Section>("read");
   const [nameDraft, setNameDraft] = useState(self.name);
   const [statusDraft, setStatusDraft] = useState(self.status);
-  const [birthdayDraft, setBirthdayDraft] = useState("");
   const [profileSaving, setProfileSaving] = useState(false);
   const [profileMsg, setProfileMsg] = useState<string | null>(null);
 
@@ -113,17 +138,10 @@ export function SettingsSections() {
       const body: {
         displayName?: string;
         statusMessage?: string;
-        birthday?: { day: string; year?: string };
       } = {
         displayName: nameDraft.trim(),
         statusMessage: statusDraft,
       };
-      const bday = birthdayDraft.replace(/[^0-9]/g, "");
-      if (bday.length === 4) {
-        body.birthday = { day: bday };
-      } else if (bday.length === 8) {
-        body.birthday = { year: bday.slice(0, 4), day: bday.slice(4) };
-      }
       const res = await api.line.updateProfile(accountId, body);
       if (!res.ok || !res.profile) {
         setProfileMsg(
@@ -137,6 +155,10 @@ export function SettingsSections() {
         birthday: res.profile.birthday?.display,
         avatarUrl: res.profile.thumbnailUrl || self.avatarUrl,
         mid: res.profile.mid,
+        phoneticName: res.profile.phoneticName || self.phoneticName,
+        pictureStatus: res.profile.pictureStatus || self.pictureStatus,
+        profileId: res.profile.profileId || self.profileId,
+        premium: res.profile.premium ?? self.premium,
       });
       setProfileMsg("LINE プロフィールを更新しました");
     } catch (err) {
@@ -177,9 +199,11 @@ export function SettingsSections() {
         setProfileMsg("背景画像をアップロードしました");
         // カバー URL は直後に取れないことがあるのでタイムスタンプ付きヒント
         updateSelf({
-          backgroundUrl: self.backgroundUrl
-            ? `${self.backgroundUrl.split("?")[0]}?t=${Date.now()}`
-            : self.backgroundUrl,
+          backgroundUrl: res.backgroundUrl
+            ? `${res.backgroundUrl.split("?")[0]}?t=${Date.now()}`
+            : self.backgroundUrl
+              ? `${self.backgroundUrl.split("?")[0]}?t=${Date.now()}`
+              : self.backgroundUrl,
         });
       } else {
         setProfileMsg(res.error ?? "背景更新に失敗しました");
@@ -297,6 +321,10 @@ export function SettingsSections() {
                         </label>
                       </div>
                       <div className="min-w-0 flex-1 pb-1">
+                        <div className="flex items-center gap-1.5">
+                          <p className="truncate text-base font-semibold">{self.name}</p>
+                          {self.premium?.active && <PremiumBadge size={14} compact />}
+                        </div>
                         <p className="text-xs text-[var(--vy-text-dim)]">
                           下の欄で表示名・ステメを編集
                         </p>
@@ -320,24 +348,7 @@ export function SettingsSections() {
                         className="mt-2 w-full rounded-lg border border-[var(--vy-border)] bg-[var(--vy-surface-2)] px-3 py-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-[var(--vy-accent)]"
                       />
                     </div>
-                    <div className="py-3">
-                      <label className="text-sm font-medium">誕生日（MMDD / YYYYMMDD・任意）</label>
-                      <input
-                        value={birthdayDraft}
-                        onChange={(e) => setBirthdayDraft(e.target.value)}
-                        placeholder={self.birthday || "0701"}
-                        className="mt-2 w-full rounded-lg border border-[var(--vy-border)] bg-[var(--vy-surface-2)] px-3 py-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-[var(--vy-accent)]"
-                      />
-                      <p className="mt-1 text-[0.7rem] text-[var(--vy-text-dim)]">
-                        一部デバイス種別では誕生日更新がサーバ拒否されることがあります
-                      </p>
-                    </div>
                   </Card>
-                  {self.musicProfile && (
-                    <p className="mt-2 text-xs text-[var(--vy-text-dim)]">
-                      音楽（表示のみ）: {self.musicProfile.slice(0, 80)}
-                    </p>
-                  )}
                   <button
                     type="button"
                     disabled={profileSaving}
@@ -971,30 +982,42 @@ function StorageSection() {
         { key: "file", label: "ファイル", size: storage.savedMedia.file, color: "#6b7280" },
       ]
     : [];
+  const diskFree = storage?.disk?.freeBytes ?? 0;
+  const diskUsed = storage?.disk?.usedBytes ?? 0;
+  const diskTotal = storage?.disk?.totalBytes ?? 0;
+  const diskUsedPct = diskTotal > 0 ? (diskUsed / diskTotal) * 100 : 0;
 
   return (
     <Section title="ストレージ" desc="アプリが使用している容量を管理します">
       {storage && (
         <div className="mb-6 overflow-hidden rounded-2xl border border-[var(--vy-border)] bg-[var(--vy-surface)]">
           <div className="p-5">
-            <div className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
               <div>
                 <p className="text-sm font-medium text-[var(--vy-text-dim)]">
                   ドライブ {storage.driveLetter ?? "---"}
                 </p>
-                {storage.disk && (
-                  <p className="text-xs text-[var(--vy-text-dim)]">
-                    合計 {formatBytes(storage.disk.totalBytes)} / 空き{" "}
-                    {formatBytes(storage.disk.freeBytes)}
-                  </p>
-                )}
+                <p className="mt-2 text-3xl font-semibold tracking-tight">
+                  {formatBytes(storage.vylineTotal)}
+                </p>
+                <p className="mt-2 text-sm text-[var(--vy-text-dim)]">
+                  アプリが保存している CDN
+                  キャッシュ、プロフィール画像、チャットメディアの合計です。
+                </p>
               </div>
-              <p className="text-2xl font-bold tracking-tight">
-                {formatBytes(storage.vylineTotal)}
-              </p>
+
+              <div className="rounded-xl border border-[var(--vy-border)] px-4 py-3">
+                <p className="text-xs text-[var(--vy-text-dim)]">ドライブ使用率</p>
+                <p className="mt-1 text-xl font-semibold tracking-tight">
+                  {formatPercent(diskUsedPct)}
+                </p>
+                <p className="mt-1 text-xs text-[var(--vy-text-dim)]">
+                  空き {formatBytes(diskFree)}
+                </p>
+              </div>
             </div>
 
-            <div className="mt-4 flex h-3 overflow-hidden rounded-full bg-[var(--vy-surface-2)]">
+            <div className="mt-5 h-3 overflow-hidden rounded-full bg-[var(--vy-surface-2)]">
               {segments.map((s) => {
                 const pct = storage.vylineTotal > 0 ? (s.size / storage.vylineTotal) * 100 : 0;
                 return (
@@ -1007,14 +1030,18 @@ function StorageSection() {
               })}
             </div>
 
-            <div className="mt-3 flex flex-wrap items-center gap-4 text-xs text-[var(--vy-text-dim)]">
+            <div className="mt-4 flex flex-wrap gap-2 text-xs text-[var(--vy-text-dim)]">
               {segments.map((s) => (
-                <span key={s.key} className="flex items-center gap-1.5">
+                <span
+                  key={s.key}
+                  className="inline-flex items-center gap-2 rounded-full border border-[var(--vy-border)] px-3 py-1.5"
+                >
                   <span
                     className="inline-block h-2 w-2 rounded-full"
                     style={{ background: s.color }}
                   />
-                  {s.label} {formatBytes(s.size)}
+                  <span>{s.label}</span>
+                  <span className="font-mono">{formatBytes(s.size)}</span>
                 </span>
               ))}
             </div>
@@ -1022,72 +1049,104 @@ function StorageSection() {
         </div>
       )}
 
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <div>
+          <p className="text-sm font-medium">削除候補</p>
+          <p className="text-xs text-[var(--vy-text-dim)]">容量の大きいものから並べています。</p>
+        </div>
+        {storage && (
+          <p className="text-xs text-[var(--vy-text-dim)]">
+            合計 {formatBytes(storage.cacheSize + storage.savedMediaSize)}
+          </p>
+        )}
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
         <TypeCard
           title="CDN キャッシュ"
           desc="スタンプ・LINE絵文字など"
           size={storage?.cache.cdn ?? 0}
+          ratio={storage && storage.vylineTotal > 0 ? storage.cache.cdn / storage.vylineTotal : 0}
           icon={<IconDownload size={20} className="text-[var(--vy-accent)]" />}
           iconBg="bg-[color-mix(in_oklab,var(--vy-accent)_18%,var(--vy-surface-2))]"
           onDelete={() =>
             clearType("CDN キャッシュ", () => api.line.clearVylineCdnCache(accountId!))
           }
           disabled={loading || !accountId}
+          accent="var(--vy-accent)"
         />
         <TypeCard
           title="アイコンキャッシュ"
           desc="プロフィール画像など"
           size={storage?.cache.icons ?? 0}
+          ratio={storage && storage.vylineTotal > 0 ? storage.cache.icons / storage.vylineTotal : 0}
           icon={<IconDownload size={20} className="text-[var(--vy-accent)]" />}
           iconBg="bg-[color-mix(in_oklab,var(--vy-accent)_18%,var(--vy-surface-2))]"
           onDelete={() =>
             clearType("アイコンキャッシュ", () => api.line.clearVylineIconCache(accountId!))
           }
           disabled={loading || !accountId}
+          accent="var(--vy-accent)"
         />
         <TypeCard
           title="画像"
           desc="チャット画像"
           size={storage?.savedMedia.image ?? 0}
+          ratio={
+            storage && storage.vylineTotal > 0 ? storage.savedMedia.image / storage.vylineTotal : 0
+          }
           icon={<IconDownload size={20} className="text-[#3b82f6]" />}
           iconBg="bg-[color-mix(in_oklab,#3b82f6_18%,var(--vy-surface-2))]"
           onDelete={() =>
             clearType("保存画像", () => api.line.clearVylineSavedMediaType(accountId!, "image"))
           }
           disabled={loading || !accountId}
+          accent="#3b82f6"
         />
         <TypeCard
           title="動画"
           desc="チャット動画"
           size={storage?.savedMedia.video ?? 0}
+          ratio={
+            storage && storage.vylineTotal > 0 ? storage.savedMedia.video / storage.vylineTotal : 0
+          }
           icon={<IconDownload size={20} className="text-[#a855f7]" />}
           iconBg="bg-[color-mix(in_oklab,#a855f7_18%,var(--vy-surface-2))]"
           onDelete={() =>
             clearType("保存動画", () => api.line.clearVylineSavedMediaType(accountId!, "video"))
           }
           disabled={loading || !accountId}
+          accent="#a855f7"
         />
         <TypeCard
           title="音声"
           desc="ボイスメッセージなど"
           size={storage?.savedMedia.audio ?? 0}
+          ratio={
+            storage && storage.vylineTotal > 0 ? storage.savedMedia.audio / storage.vylineTotal : 0
+          }
           icon={<IconDownload size={20} className="text-[#22c55e]" />}
           iconBg="bg-[color-mix(in_oklab,#22c55e_18%,var(--vy-surface-2))]"
           onDelete={() =>
             clearType("保存音声", () => api.line.clearVylineSavedMediaType(accountId!, "audio"))
           }
           disabled={loading || !accountId}
+          accent="#22c55e"
         />
         <TypeCard
           title="ファイル"
           desc="PDF など"
           size={storage?.savedMedia.file ?? 0}
+          ratio={
+            storage && storage.vylineTotal > 0 ? storage.savedMedia.file / storage.vylineTotal : 0
+          }
           icon={<IconDownload size={20} className="text-[#6b7280]" />}
           iconBg="bg-[color-mix(in_oklab,#6b7280_18%,var(--vy-surface-2))]"
           onDelete={() =>
             clearType("保存ファイル", () => api.line.clearVylineSavedMediaType(accountId!, "file"))
           }
           disabled={loading || !accountId}
+          accent="#6b7280"
         />
       </div>
 
@@ -1109,42 +1168,69 @@ function TypeCard({
   title,
   desc,
   size,
+  ratio,
   icon,
   iconBg,
+  accent,
   onDelete,
   disabled,
 }: {
   title: string;
   desc: string;
   size: number;
+  ratio: number;
   icon: React.ReactNode;
   iconBg: string;
+  accent: string;
   onDelete: () => void;
   disabled: boolean;
 }) {
+  const hasData = size > 0;
   return (
     <div className="overflow-hidden rounded-2xl border border-[var(--vy-border)] bg-[var(--vy-surface)]">
       <div className="p-5">
-        <div className="flex items-center gap-3">
-          <div className={`flex h-10 w-10 items-center justify-center rounded-xl ${iconBg}`}>
-            {icon}
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex min-w-0 items-center gap-3">
+            <div
+              className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-xl ${iconBg}`}
+            >
+              {icon}
+            </div>
+            <div className="min-w-0">
+              <p className="truncate text-sm font-medium">{title}</p>
+              <p className="mt-1 text-xs text-[var(--vy-text-dim)]">{desc}</p>
+            </div>
           </div>
-          <div className="min-w-0 flex-1">
-            <p className="text-sm font-medium">{title}</p>
-            <p className="text-xs text-[var(--vy-text-dim)]">{desc}</p>
+
+          <div className="shrink-0 text-right">
+            <p className="text-[11px] text-[var(--vy-text-dim)]">使用量</p>
+            <p className="mt-1 font-mono text-base font-semibold">{formatBytes(size)}</p>
           </div>
         </div>
-        <div className="mt-4 flex items-baseline justify-between">
-          <span className="text-lg font-semibold font-mono">{formatBytes(size)}</span>
+
+        <div className="mt-4">
+          <div className="h-2 overflow-hidden rounded-full bg-[var(--vy-surface-2)]">
+            <div
+              className="h-full rounded-full transition-all duration-500"
+              style={{ background: accent, width: `${Math.max(ratio * 100, hasData ? 4 : 0)}%` }}
+            />
+          </div>
+          <p className="mt-2 text-xs text-[var(--vy-text-dim)]">
+            {hasData ? `Vyline 全体の ${formatPercent(ratio * 100)}` : "保存データはありません"}
+          </p>
         </div>
+
         <button
           type="button"
           onClick={onDelete}
-          disabled={disabled}
-          className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-xl border border-[var(--vy-border)] px-3 py-2 text-xs font-medium transition-colors hover:bg-[var(--vy-surface-2)] disabled:cursor-not-allowed disabled:opacity-50"
+          disabled={disabled || !hasData}
+          className={cn(
+            "mt-4 inline-flex w-full items-center justify-center gap-2 rounded-xl border border-[var(--vy-border)] px-3 py-2 text-xs font-medium transition-colors",
+            "hover:bg-[var(--vy-surface-2)] disabled:cursor-not-allowed disabled:opacity-50",
+          )}
         >
           <IconTrash size={14} />
-          削除
+          {hasData ? "削除" : "データなし"}
         </button>
       </div>
     </div>

--- a/Vyline/apps/desktop/src/components/sidebar.tsx
+++ b/Vyline/apps/desktop/src/components/sidebar.tsx
@@ -11,6 +11,7 @@ import {
 import { cn } from "@/lib/utils";
 import { Avatar } from "@/components/vy-ui";
 import { OfficialBadge } from "@/components/official-badge";
+import { PremiumBadge } from "@/components/premium-badge";
 import { MessageContextMenu, type MenuItem } from "@/components/message-context-menu";
 import { api } from "@/api/client";
 import { useAuthStore } from "@/stores/authStore";
@@ -53,6 +54,28 @@ function buildPreviewMap(
   messages: ReturnType<typeof useStore.getState>["messages"],
   chats: Chat[],
 ): Map<string, { text: string; time: number } | null> {
+  const previewForMessage = (m: (typeof messages)[number]): string => {
+    if (m.messageState.startsWith("revoked")) {
+      if (m.revokedSnapshot) return `取り消し済み: ${previewForMessage(m.revokedSnapshot)}`;
+      const last = m.history
+        ? [...m.history].reverse().find((h) => h.state === "normal" || h.state === "edited")
+        : undefined;
+      return last?.text ? `取り消し済み: ${last.text}` : "取り消し済みのメッセージ";
+    }
+    if (m.kind === "sticker") return m.altText || "[スタンプ]";
+    if (m.kind === "image") return "[画像]";
+    if (m.kind === "video") return "[動画]";
+    if (m.kind === "audio") return "[音声メッセージ]";
+    if (m.kind === "flex" || m.kind === "rich")
+      return m.altText || m.text || (m.kind === "flex" ? "[Flex]" : "[リッチメッセージ]");
+    if (m.kind === "call") return "[通話]";
+    if (m.kind === "emoji") return "[絵文字]";
+    if (m.kind === "location") return "[位置情報]";
+    if (m.kind === "contact") return "[連絡先]";
+    if (m.kind === "system") return m.text ?? "";
+    return m.text ?? "";
+  };
+
   const lastByChat = new Map<string, (typeof messages)[number]>();
   for (const m of messages) {
     lastByChat.set(m.chatId, m);
@@ -68,20 +91,7 @@ function buildPreviewMap(
       );
       continue;
     }
-    let text = "";
-    if (last.messageState.startsWith("revoked")) text = "メッセージの送信を取り消しました";
-    else if (last.kind === "sticker") text = last.altText || "[スタンプ]";
-    else if (last.kind === "image") text = "[画像]";
-    else if (last.kind === "video") text = "[動画]";
-    else if (last.kind === "audio") text = "[音声メッセージ]";
-    else if (last.kind === "flex" || last.kind === "rich")
-      text = last.altText || last.text || (last.kind === "flex" ? "[Flex]" : "[リッチメッセージ]");
-    else if (last.kind === "call") text = "[通話]";
-    else if (last.kind === "emoji") text = "[絵文字]";
-    else if (last.kind === "location") text = "[位置情報]";
-    else if (last.kind === "contact") text = "[連絡先]";
-    else if (last.kind === "system") text = last.text ?? "";
-    else text = last.text ?? chat.lastMessagePreview ?? "";
+    let text = previewForMessage(last) || chat.lastMessagePreview || "";
     if (last.authorId === "me" && text) text = `あなた: ${text}`;
     out.set(chat.id, { text, time: Math.max(last.createdAt, apiTime) });
   }
@@ -339,7 +349,10 @@ export function Sidebar() {
           onClick={() => setScreen("settings")}
           className="min-w-0 flex-1 text-left outline-none"
         >
-          <p className="truncate text-sm font-semibold">{self.name}</p>
+          <div className="flex min-w-0 items-center gap-1.5">
+            <p className="truncate text-sm font-semibold">{self.name}</p>
+            {self.premium?.active && <PremiumBadge size={14} compact />}
+          </div>
           <p className="truncate text-xs text-[var(--vy-text-dim)]">{self.status}</p>
         </button>
         <button
@@ -719,6 +732,8 @@ function AccountSwitcher() {
 
   const currentSession = sessions.find((s) => s.accountId === accountId);
   const currentName = currentSession?.displayName || accountId || "未ログイン";
+  const selfPremium = useStore((s) => s.self.premium?.active ?? false);
+  const currentPremium = currentSession?.premium?.active ?? selfPremium;
 
   const handleSwitch = (id: string) => {
     setOpen(false);
@@ -751,7 +766,10 @@ function AccountSwitcher() {
           imageUrl={currentSession?.picturePath}
         />
         <div className="min-w-0 flex-1">
-          <p className="truncate text-sm font-semibold">{currentName}</p>
+          <div className="flex min-w-0 items-center gap-1.5">
+            <p className="truncate text-sm font-semibold">{currentName}</p>
+            {currentPremium && <PremiumBadge size={14} compact />}
+          </div>
           <p className="truncate text-[0.65rem] text-[var(--vy-text-dim)]">{accountId}</p>
         </div>
         <IconChevron
@@ -767,6 +785,7 @@ function AccountSwitcher() {
             .map((id) => {
               const s = sessions.find((s) => s.accountId === id);
               const name = s?.displayName || id;
+              const isPremium = s?.premium?.active ?? false;
               return (
                 <button
                   key={id}
@@ -782,7 +801,10 @@ function AccountSwitcher() {
                     imageUrl={s?.picturePath}
                   />
                   <div className="min-w-0 flex-1">
-                    <p className="truncate text-xs font-medium">{name}</p>
+                    <div className="flex min-w-0 items-center gap-1">
+                      <p className="truncate text-xs font-medium">{name}</p>
+                      {isPremium && <PremiumBadge size={12} compact />}
+                    </div>
                     <p className="truncate text-[0.6rem] text-[var(--vy-text-dim)]">{id}</p>
                   </div>
                 </button>

--- a/Vyline/apps/desktop/src/components/sticker-emoji-panel.tsx
+++ b/Vyline/apps/desktop/src/components/sticker-emoji-panel.tsx
@@ -94,10 +94,19 @@ function CombinationPreview({ items }: { items: CombinationPick[] }) {
           return (
             <img
               key={`${item.packageId}-${item.stickerId}-${i}`}
-              src={item.url.startsWith("http") ? `/api/cdn/line?u=${encodeURIComponent(item.url)}` : item.url}
+              src={
+                item.url.startsWith("http")
+                  ? `/api/cdn/line?u=${encodeURIComponent(item.url)}`
+                  : item.url
+              }
               alt={item.name || item.stickerId}
               className="absolute object-contain"
-              style={{ left: `${tile.x}%`, top: `${tile.y}%`, width: `${tile.w}%`, height: `${tile.h}%` }}
+              style={{
+                left: `${tile.x}%`,
+                top: `${tile.y}%`,
+                width: `${tile.w}%`,
+                height: `${tile.h}%`,
+              }}
               loading="lazy"
               referrerPolicy="no-referrer"
             />
@@ -288,7 +297,9 @@ export function StickerEmojiPanel({
         (x) => x.packageId === item.packageId && x.stickerId === item.stickerId,
       );
       if (exists) {
-        return prev.filter((x) => !(x.packageId === item.packageId && x.stickerId === item.stickerId));
+        return prev.filter(
+          (x) => !(x.packageId === item.packageId && x.stickerId === item.stickerId),
+        );
       }
       if (prev.length >= 6) {
         setComboError("組み合わせは最大6枚までです");
@@ -461,7 +472,9 @@ export function StickerEmojiPanel({
                 {comboCreatedId && (
                   <div className="mt-2 rounded-xl border border-[color-mix(in_oklab,var(--vy-accent)_35%,var(--vy-border))] bg-[color-mix(in_oklab,var(--vy-accent)_10%,transparent)] px-3 py-2 text-xs">
                     <span className="font-semibold text-[var(--vy-text)]">作成済み</span>
-                    <span className="ml-2 break-all text-[var(--vy-text-dim)]">{comboCreatedId}</span>
+                    <span className="ml-2 break-all text-[var(--vy-text-dim)]">
+                      {comboCreatedId}
+                    </span>
                     <button
                       type="button"
                       onClick={() => void copyText(comboCreatedId)}

--- a/Vyline/apps/desktop/src/components/sticker-emoji-panel.tsx
+++ b/Vyline/apps/desktop/src/components/sticker-emoji-panel.tsx
@@ -2,6 +2,7 @@ import { memo, useEffect, useMemo, useState } from "react";
 import { api } from "@/api/client";
 import { cn } from "@/lib/utils";
 import { copyText } from "@/utils/clipboard";
+import { PremiumBadge } from "@/components/premium-badge";
 import {
   lineStoreUrl,
   loadStickerFavorites,
@@ -25,6 +26,7 @@ export type CatalogPack = {
 };
 
 type Catalog = StickersCatalogCache;
+type CombinationPick = { packageId: string; stickerId: string; url: string; name?: string };
 
 /** 絵文字/スタンプ画像を先読みしてブラウザ＋CDNキャッシュを温める */
 function prefetchImgs(urls: string[]): void {
@@ -34,6 +36,81 @@ function prefetchImgs(urls: string[]): void {
     img.decoding = "async";
     img.src = src;
   }
+}
+
+function CombinationPreview({ items }: { items: CombinationPick[] }) {
+  const count = items.length;
+  const tiles = (() => {
+    switch (count) {
+      case 1:
+        return [{ x: 18, y: 18, w: 64, h: 64 }];
+      case 2:
+        return [
+          { x: 4, y: 18, w: 38, h: 64 },
+          { x: 58, y: 18, w: 38, h: 64 },
+        ];
+      case 3:
+        return [
+          { x: 22, y: 4, w: 52, h: 44 },
+          { x: 6, y: 50, w: 30, h: 36 },
+          { x: 58, y: 50, w: 30, h: 36 },
+        ];
+      case 4:
+        return [
+          { x: 6, y: 6, w: 36, h: 36 },
+          { x: 50, y: 6, w: 36, h: 36 },
+          { x: 6, y: 50, w: 36, h: 36 },
+          { x: 50, y: 50, w: 36, h: 36 },
+        ];
+      case 5:
+        return [
+          { x: 10, y: 6, w: 28, h: 28 },
+          { x: 50, y: 6, w: 28, h: 28 },
+          { x: 4, y: 42, w: 24, h: 24 },
+          { x: 30, y: 42, w: 24, h: 24 },
+          { x: 56, y: 42, w: 24, h: 24 },
+        ];
+      default:
+        return [
+          { x: 6, y: 8, w: 24, h: 24 },
+          { x: 32, y: 8, w: 24, h: 24 },
+          { x: 58, y: 8, w: 24, h: 24 },
+          { x: 6, y: 42, w: 24, h: 24 },
+          { x: 32, y: 42, w: 24, h: 24 },
+          { x: 58, y: 42, w: 24, h: 24 },
+        ];
+    }
+  })();
+
+  return (
+    <div className="relative h-24 w-24 overflow-hidden rounded-2xl border border-[var(--vy-border)] bg-[var(--vy-surface)] shadow-inner">
+      {count === 0 ? (
+        <div className="flex h-full items-center justify-center text-[0.65rem] text-[var(--vy-text-dim)]">
+          追加したスタンプがここに並びます
+        </div>
+      ) : (
+        tiles.map((tile, i) => {
+          const item = items[i]!;
+          return (
+            <img
+              key={`${item.packageId}-${item.stickerId}-${i}`}
+              src={item.url.startsWith("http") ? `/api/cdn/line?u=${encodeURIComponent(item.url)}` : item.url}
+              alt={item.name || item.stickerId}
+              className="absolute object-contain"
+              style={{ left: `${tile.x}%`, top: `${tile.y}%`, width: `${tile.w}%`, height: `${tile.h}%` }}
+              loading="lazy"
+              referrerPolicy="no-referrer"
+            />
+          );
+        })
+      )}
+      {count > 6 && (
+        <div className="absolute inset-0 flex items-center justify-center rounded-2xl bg-[color-mix(in_oklab,var(--vy-surface)_32%,transparent)] text-xs font-semibold">
+          +{count - 6}
+        </div>
+      )}
+    </div>
+  );
 }
 
 const UNICODE_EMOJI = [
@@ -100,6 +177,11 @@ export function StickerEmojiPanel({
     const cached = accountId ? getCachedStickersCatalog(accountId) : null;
     return cached?.stickerPacks[0]?.packageId ?? cached?.emojiPacks[0]?.packageId ?? null;
   });
+  const [comboMode, setComboMode] = useState(false);
+  const [comboItems, setComboItems] = useState<CombinationPick[]>([]);
+  const [comboBusy, setComboBusy] = useState(false);
+  const [comboError, setComboError] = useState<string | null>(null);
+  const [comboCreatedId, setComboCreatedId] = useState<string | null>(null);
 
   useEffect(() => {
     if (!accountId) return;
@@ -165,6 +247,7 @@ export function StickerEmojiPanel({
   }, [catalog, tab]);
 
   const activePack = packs.find((p) => p.packageId === packId) ?? packs[0];
+  const selectedCountText = `${comboItems.length} 枚選択中`;
 
   useEffect(() => {
     if (tab === "unicode") return;
@@ -186,6 +269,67 @@ export function StickerEmojiPanel({
     const items = active ? active.items.map((i) => i.url) : [];
     prefetchImgs([...tabIcons, ...items]);
   }, [catalog, packId]);
+
+  function toggleComboMode(): void {
+    setComboMode((next) => {
+      const enabled = !next;
+      if (!enabled) {
+        setComboError(null);
+      }
+      return enabled;
+    });
+  }
+
+  function addComboItem(item: CombinationPick): void {
+    setComboError(null);
+    setComboCreatedId(null);
+    setComboItems((prev) => {
+      const exists = prev.some(
+        (x) => x.packageId === item.packageId && x.stickerId === item.stickerId,
+      );
+      if (exists) {
+        return prev.filter((x) => !(x.packageId === item.packageId && x.stickerId === item.stickerId));
+      }
+      if (prev.length >= 6) {
+        setComboError("組み合わせは最大6枚までです");
+        return prev;
+      }
+      return [...prev, item];
+    });
+  }
+
+  async function createComboSticker(): Promise<void> {
+    if (!accountId) return;
+    if (comboItems.length === 0) {
+      setComboError("スタンプを1つ以上選んでください");
+      return;
+    }
+    setComboBusy(true);
+    setComboError(null);
+    try {
+      const packageIds = [...new Set(comboItems.map((item) => item.packageId))];
+      const canCreate = await api.line.canCreateCombinationSticker(accountId, packageIds);
+      if (!canCreate.ok || !canCreate.canCreate) {
+        setComboError("この組み合わせは作成できません");
+        return;
+      }
+      const created = await api.line.createCombinationSticker(
+        accountId,
+        comboItems.map((item) => ({ packageId: item.packageId, stickerId: item.stickerId })),
+      );
+      if (!created.ok) {
+        setComboError(created.error || "作成に失敗しました");
+        return;
+      }
+      setComboCreatedId(created.id);
+      setComboItems([]);
+      void copyText(`組み合わせスタンプを作成しました: ${created.id}`);
+    } catch (err) {
+      setComboError(String(err));
+    } finally {
+      setComboBusy(false);
+    }
+  }
 
   return (
     <div className="vy-scale-in absolute bottom-full left-3 mb-2 flex h-[320px] w-[min(380px,92vw)] flex-col overflow-hidden rounded-2xl border border-[var(--vy-border)] bg-[var(--vy-surface)] shadow-2xl md:left-5">
@@ -212,13 +356,30 @@ export function StickerEmojiPanel({
             {label}
           </button>
         ))}
-        <span className="ml-auto px-2 text-[0.65rem] text-[var(--vy-text-dim)]">
-          {catalog?.premium.active
-            ? catalog.premium.onFreeTrial
-              ? "Premium お試し"
-              : "Premium"
-            : "Premium —"}
+        <span className="ml-auto flex items-center gap-1 px-2 text-[0.65rem] text-[var(--vy-text-dim)]">
+          {catalog?.premium.active && <PremiumBadge size={12} compact />}
+          <span>
+            {catalog?.premium.active
+              ? catalog.premium.onFreeTrial
+                ? "Premium お試し"
+                : "Premium"
+              : "Premium —"}
+          </span>
         </span>
+        {tab === "sticker" && (
+          <button
+            type="button"
+            onClick={toggleComboMode}
+            className={cn(
+              "mb-1 rounded-full px-2.5 py-1 text-[0.65rem] font-semibold transition-colors",
+              comboMode
+                ? "bg-[var(--vy-accent)] text-[var(--vy-accent-contrast)]"
+                : "bg-[var(--vy-surface-2)] text-[var(--vy-text-dim)] hover:text-[var(--vy-text)]",
+            )}
+          >
+            {comboMode ? "組み合わせ中" : "組み合わせ作成"}
+          </button>
+        )}
       </div>
 
       {tab !== "unicode" && (
@@ -249,6 +410,72 @@ export function StickerEmojiPanel({
       )}
 
       <div className="min-h-0 flex-1 overflow-y-auto p-2">
+        {comboMode && tab === "sticker" && (
+          <div className="mb-2 rounded-2xl border border-[var(--vy-border)] bg-[var(--vy-surface-2)] p-2">
+            <div className="flex items-start gap-3">
+              <CombinationPreview items={comboItems} />
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <p className="text-xs font-semibold text-[var(--vy-text)]">組み合わせ作成</p>
+                  <span className="rounded-full bg-[color-mix(in_oklab,var(--vy-text)_10%,transparent)] px-2 py-0.5 text-[0.65rem] text-[var(--vy-text-dim)]">
+                    {selectedCountText}
+                  </span>
+                </div>
+                <p className="mt-1 text-[0.7rem] text-[var(--vy-text-dim)]">
+                  スタンプを最大6枚まで選んで、作成ボタンを押してください。
+                </p>
+                <div className="mt-2 flex flex-wrap gap-1">
+                  {comboItems.map((item) => (
+                    <button
+                      key={`${item.packageId}-${item.stickerId}`}
+                      type="button"
+                      onClick={() => addComboItem(item)}
+                      className="inline-flex items-center gap-1 rounded-full border border-[var(--vy-border)] px-2 py-1 text-[0.65rem] text-[var(--vy-text-dim)] transition-colors hover:bg-[var(--vy-surface)]"
+                    >
+                      <span className="max-w-24 truncate">{item.name || item.stickerId}</span>
+                      <span aria-hidden>×</span>
+                    </button>
+                  ))}
+                </div>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    onClick={() => void createComboSticker()}
+                    disabled={comboBusy || comboItems.length === 0}
+                    className="rounded-full bg-[var(--vy-accent)] px-3 py-1.5 text-xs font-semibold text-[var(--vy-accent-contrast)] transition-opacity disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {comboBusy ? "作成中…" : "作成"}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setComboItems([]);
+                      setComboError(null);
+                      setComboCreatedId(null);
+                    }}
+                    className="rounded-full border border-[var(--vy-border)] px-3 py-1.5 text-xs text-[var(--vy-text-dim)] transition-colors hover:bg-[var(--vy-surface)]"
+                  >
+                    クリア
+                  </button>
+                </div>
+                {comboCreatedId && (
+                  <div className="mt-2 rounded-xl border border-[color-mix(in_oklab,var(--vy-accent)_35%,var(--vy-border))] bg-[color-mix(in_oklab,var(--vy-accent)_10%,transparent)] px-3 py-2 text-xs">
+                    <span className="font-semibold text-[var(--vy-text)]">作成済み</span>
+                    <span className="ml-2 break-all text-[var(--vy-text-dim)]">{comboCreatedId}</span>
+                    <button
+                      type="button"
+                      onClick={() => void copyText(comboCreatedId)}
+                      className="ml-2 rounded-full bg-[var(--vy-surface)] px-2 py-0.5 font-medium text-[var(--vy-text)]"
+                    >
+                      コピー
+                    </button>
+                  </div>
+                )}
+                {comboError && <p className="mt-2 text-xs text-[var(--vy-danger)]">{comboError}</p>}
+              </div>
+            </div>
+          </div>
+        )}
         {loading && !catalog && (
           <p className="px-2 py-6 text-center text-xs text-[var(--vy-text-dim)]">読み込み中…</p>
         )}
@@ -282,7 +509,14 @@ export function StickerEmojiPanel({
                 type="button"
                 title={f.name || f.id}
                 onClick={() => {
-                  if (f.type === "sticker")
+                  if (comboMode && f.type === "sticker") {
+                    addComboItem({
+                      packageId: f.packageId,
+                      stickerId: f.id,
+                      url: f.url,
+                      name: f.name || f.id,
+                    });
+                  } else if (f.type === "sticker")
                     onPickSticker(f.packageId, f.id, catalog?.premium?.active);
                   else onPickEmoji(f.packageId, f.id);
                 }}
@@ -317,7 +551,14 @@ export function StickerEmojiPanel({
                     type="button"
                     title={item.alt || item.id}
                     onClick={() => {
-                      if (activePack.type === "sticker") {
+                      if (comboMode && activePack.type === "sticker") {
+                        addComboItem({
+                          packageId: activePack.packageId,
+                          stickerId: item.id,
+                          url: item.url,
+                          name: item.alt || activePack.name,
+                        });
+                      } else if (activePack.type === "sticker") {
                         onPickSticker(activePack.packageId, item.id, catalog?.premium?.active);
                       } else {
                         onPickEmoji(activePack.packageId, item.id);
@@ -354,6 +595,11 @@ export function StickerEmojiPanel({
                   {isFav && (
                     <span className="pointer-events-none absolute right-0.5 top-0.5 text-[0.6rem] text-[var(--vy-accent)]">
                       ★
+                    </span>
+                  )}
+                  {comboMode && activePack.type === "sticker" && (
+                    <span className="pointer-events-none absolute left-0.5 top-0.5 rounded-full bg-[var(--vy-accent)] px-1 py-0.5 text-[0.55rem] font-bold text-[var(--vy-accent-contrast)]">
+                      +
                     </span>
                   )}
                 </div>

--- a/Vyline/apps/desktop/src/hooks/useVylineSync.ts
+++ b/Vyline/apps/desktop/src/hooks/useVylineSync.ts
@@ -198,21 +198,21 @@ export function useVylineSync(enabled = true) {
 
     if (!line.chats.length && useStore.getState().chats.length > 0) return;
 
-      hydrateLineData({
-        profile: line.profile
-          ? {
-              displayName: line.profile.displayName,
-              phoneticName: line.profile.phoneticName,
-              pictureStatus: line.profile.pictureStatus,
-              statusMessage: line.profile.statusMessage,
-              thumbnailUrl: line.profile.thumbnailUrl,
-              musicProfile: line.profile.musicProfile,
-              birthday: line.profile.birthday,
-              backgroundUrl: line.profile.backgroundUrl,
-              profileId: line.profile.profileId,
-              premium: line.profile.premium ?? null,
-            }
-          : null,
+    hydrateLineData({
+      profile: line.profile
+        ? {
+            displayName: line.profile.displayName,
+            phoneticName: line.profile.phoneticName,
+            pictureStatus: line.profile.pictureStatus,
+            statusMessage: line.profile.statusMessage,
+            thumbnailUrl: line.profile.thumbnailUrl,
+            musicProfile: line.profile.musicProfile,
+            birthday: line.profile.birthday,
+            backgroundUrl: line.profile.backgroundUrl,
+            profileId: line.profile.profileId,
+            premium: line.profile.premium ?? null,
+          }
+        : null,
 
       chats: line.chats,
 

--- a/Vyline/apps/desktop/src/hooks/useVylineSync.ts
+++ b/Vyline/apps/desktop/src/hooks/useVylineSync.ts
@@ -198,16 +198,21 @@ export function useVylineSync(enabled = true) {
 
     if (!line.chats.length && useStore.getState().chats.length > 0) return;
 
-    hydrateLineData({
-      profile: line.profile
-        ? {
-            displayName: line.profile.displayName,
-
-            statusMessage: line.profile.statusMessage,
-
-            thumbnailUrl: line.profile.thumbnailUrl,
-          }
-        : null,
+      hydrateLineData({
+        profile: line.profile
+          ? {
+              displayName: line.profile.displayName,
+              phoneticName: line.profile.phoneticName,
+              pictureStatus: line.profile.pictureStatus,
+              statusMessage: line.profile.statusMessage,
+              thumbnailUrl: line.profile.thumbnailUrl,
+              musicProfile: line.profile.musicProfile,
+              birthday: line.profile.birthday,
+              backgroundUrl: line.profile.backgroundUrl,
+              profileId: line.profile.profileId,
+              premium: line.profile.premium ?? null,
+            }
+          : null,
 
       chats: line.chats,
 

--- a/Vyline/apps/desktop/src/lib/store-types.ts
+++ b/Vyline/apps/desktop/src/lib/store-types.ts
@@ -151,6 +151,10 @@ export type RetryIntent =
       contentMetadata?: Record<string, string>;
     }
   | { kind: "sticker"; packageId: string; stickerId: string; isPremium?: boolean }
+  | {
+      kind: "combinationSticker";
+      items: Array<{ packageId: string; stickerId: string; x?: number; y?: number; size?: number }>;
+    }
   | { kind: "emoji"; packageId: string; sticonId: string };
 
 export type Member = {

--- a/Vyline/apps/desktop/src/lib/store-types.ts
+++ b/Vyline/apps/desktop/src/lib/store-types.ts
@@ -125,6 +125,8 @@ export type Message = {
     contentType: string;
     updatedTime: number;
   }>;
+  /** 取り消し前のメッセージ本体スナップショット */
+  revokedSnapshot?: MessageSnapshot;
   linkPreview?: LinkPreview;
   /** 失敗時の再送に使う送信意図（楽観メッセージに保持） */
   retry?: RetryIntent;
@@ -138,6 +140,8 @@ export type Message = {
     longitude?: number;
   };
 };
+
+export type MessageSnapshot = Omit<Message, "history" | "revokedSnapshot">;
 
 export type RetryIntent =
   | {
@@ -220,8 +224,18 @@ export type SelfProfile = {
   avatar: string;
   avatarUrl?: string;
   status: string;
+  phoneticName?: string;
+  pictureStatus?: string;
   musicProfile?: string;
   birthday?: string;
   backgroundUrl?: string;
   mid?: string;
+  profileId?: string;
+  premium?: {
+    active: boolean;
+    planType?: string | number;
+    validUntil?: number;
+    onFreeTrial?: boolean;
+    willExpire?: boolean;
+  };
 };

--- a/Vyline/apps/desktop/src/lib/store.ts
+++ b/Vyline/apps/desktop/src/lib/store.ts
@@ -23,6 +23,11 @@ import {
   type ContactInfo,
 } from "./mappers.js";
 import { lineStickerUrl } from "../utils/lineMedia.js";
+import {
+  renderCombinationStickerPreview,
+  setCombinationStickerPreview,
+  type CombinationStickerPlacement,
+} from "../utils/combinationStickers.js";
 import { getDismissedChatMids } from "../utils/dismissedChats.js";
 import { parseMentions, type MentionDraft } from "../utils/mention.js";
 import { compressImageFile } from "../utils/compressImage.js";
@@ -167,7 +172,16 @@ function applyReadWatermarkLocal(
 }
 
 function messagePreview(m: Message): string {
-  if (m.messageState.startsWith("revoked")) {
+  const isRevoked =
+    m.messageState.startsWith("revoked") ||
+    Boolean(m.revokedSnapshot) ||
+    Boolean(
+      m.history?.length &&
+        m.history.some(
+          (h) => h.state === "normal" || h.state === "edited" || h.contentType === "UNSENT",
+        ),
+    );
+  if (isRevoked) {
     if (m.revokedSnapshot) return `取り消し済み: ${messagePreview(m.revokedSnapshot)}`;
     const last = m.history
       ? [...m.history].reverse().find((h) => h.state === "normal" || h.state === "edited")
@@ -312,6 +326,10 @@ type State = {
     packageId: string,
     stickerId: string,
     isPremium?: boolean,
+  ) => Promise<void>;
+  sendCombinationSticker: (
+    chatId: string,
+    items: Array<{ packageId: string; stickerId: string; x?: number; y?: number; size?: number }>,
   ) => Promise<void>;
   sendLineEmoji: (chatId: string, packageId: string, sticonId: string) => Promise<void>;
   sendImageFile: (chatId: string, file: File) => Promise<void>;
@@ -935,6 +953,97 @@ export const useStore = create<State>()(
         })();
       },
 
+      sendCombinationSticker: async (chatId, items) => {
+        const { accountId, blockedMids } = get();
+        if (!accountId || !items.length) return;
+        if (chatId.startsWith("u") && blockedMids.includes(chatId)) return;
+        const placements: CombinationStickerPlacement[] = items.map((item, index) => ({
+          packageId: item.packageId,
+          stickerId: item.stickerId,
+          url: lineStickerUrl(item.stickerId),
+          name: item.stickerId,
+          x: item.x ?? Math.max(0, 40 + index * 18),
+          y: item.y ?? Math.max(0, 40 + index * 18),
+          size: item.size ?? 76,
+        }));
+        const tempId = `pending_cstk_${Date.now()}`;
+        const optimistic: Message = {
+          id: tempId,
+          chatId,
+          authorId: "me",
+          kind: "sticker",
+          sticker: lineStickerUrl(items[0]!.stickerId),
+          createdAt: Date.now(),
+          status: "sending",
+          read: false,
+          messageState: "normal",
+          retry: { kind: "combinationSticker", items: items.map((item) => ({ ...item })) },
+        };
+        set((st) => ({ messages: [...st.messages, optimistic] }));
+
+        void (async () => {
+          try {
+            const res = await api.line.sendCombinationSticker(accountId!, chatId, items);
+            if (!res.ok) {
+              set((st) => ({
+                messages: st.messages.map((m) =>
+                  m.id === tempId ? { ...m, status: "failed" } : m,
+                ),
+              }));
+              return;
+            }
+            if (res.message) {
+              const contactCache = buildContactCache(get().chats);
+              const mapped = mapMessage(res.message, chatId, accountId!, contactCache);
+              let preview = mapped.sticker ?? "";
+              try {
+                const dataUrl = await renderCombinationStickerPreview(placements);
+                if (dataUrl) {
+                  preview = dataUrl;
+                  setCombinationStickerPreview(accountId!, mapped.id, dataUrl);
+                }
+              } catch {
+                if (!preview) preview = lineStickerUrl(items[0]!.stickerId);
+              }
+              const finalMsg: Message = {
+                ...mapped,
+                kind: "sticker",
+                sticker: preview || mapped.sticker || "🎴",
+              };
+              set((st) => ({
+                messages: st.messages.map((m) => (m.id === tempId ? finalMsg : m)),
+                chats: st.chats.map((c) =>
+                  c.id === chatId
+                    ? {
+                        ...c,
+                        lastMessagePreview: "スタンプ",
+                        lastMessageTime: Math.max(c.lastMessageTime ?? 0, finalMsg.createdAt),
+                      }
+                    : c,
+                ),
+              }));
+            } else {
+              set((st) => ({
+                messages: st.messages.map((m) => (m.id === tempId ? { ...m, status: "sent" } : m)),
+              }));
+            }
+            const existing = refreshDebounce.get(chatId);
+            if (existing) clearTimeout(existing);
+            refreshDebounce.set(
+              chatId,
+              setTimeout(() => {
+                refreshDebounce.delete(chatId);
+                void get().refreshMessages(chatId, { force: true });
+              }, 800),
+            );
+          } catch {
+            set((st) => ({
+              messages: st.messages.map((m) => (m.id === tempId ? { ...m, status: "failed" } : m)),
+            }));
+          }
+        })();
+      },
+
       sendLineEmoji: async (chatId, packageId, sticonId) => {
         const { accountId, blockedMids } = get();
         if (!accountId || !packageId || !sticonId) return;
@@ -1259,6 +1368,10 @@ export const useStore = create<State>()(
               sticonId: intent.sticonId,
             });
             ok = res.ok;
+          } else if (intent.kind === "combinationSticker") {
+            const res = await api.line.sendCombinationSticker(accountId, chatId, intent.items);
+            ok = res.ok;
+            confirmed = res.ok ? (res.message ?? null) : null;
           }
           if (!ok) {
             markFailed();
@@ -1538,6 +1651,18 @@ export const useStore = create<State>()(
               for (let i = 0; i < mapped.length; i++) {
                 const m = mapped[i]!;
                 const prev = prevById.get(m.id);
+                const prevRevoked = Boolean(
+                  prev &&
+                    (prev.messageState.startsWith("revoked") ||
+                      prev.revokedSnapshot ||
+                      (prev.history?.length &&
+                        prev.history.some(
+                          (h) =>
+                            h.state === "normal" ||
+                            h.state === "edited" ||
+                            h.contentType === "UNSENT",
+                        ))),
+                );
                 if (m.authorId === "me" && prev?.read && !m.read) {
                   mapped[i] = {
                     ...m,
@@ -1591,6 +1716,20 @@ export const useStore = create<State>()(
                 }
                 if (prev?.revokedSnapshot && !m.revokedSnapshot) {
                   mapped[i] = { ...m, revokedSnapshot: prev.revokedSnapshot };
+                }
+                if (prevRevoked && !m.messageState?.startsWith("revoked")) {
+                  const last = prev?.history
+                    ? [...prev.history]
+                        .reverse()
+                        .find((h) => h.state === "normal" || h.state === "edited")
+                    : undefined;
+                  mapped[i] = {
+                    ...m,
+                    messageState: prev?.messageState ?? "revoked-by-self",
+                    history: prev?.history?.length ? prev.history : m.history,
+                    revokedSnapshot: prev?.revokedSnapshot ?? m.revokedSnapshot,
+                    text: prev?.revokedSnapshot?.text ?? last?.text ?? prev?.text ?? m.text,
+                  };
                 }
               }
               // pending / 送信直後の確定メッセージをサーバ欠落時も残す
@@ -1891,6 +2030,18 @@ export const useStore = create<State>()(
                 if (m.chatId !== chatId) return m;
                 const upd = incomingById.get(m.id);
                 if (!upd) return m;
+                const wasRevoked =
+                  m.messageState.startsWith("revoked") ||
+                  Boolean(m.revokedSnapshot) ||
+                  Boolean(
+                    m.history?.length &&
+                      m.history.some(
+                        (h) =>
+                          h.state === "normal" ||
+                          h.state === "edited" ||
+                          h.contentType === "UNSENT",
+                      ),
+                  );
                 const reactionChanged =
                   JSON.stringify(upd.reactions) !== JSON.stringify(m.reactions);
                 const revokedChanged =
@@ -1904,6 +2055,12 @@ export const useStore = create<State>()(
                     messageReactionCache.delete(m.id);
                   }
                   updated.reactions = upd.reactions;
+                  if (wasRevoked) {
+                    updated.messageState = m.messageState;
+                    updated.history = m.history;
+                    if (m.revokedSnapshot) updated.revokedSnapshot = m.revokedSnapshot;
+                    if (m.text !== undefined) updated.text = m.text;
+                  }
                 }
                 if (revokedChanged) {
                   updated.messageState = upd.messageState;

--- a/Vyline/apps/desktop/src/lib/store.ts
+++ b/Vyline/apps/desktop/src/lib/store.ts
@@ -8,6 +8,7 @@ import type {
   ChatSort,
   Message,
   MessageReaction,
+  MessageSnapshot,
   VyTheme,
   Settings,
   Screen,
@@ -80,6 +81,11 @@ function buildContactCache(chats: Chat[]): Map<string, ContactInfo> {
     }
   }
   return contactCache;
+}
+
+function snapshotFromMessage(m: Message): MessageSnapshot {
+  const { history: _history, revokedSnapshot: _revokedSnapshot, ...snapshot } = m;
+  return snapshot;
 }
 
 /**
@@ -162,11 +168,12 @@ function applyReadWatermarkLocal(
 
 function messagePreview(m: Message): string {
   if (m.messageState.startsWith("revoked")) {
+    if (m.revokedSnapshot) return `取り消し済み: ${messagePreview(m.revokedSnapshot)}`;
     const last = m.history
       ? [...m.history].reverse().find((h) => h.state === "normal" || h.state === "edited")
       : undefined;
-    if (last?.text) return last.text;
-    return "メッセージの送信を取り消しました";
+    if (last?.text) return `取り消し済み: ${last.text}`;
+    return "取り消し済みのメッセージ";
   }
   switch (m.kind) {
     case "sticker":
@@ -273,9 +280,19 @@ type State = {
       displayName: string;
       statusMessage: string;
       thumbnailUrl?: string;
+      phoneticName?: string;
+      pictureStatus?: string;
       musicProfile?: string;
       birthday?: { display?: string } | null;
       backgroundUrl?: string;
+      profileId?: string;
+      premium?: {
+        active: boolean;
+        planType?: string | number;
+        validUntil?: number;
+        onFreeTrial?: boolean;
+        willExpire?: boolean;
+      } | null;
     } | null;
     chats: LineChat[];
     messages: LineMessage[];
@@ -579,10 +596,14 @@ export const useStore = create<State>()(
                 avatar: initial(profile.displayName),
                 avatarUrl: profile.thumbnailUrl || st.self.avatarUrl,
                 status: profile.statusMessage || "",
+                phoneticName: profile.phoneticName || st.self.phoneticName,
+                pictureStatus: profile.pictureStatus || st.self.pictureStatus,
                 musicProfile: profile.musicProfile || st.self.musicProfile,
                 birthday: profile.birthday?.display || st.self.birthday,
                 backgroundUrl: profile.backgroundUrl || st.self.backgroundUrl,
                 mid: profile.mid || st.self.mid,
+                profileId: profile.profileId || st.self.profileId,
+                premium: profile.premium ?? st.self.premium,
               },
             }));
           }
@@ -693,10 +714,14 @@ export const useStore = create<State>()(
                 avatar: initial(profile.displayName),
                 avatarUrl: profile.thumbnailUrl || st.self.avatarUrl,
                 status: profile.statusMessage || "",
+                phoneticName: profile.phoneticName || st.self.phoneticName,
+                pictureStatus: profile.pictureStatus || st.self.pictureStatus,
                 musicProfile: profile.musicProfile || st.self.musicProfile,
                 birthday: profile.birthday?.display || st.self.birthday,
                 backgroundUrl: profile.backgroundUrl || st.self.backgroundUrl,
                 mid: profile.mid || st.self.mid,
+                profileId: profile.profileId || st.self.profileId,
+                premium: profile.premium ?? st.self.premium,
               }
             : st.self,
         }));
@@ -992,55 +1017,53 @@ export const useStore = create<State>()(
           messageState: "normal",
         };
         set((st) => ({ messages: [...st.messages, optimistic] }));
-        void (async () => {
-          try {
-            const highQuality = get().settings.highQualityImages;
-            const { blob, mime } = highQuality
-              ? { blob: file, mime: file.type || "application/octet-stream" }
-              : await compressImageFile(file);
-            if (blob.size > 11_000_000) {
-              window.alert(
-                blob === file
-                  ? "ファイルが大きすぎます（11MB まで）"
-                  : "画像が大きすぎます（圧縮後も 11MB 超）",
-              );
-              set((st) => ({ messages: st.messages.filter((m) => m.id !== tempId) }));
-              return;
-            }
-            const buf = await blob.arrayBuffer();
-            const bytes = new Uint8Array(buf);
-            let binary = "";
-            const chunk = 0x8000;
-            for (let i = 0; i < bytes.length; i += chunk) {
-              binary += String.fromCharCode(...bytes.subarray(i, i + chunk));
-            }
-            const dataBase64 = btoa(binary);
-            const res = await api.line.sendMedia(accountId!, chatId, dataBase64, {
-              mimeType: mime,
-              filename: file.name || (isVideo ? "video.mp4" : "image.jpg"),
-              mediaType: isVideo ? "video" : "image",
-            });
-            if (res.ok) {
-              const existing = refreshDebounce.get(chatId);
-              if (existing) clearTimeout(existing);
-              refreshDebounce.set(
-                chatId,
-                setTimeout(() => {
-                  refreshDebounce.delete(chatId);
-                  void get().refreshMessages(chatId, { force: true });
-                }, 800),
-              );
-            } else {
-              // 画像は再送 UI を持たないので失敗時は楽観表示を除去
-              set((st) => ({ messages: st.messages.filter((m) => m.id !== tempId) }));
-            }
-          } catch {
+        try {
+          const highQuality = get().settings.highQualityImages;
+          const { blob, mime } = highQuality
+            ? { blob: file, mime: file.type || "application/octet-stream" }
+            : await compressImageFile(file);
+          if (blob.size > 11_000_000) {
+            window.alert(
+              blob === file
+                ? "ファイルが大きすぎます（11MB まで）"
+                : "画像が大きすぎます（圧縮後も 11MB 超）",
+            );
             set((st) => ({ messages: st.messages.filter((m) => m.id !== tempId) }));
-          } finally {
-            // 送信完了後にローカルURLを解放（60s 後でも安全な間隔）
-            setTimeout(() => URL.revokeObjectURL(localUrl), 60_000);
+            return;
           }
-        })();
+          const buf = await blob.arrayBuffer();
+          const bytes = new Uint8Array(buf);
+          let binary = "";
+          const chunk = 0x8000;
+          for (let i = 0; i < bytes.length; i += chunk) {
+            binary += String.fromCharCode(...bytes.subarray(i, i + chunk));
+          }
+          const dataBase64 = btoa(binary);
+          const res = await api.line.sendMedia(accountId!, chatId, dataBase64, {
+            mimeType: mime,
+            filename: file.name || (isVideo ? "video.mp4" : "image.jpg"),
+            mediaType: isVideo ? "video" : "image",
+          });
+          if (res.ok) {
+            const existing = refreshDebounce.get(chatId);
+            if (existing) clearTimeout(existing);
+            refreshDebounce.set(
+              chatId,
+              setTimeout(() => {
+                refreshDebounce.delete(chatId);
+                void get().refreshMessages(chatId, { force: true });
+              }, 800),
+            );
+          } else {
+            // 画像は再送 UI を持たないので失敗時は楽観表示を除去
+            set((st) => ({ messages: st.messages.filter((m) => m.id !== tempId) }));
+          }
+        } catch {
+          set((st) => ({ messages: st.messages.filter((m) => m.id !== tempId) }));
+        } finally {
+          // 送信完了後にローカルURLを解放（60s 後でも安全な間隔）
+          setTimeout(() => URL.revokeObjectURL(localUrl), 60_000);
+        }
       },
 
       sendAudio: async (chatId, seconds, blob) => {
@@ -1092,6 +1115,10 @@ export const useStore = create<State>()(
           window.alert("送信が完了してから取り消しできます");
           return;
         }
+        if (msg.messageState.startsWith("revoked") || msg.revokedSnapshot) {
+          get().showNotice("一度取り消したメッセージは再度取り消せません");
+          return;
+        }
         const prevState = msg.messageState ?? "normal";
         const historyEntry = {
           state: prevState,
@@ -1105,7 +1132,9 @@ export const useStore = create<State>()(
               ? {
                   ...m,
                   history: [...(m.history ?? []), historyEntry],
+                  revokedSnapshot: m.revokedSnapshot ?? snapshotFromMessage(m),
                   messageState: "revoked-by-self" as MessageState,
+                  text: undefined,
                 }
               : m,
           ),
@@ -1560,6 +1589,9 @@ export const useStore = create<State>()(
                 ) {
                   mapped[i] = { ...m, messageState: "revoked-by-self" as MessageState };
                 }
+                if (prev?.revokedSnapshot && !m.revokedSnapshot) {
+                  mapped[i] = { ...m, revokedSnapshot: prev.revokedSnapshot };
+                }
               }
               // pending / 送信直後の確定メッセージをサーバ欠落時も残す
               const keep = existingChat.filter((m) => {
@@ -1875,6 +1907,8 @@ export const useStore = create<State>()(
                 }
                 if (revokedChanged) {
                   updated.messageState = upd.messageState;
+                  updated.revokedSnapshot =
+                    m.revokedSnapshot ?? upd.revokedSnapshot ?? snapshotFromMessage(m);
                   const prevState = m.messageState ?? "normal";
                   updated.history = [
                     ...(m.history ?? []),
@@ -1967,6 +2001,7 @@ export const useStore = create<State>()(
                 ? "revoked-by-self"
                 : "revoked-by-other") as MessageState,
               history,
+              revokedSnapshot: m.revokedSnapshot ?? snapshotFromMessage(m),
               text: undefined,
             };
           });
@@ -1989,10 +2024,11 @@ export const useStore = create<State>()(
         if (!accountId) return;
         const msg = get().messages.find((m) => m.id === messageId);
         if (!msg || msg.messageState !== "revoked-by-self") return;
+        const snapshot = msg.revokedSnapshot;
         const lastNormal = [...(msg.history ?? [])]
           .reverse()
           .find((h) => h.state === "normal" || h.state === "edited");
-        if (!lastNormal) {
+        if (!snapshot && !lastNormal) {
           window.alert("復元できる元のメッセージがありません");
           return;
         }
@@ -2007,9 +2043,16 @@ export const useStore = create<State>()(
             m.id === messageId
               ? {
                   ...m,
-                  messageState: "normal" as MessageState,
+                  ...snapshot,
+                  messageState: (snapshot?.messageState ??
+                    (lastNormal?.state === "edited" ? "edited" : "normal")) as MessageState,
                   history: [...(m.history ?? []), historyEntry],
-                  text: lastNormal.text ?? undefined,
+                  ...(snapshot
+                    ? { revokedSnapshot: snapshot }
+                    : m.revokedSnapshot
+                      ? { revokedSnapshot: m.revokedSnapshot }
+                      : {}),
+                  text: snapshot?.text ?? lastNormal?.text ?? undefined,
                 }
               : m,
           ),

--- a/Vyline/apps/desktop/src/utils/combinationStickers.ts
+++ b/Vyline/apps/desktop/src/utils/combinationStickers.ts
@@ -1,0 +1,100 @@
+export type CombinationStickerItem = {
+  packageId: string;
+  stickerId: string;
+  url: string;
+  name?: string;
+};
+
+export type CombinationStickerPlacement = CombinationStickerItem & {
+  x: number;
+  y: number;
+  size: number;
+};
+
+const STORAGE_KEY = (accountId: string) => `vyline:combinationStickerPreviews:${accountId}`;
+
+function loadPreviewStore(accountId: string): Record<string, string> {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY(accountId));
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? (parsed as Record<string, string>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function savePreviewStore(accountId: string, store: Record<string, string>): void {
+  try {
+    localStorage.setItem(STORAGE_KEY(accountId), JSON.stringify(store));
+  } catch {
+    /* ignore quota/private mode */
+  }
+}
+
+export function getCombinationStickerPreview(accountId: string, comboId: string): string | null {
+  const store = loadPreviewStore(accountId);
+  return store[comboId] ?? null;
+}
+
+export function setCombinationStickerPreview(
+  accountId: string,
+  comboId: string,
+  dataUrl: string,
+): void {
+  const store = loadPreviewStore(accountId);
+  store[comboId] = dataUrl;
+  savePreviewStore(accountId, store);
+}
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.decoding = "async";
+    img.crossOrigin = "anonymous";
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error(`failed to load image: ${src}`));
+    img.src = src.startsWith("http") ? `/api/cdn/line?u=${encodeURIComponent(src)}` : src;
+  });
+}
+
+export async function renderCombinationStickerPreview(
+  items: CombinationStickerPlacement[],
+  canvasSize = 512,
+): Promise<string> {
+  const canvas = document.createElement("canvas");
+  canvas.width = canvasSize;
+  canvas.height = canvasSize;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return "";
+  ctx.clearRect(0, 0, canvasSize, canvasSize);
+  ctx.fillStyle = "rgba(0,0,0,0)";
+  ctx.fillRect(0, 0, canvasSize, canvasSize);
+
+  const loaded = await Promise.all(
+    items.map(async (item) => {
+      try {
+        const img = await loadImage(item.url);
+        return { item, img };
+      } catch {
+        return null;
+      }
+    }),
+  );
+
+  for (const entry of loaded) {
+    if (!entry) continue;
+    const { item, img } = entry;
+    const box = item.size;
+    const x = item.x;
+    const y = item.y;
+    const scale = Math.min(box / img.naturalWidth, box / img.naturalHeight, 1);
+    const w = img.naturalWidth * scale;
+    const h = img.naturalHeight * scale;
+    const dx = x + (box - w) / 2;
+    const dy = y + (box - h) / 2;
+    ctx.drawImage(img, dx, dy, w, h);
+  }
+
+  return canvas.toDataURL("image/png");
+}

--- a/Vyline/backend/src/api/line.ts
+++ b/Vyline/backend/src/api/line.ts
@@ -40,8 +40,12 @@ import {
   sendMessage,
   sendMedia,
   sendSticker,
+  canCreateCombinationSticker,
+  createCombinationSticker,
+  isStickerAvailableForCombinationSticker,
   fetchStickersCatalog,
   sendLineEmoji,
+  sendCombinationSticker,
   unsendMessage,
   editMessage,
   getMessageEditNotice,
@@ -167,6 +171,19 @@ function handleError(err: unknown, c: Context<any, any, any>) {
         ok: false,
         error: "MESSAGE_NOT_DESTRUCTIBLE: message too old",
         code: "MESSAGE_NOT_DESTRUCTIBLE",
+      },
+      400,
+    );
+  }
+  if (
+    code === "MESSAGE_ALREADY_REVOKED" ||
+    message.toUpperCase().includes("MESSAGE_ALREADY_REVOKED")
+  ) {
+    return c.json(
+      {
+        ok: false,
+        error: "このメッセージはすでに送信取り消し済みです。もう一度取り消すことはできません。",
+        code: "MESSAGE_ALREADY_REVOKED",
       },
       400,
     );
@@ -500,6 +517,99 @@ lineRouter.get("/:accountId/stickers", async (c) => {
   }
 });
 
+// ─── POST /line/:accountId/combination-stickers/can-create ───────
+// { packageIds: string[] }
+
+lineRouter.post("/:accountId/combination-stickers/can-create", async (c) => {
+  const accountId = c.req.param("accountId");
+  const body = await c.req.json<{ packageIds?: string[] }>();
+  if (!body.packageIds?.length) {
+    return c.json({ ok: false, error: "packageIds required" }, 400);
+  }
+  try {
+    const result = await canCreateCombinationSticker(accountId, body.packageIds);
+    return c.json({ ok: true, ...result });
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+// ─── POST /line/:accountId/combination-stickers/available ───────
+// { packageId: string }
+
+lineRouter.post("/:accountId/combination-stickers/available", async (c) => {
+  const accountId = c.req.param("accountId");
+  const body = await c.req.json<{ packageId?: string }>();
+  if (!body.packageId) {
+    return c.json({ ok: false, error: "packageId required" }, 400);
+  }
+  try {
+    const result = await isStickerAvailableForCombinationSticker(accountId, body.packageId);
+    return c.json({ ok: true, ...result });
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+// ─── POST /line/:accountId/combination-stickers ───────
+// { items: [{ packageId, stickerId }], idOfPreviousVersionOfCombinationSticker? }
+
+lineRouter.post("/:accountId/combination-stickers", async (c) => {
+  const accountId = c.req.param("accountId");
+  const body = await c.req.json<{
+    items?: Array<{ packageId: string; stickerId: string; x?: number; y?: number; size?: number }>;
+    idOfPreviousVersionOfCombinationSticker?: string;
+  }>();
+  if (!body.items?.length) {
+    return c.json({ ok: false, error: "items required" }, 400);
+  }
+  try {
+    const result =
+      body.idOfPreviousVersionOfCombinationSticker != null
+        ? await createCombinationSticker(accountId, body.items, {
+            idOfPreviousVersionOfCombinationSticker: body.idOfPreviousVersionOfCombinationSticker,
+          })
+        : await createCombinationSticker(accountId, body.items);
+    return c.json({ ok: true, ...result });
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+// ─── POST /line/:accountId/send-combination-sticker ───────
+// { chatMid, items: [{ packageId, stickerId }], idOfPreviousVersionOfCombinationSticker? }
+
+lineRouter.post("/:accountId/send-combination-sticker", async (c) => {
+  const accountId = c.req.param("accountId");
+  const body = await c.req.json<{
+    chatMid?: string;
+    items?: Array<{ packageId: string; stickerId: string; x?: number; y?: number; size?: number }>;
+    idOfPreviousVersionOfCombinationSticker?: string;
+  }>();
+  if (!body.chatMid) {
+    return c.json({ ok: false, error: "chatMid required" }, 400);
+  }
+  if (!body.items?.length) {
+    return c.json({ ok: false, error: "items required" }, 400);
+  }
+  try {
+    const message = await sendCombinationSticker(
+      accountId,
+      body.chatMid,
+      body.items,
+      body.idOfPreviousVersionOfCombinationSticker != null
+        ? {
+            idOfPreviousVersionOfCombinationSticker:
+              body.idOfPreviousVersionOfCombinationSticker,
+          }
+        : undefined,
+    );
+    return c.json({ ok: true, message: message ?? undefined });
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
 // ─── POST /line/:accountId/send-emoji ─────────
 // { chatMid, packageId, sticonId }
 
@@ -555,6 +665,49 @@ lineRouter.post("/:accountId/send-media", async (c) => {
     if (body.mediaType) opts.mediaType = body.mediaType;
     await sendMedia(accountId, body.chatMid, body.dataBase64, opts);
     return c.json({ ok: true });
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+// ─── POST /line/:accountId/send-media-batch ───────
+// { chatMid, items: [{ dataBase64, mimeType?, filename?, mediaType? }] }
+
+lineRouter.post("/:accountId/send-media-batch", async (c) => {
+  const accountId = c.req.param("accountId");
+  const body = await c.req.json<{
+    chatMid?: string;
+    items?: Array<{
+      dataBase64?: string;
+      mimeType?: string;
+      filename?: string;
+      mediaType?: "image" | "video" | "audio" | "file" | "gif";
+    }>;
+  }>();
+
+  if (!body.chatMid || !Array.isArray(body.items) || body.items.length === 0) {
+    return c.json({ ok: false, error: "chatMid and items required" }, 400);
+  }
+
+  try {
+    let count = 0;
+    for (const item of body.items) {
+      if (!item?.dataBase64) continue;
+      if (item.dataBase64.length > 12_000_000) {
+        return c.json({ ok: false, error: "file too large" }, 413);
+      }
+      const opts: {
+        mimeType?: string;
+        filename?: string;
+        mediaType?: "image" | "video" | "audio" | "file" | "gif";
+      } = {};
+      if (item.mimeType) opts.mimeType = item.mimeType;
+      if (item.filename) opts.filename = item.filename;
+      if (item.mediaType) opts.mediaType = item.mediaType;
+      await sendMedia(accountId, body.chatMid, item.dataBase64, opts);
+      count++;
+    }
+    return c.json({ ok: true, count });
   } catch (err) {
     return handleError(err, c);
   }
@@ -744,14 +897,6 @@ lineRouter.patch("/:accountId/profile", async (c) => {
     allowSearchByUserid?: boolean;
     allowSearchByEmail?: boolean;
     hiddenFromList?: boolean;
-    birthday?: {
-      year?: string;
-      day: string;
-      yearEnabled?: boolean;
-      dayEnabled?: boolean;
-      yearPrivacy?: "PUBLIC" | "PRIVATE";
-      dayPrivacy?: "PUBLIC" | "PRIVATE";
-    };
   }>();
   try {
     const profile = await updateMyProfile(accountId, body);

--- a/Vyline/backend/src/api/line.ts
+++ b/Vyline/backend/src/api/line.ts
@@ -599,8 +599,7 @@ lineRouter.post("/:accountId/send-combination-sticker", async (c) => {
       body.items,
       body.idOfPreviousVersionOfCombinationSticker != null
         ? {
-            idOfPreviousVersionOfCombinationSticker:
-              body.idOfPreviousVersionOfCombinationSticker,
+            idOfPreviousVersionOfCombinationSticker: body.idOfPreviousVersionOfCombinationSticker,
           }
         : undefined,
     );

--- a/Vyline/backend/src/service/lineService.ts
+++ b/Vyline/backend/src/service/lineService.ts
@@ -175,9 +175,18 @@ function extractBackgroundUrl(value: unknown, depth = 0): string | null {
   if (depth > 12 || value == null) return null;
   if (typeof value === "string") {
     const s = value.trim();
+    if (/^\/(?:myhome|mh|hm)\//i.test(s)) {
+      return `https://obs.line-scdn.net${s}`;
+    }
+    if (/^[a-z0-9_-]{8,}$/i.test(s) && !s.includes(" ")) {
+      const maybe = backgroundObjToUrl(s);
+      if (maybe) return maybe;
+    }
     if (
       /^https?:\/\//i.test(s) &&
-      (s.includes("myhome") || /\.(png|jpe?g|webp|gif)(\?|$)/i.test(s))
+      (s.includes("myhome") ||
+        s.includes("line-scdn.net") ||
+        /\.(png|jpe?g|webp|gif)(\?|$)/i.test(s))
     ) {
       return s;
     }
@@ -228,19 +237,24 @@ async function fetchHomeProfileBackgroundUrl(
   }
   try {
     const client = requireClient(accountId);
-    const res = await withTimeout(
-      (async () => {
-        const r = await client.voomRest<unknown>({
-          routing: "HOMEAPI",
-          path: `/api/v1/home/profile.json?homeId=${encodeURIComponent(targetMid)}`,
-        });
-        return r;
-      })(),
-      HOME_BACKGROUND_RPC_TIMEOUT_MS,
-      "homeProfile",
-    );
-    const result = (res as { result?: unknown })?.result;
-    const url = result ? extractBackgroundUrl(result) : null;
+    const fetchHomeBackground = async (path: string, label: string): Promise<string | null> => {
+      const res = await withTimeout(
+        (async () => {
+          const r = await client.voomRest<unknown>({
+            routing: "HOMEAPI",
+            path: `${path}?homeId=${encodeURIComponent(targetMid)}`,
+          });
+          return r;
+        })(),
+        HOME_BACKGROUND_RPC_TIMEOUT_MS,
+        label,
+      );
+      const result = (res as { result?: unknown })?.result;
+      return result ? extractBackgroundUrl(result) : null;
+    };
+    const url =
+      (await fetchHomeBackground("/api/v1/home/profile.json", "homeProfile")) ??
+      (await fetchHomeBackground("/api/v1/home/cover.json", "homeCover"));
     homeBackgroundCache.set(key, { at: Date.now(), url: url ?? "" });
     return url;
   } catch (err) {
@@ -988,7 +1002,8 @@ export async function fetchProfile(accountId: string): Promise<LineProfile> {
   const mem = myProfileCache.get(accountId);
   if (mem && now - mem.at < MY_PROFILE_CACHE_MS) {
     if (mem.profile.premium) return mem.profile;
-    const premium = premiumStatusCache.get(accountId)?.premium ?? (await fetchPremiumStatus(accountId));
+    const premium =
+      premiumStatusCache.get(accountId)?.premium ?? (await fetchPremiumStatus(accountId));
     const next = { ...mem.profile, premium };
     myProfileCache.set(accountId, { at: mem.at, profile: next });
     return next;
@@ -1048,8 +1063,8 @@ export async function fetchProfile(accountId: string): Promise<LineProfile> {
         statusMessage?: string;
         musicProfile?: string;
         videoProfile?: string;
-      profileId?: string;
-    }
+        profileId?: string;
+      }
     | undefined;
 
   const persistAndReturn = (out: LineProfile): LineProfile => {
@@ -1135,7 +1150,8 @@ export async function fetchProfile(accountId: string): Promise<LineProfile> {
     const profile = await vylineGetProfile(accountId, String(knownMid));
     if (profile?.displayName) {
       const mapped = lineProfileFromVyline(profile);
-      mapped.premium = premiumStatusCache.get(accountId)?.premium ?? (await fetchPremiumStatus(accountId));
+      mapped.premium =
+        premiumStatusCache.get(accountId)?.premium ?? (await fetchPremiumStatus(accountId));
       myProfileCache.set(accountId, { at: now, profile: mapped });
       refreshInBg();
       return mapped;
@@ -1785,6 +1801,19 @@ export async function fetchContactProfile(
 
   const cached = contactProfileCache.get(cacheKey);
   if (cached && now - cached.at < CONTACT_PROFILE_CACHE_MS) {
+    if (targetMid.startsWith("u") && !cached.profile.backgroundUrl) {
+      const next = { ...cached.profile };
+      try {
+        const bg = await fetchHomeProfileBackgroundUrl(accountId, targetMid);
+        if (bg) {
+          next.backgroundUrl = bg;
+          contactProfileCache.set(cacheKey, { at: Date.now(), profile: next });
+          return next;
+        }
+      } catch {
+        /* optional */
+      }
+    }
     return cached.profile;
   }
 
@@ -1803,6 +1832,14 @@ export async function fetchContactProfile(
     const vylineHit = await vylineGetProfile(accountId, targetMid);
     if (vylineHit && !vylineProfileNeedsRefresh(vylineHit)) {
       const profile = lineProfileFromVyline(vylineHit);
+      if (targetMid.startsWith("u") && !profile.backgroundUrl) {
+        try {
+          const bg = await fetchHomeProfileBackgroundUrl(accountId, targetMid);
+          if (bg) profile.backgroundUrl = bg;
+        } catch {
+          /* optional */
+        }
+      }
       contactProfileCache.set(cacheKey, { at: Date.now(), profile });
       return profile;
     }
@@ -4100,11 +4137,25 @@ export async function sendMedia(
 
       try {
         if (plainMode) {
-          // E2EE 鍵を整えられない相手は uploadMediaByE2EE の内部 plain フォールバックを使う
-          // （uploadObjTalk は talk メッセージを作らないため使わない）
-          await tryUpload();
+          // 平文チャットは E2EE メディアメッセージではなく raw OBS upload で送る。
+          // uploadObjTalk が talk 側のメッセージ作成まで面倒を見るため、sendMessage は呼ばない。
+          const { objId, objHash } = await client.base.obs.uploadObjTalk(
+            chatMid,
+            mediaType,
+            blob,
+            undefined,
+            filename,
+          );
           log.info(
-            { accountId, chatMid, mediaType, size: binary.byteLength, plain: true },
+            {
+              accountId,
+              chatMid,
+              mediaType,
+              size: binary.byteLength,
+              plain: true,
+              objId,
+              objHash,
+            },
             "media sent",
           );
           return;
@@ -4191,77 +4242,35 @@ export async function sendSticker(
       return null;
     }
   }
-  return runSendRpc(accountId, async () => {
-    const client = requireClient(accountId);
-    const myMid = await resolveMyMid(client, accountId);
-    const packageId = String(opts?.packageId ?? "11537");
-    const stickerId = String(opts?.stickerId ?? "52002734");
-    // Premium sticker: STKVER=100, 所持チェック不要
-    const premium = Boolean(opts?.isPremium);
-    const stkver = premium ? "100" : "1";
-    const contentMetadata: Record<string, string> = {
-      STKPKGID: packageId,
-      STKID: stickerId,
-      STKVER: stkver,
-      STKTXT: "[スタンプ]",
-    };
-    if (premium) {
-      contentMetadata.STKOPT = "A";
-    }
-
-    const sendPlain = async () =>
-      client.base.talk.sendMessage({
-        to: chatMid,
-        contentType: "STICKER",
-        contentMetadata,
-        e2ee: false,
-      });
-
-    let sent: unknown;
-    if (noE2eePeers.has(chatMid)) {
-      sent = await sendPlain();
-    } else {
-      try {
-        await ensureE2EEIdentityCached(client, accountId);
-        const envelope = await encryptLetterSealingMessage(client, {
-          to: chatMid,
-          from: myMid,
-          contentType: 7, // STICKER
-          payload: {},
-        });
-        sent = await client.base.talk.sendMessage({
-          to: chatMid,
-          contentType: "STICKER",
-          contentMetadata: { ...contentMetadata, ...envelope.contentMetadata },
-          chunks: envelope.chunks,
-          e2ee: true,
-        });
-      } catch (err) {
-        const errMsg = err instanceof Error ? err.message : String(err);
-        markNoE2eePeer(chatMid, errMsg);
-        log.warn({ accountId, chatMid, errMsg }, "e2ee sticker send failed, trying plain");
-        sent = await sendPlain();
+  return runSendRpc(accountId, async () =>
+    sendStickerMessage(accountId, chatMid, async () => {
+      const packageId = String(opts?.packageId ?? "11537");
+      const stickerId = String(opts?.stickerId ?? "52002734");
+      // Premium sticker: STKVER=100, 所持チェック不要
+      const premium = Boolean(opts?.isPremium);
+      const stkver = premium ? "100" : "1";
+      const contentMetadata: Record<string, string> = {
+        STKPKGID: packageId,
+        STKID: stickerId,
+        STKVER: stkver,
+        STKTXT: "[スタンプ]",
+      };
+      if (premium) {
+        contentMetadata.STKOPT = "A";
       }
-    }
-
-    invalidateMessageBoxesCache(accountId);
-    invalidateBoxCursorCache(accountId, chatMid);
-    // 送信結果に STK メタが無い場合もあるので補完してキャッシュ
-    if (sent && typeof sent === "object") {
-      const raw = sent as Record<string, unknown>;
-      const meta = (raw.contentMetadata ?? {}) as Record<string, string>;
-      raw.contentMetadata = { ...contentMetadata, ...meta };
-      raw.contentType = raw.contentType ?? "STICKER";
-    }
-    const remembered = await rememberSentRaw(accountId, chatMid, myMid, sent);
-    log.info({ accountId, chatMid, packageId, stickerId }, "sticker sent");
-    return remembered;
-  });
+      return {
+        contentMetadata,
+      };
+    }),
+  );
 }
 
 type CombinationStickerInput = {
   packageId: string;
   stickerId: string;
+  x?: number;
+  y?: number;
+  size?: number;
 };
 
 function buildCombinationStickerLayouts(items: CombinationStickerInput[]): {
@@ -4273,6 +4282,18 @@ function buildCombinationStickerLayouts(items: CombinationStickerInput[]): {
   const count = Math.max(1, items.length);
 
   const toLayoutInfo = (index: number): CombinationStickerLayoutInfo => {
+    const item = items[index];
+    if (item?.x != null && item?.y != null && item?.size != null) {
+      const scale = canvasWidth / 240;
+      const size = Math.max(40, Math.min(canvasWidth, Math.round(item.size * scale)));
+      return {
+        width: size,
+        height: size,
+        rotation: 0,
+        x: Math.max(0, Math.round(item.x * scale)),
+        y: Math.max(0, Math.round(item.y * scale)),
+      };
+    }
     switch (count) {
       case 1:
         return { width: 352, height: 352, rotation: 0, x: 80, y: 80 };
@@ -4393,16 +4414,113 @@ export async function createCombinationSticker(
     throw new Error("at least one sticker is required");
   }
   return await runSendRpc(accountId, async () => {
-    const client = requireClient(accountId);
-    const payload = buildCombinationStickerLayouts(items);
-    const result = await client.base.shop.createCombinationSticker({
-      request: {
-        ...payload,
-        idOfPreviousVersionOfCombinationSticker:
-          opts?.idOfPreviousVersionOfCombinationSticker ?? "",
-      },
+    return await createCombinationStickerCore(accountId, items, opts);
+  });
+}
+
+async function createCombinationStickerCore(
+  accountId: string,
+  items: CombinationStickerInput[],
+  opts?: { idOfPreviousVersionOfCombinationSticker?: string },
+): Promise<{ id: string }> {
+  const client = requireClient(accountId);
+  const payload = buildCombinationStickerLayouts(items);
+  const result = await client.base.shop.createCombinationSticker({
+    request: {
+      ...payload,
+      idOfPreviousVersionOfCombinationSticker: opts?.idOfPreviousVersionOfCombinationSticker ?? "",
+    },
+  });
+  return { id: String(result?.id ?? "") };
+}
+
+async function sendStickerMessage(
+  accountId: string,
+  chatMid: string,
+  build: (
+    client: ReturnType<typeof requireClient>,
+    myMid: string,
+  ) => Promise<{
+    contentMetadata: Record<string, string>;
+  }>,
+): Promise<Message | null> {
+  const client = requireClient(accountId);
+  const myMid = await resolveMyMid(client, accountId);
+  const built = await build(client, myMid);
+
+  const sendPlain = async () =>
+    client.base.talk.sendMessage({
+      to: chatMid,
+      contentType: "STICKER",
+      contentMetadata: built.contentMetadata,
+      e2ee: false,
     });
-    return { id: String(result?.id ?? "") };
+
+  let sent: unknown;
+  if (noE2eePeers.has(chatMid)) {
+    sent = await sendPlain();
+  } else {
+    try {
+      await ensureE2EEIdentityCached(client, accountId);
+      const envelope = await encryptLetterSealingMessage(client, {
+        to: chatMid,
+        from: myMid,
+        contentType: 7, // STICKER
+        payload: {},
+      });
+      sent = await client.base.talk.sendMessage({
+        to: chatMid,
+        contentType: "STICKER",
+        contentMetadata: { ...built.contentMetadata, ...envelope.contentMetadata },
+        chunks: envelope.chunks,
+        e2ee: true,
+      });
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      markNoE2eePeer(chatMid, errMsg);
+      log.warn({ accountId, chatMid, errMsg }, "e2ee sticker send failed, trying plain");
+      sent = await sendPlain();
+    }
+  }
+
+  invalidateMessageBoxesCache(accountId);
+  invalidateBoxCursorCache(accountId, chatMid);
+  if (sent && typeof sent === "object") {
+    const raw = sent as Record<string, unknown>;
+    const meta = (raw.contentMetadata ?? {}) as Record<string, string>;
+    raw.contentMetadata = { ...built.contentMetadata, ...meta };
+    raw.contentType = raw.contentType ?? "STICKER";
+  }
+  const remembered = await rememberSentRaw(accountId, chatMid, myMid, sent);
+  return remembered;
+}
+
+export async function sendCombinationSticker(
+  accountId: string,
+  chatMid: string,
+  items: CombinationStickerInput[],
+  opts?: { idOfPreviousVersionOfCombinationSticker?: string },
+): Promise<Message | null> {
+  if (chatMid.startsWith("u")) {
+    const blocked = await fetchBlockedContactIds(accountId);
+    if (blocked.includes(chatMid)) {
+      log.info({ accountId, chatMid }, "sendCombinationSticker blocked: user is blocked");
+      return null;
+    }
+  }
+  if (!items.length) {
+    throw new Error("at least one sticker is required");
+  }
+  return runSendRpc(accountId, async () => {
+    const created = await createCombinationStickerCore(accountId, items, opts);
+    const remembered = await sendStickerMessage(accountId, chatMid, async () => ({
+      contentMetadata: { CSSTKID: created.id },
+    }));
+    log.info(
+      { accountId, chatMid, combinationStickerId: created.id, count: items.length },
+      "combination sticker sent",
+    );
+    return remembered;
   });
 }
 

--- a/Vyline/backend/src/service/lineService.ts
+++ b/Vyline/backend/src/service/lineService.ts
@@ -44,6 +44,7 @@ import {
   vylinePutProfiles,
   vylineResolvedNameMap,
 } from "../storage/vylineCache.js";
+import { updateSessionMeta } from "../storage/tokenStore.js";
 import { VylineStorage } from "../storage/vylineStorage.js";
 import { banCreateGroup, isCreateGroupBanned } from "../storage/featureLocks.js";
 import {
@@ -75,6 +76,7 @@ import {
   markMessageRevoked,
   restoreRevokedMessage,
   getMessageHistory,
+  findStoredMessageById,
   warmAccountCache,
   saveBoxOrder,
   type BootstrapPayload,
@@ -89,6 +91,40 @@ export { CallNotAllowedError, callAllowlistHint };
 export type { CallSessionSnapshot } from "../call/callManager.js";
 
 const log = childLogger("service:line");
+
+type CombinationStickerLayoutInfo = {
+  width: number;
+  height: number;
+  rotation: number;
+  x: number;
+  y: number;
+};
+
+type CombinationStickerStickerInfo = {
+  stickerId: number;
+  productId: number;
+  stickerHash: string;
+  stickerOptions: string;
+  stickerVersion: number;
+};
+
+type CombinationStickerLayout = {
+  layoutInfo: CombinationStickerLayoutInfo;
+  stickerInfo: CombinationStickerStickerInfo;
+};
+
+type CombinationStickerMetadata = {
+  version: number;
+  canvasWidth: number;
+  canvasHeight: number;
+  stickerLayouts: CombinationStickerLayout[];
+};
+
+type CombinationStickerStickerData = {
+  packageId: string;
+  stickerId: string;
+  version: number;
+};
 
 // ─── helpers ──────────────────────────────────
 
@@ -301,8 +337,9 @@ async function ensureGroupE2EEKey(
         msg.includes("NOT_FOUND") ||
         msg.includes("no valid group key") ||
         msg.includes("there is no valid group key");
-      if (expectedMissing) {
+      if (expectedMissing || isRetryPlainError(msg)) {
         log.debug({ chatMid, err: msg }, "ensureGroupE2EEKey: no group key (skip)");
+        if (isRetryPlainError(msg)) noE2eePeers.add(chatMid);
       } else {
         log.warn(
           { chatMid, err: msg },
@@ -580,6 +617,15 @@ const CONTACT_PROFILE_MISS_MS = Number(process.env.VYLINE_CONTACT_MISS_CACHE_MS 
 const contactProfileMiss = new Map<string, number>();
 const myProfileCache = new Map<string, { at: number; profile: LineProfile }>();
 const myMidCache = new Map<string, string>();
+type PremiumStatus = {
+  active: boolean;
+  planType?: string | number;
+  validUntil?: number;
+  onFreeTrial?: boolean;
+  willExpire?: boolean;
+};
+const premiumStatusCache = new Map<string, { at: number; premium: PremiumStatus }>();
+const PREMIUM_STATUS_CACHE_MS = Number(process.env.VYLINE_PREMIUM_STATUS_CACHE_MS ?? 10 * 60_000);
 
 /** Desktop: 起動時に鍵検証済み — 毎リクエスト getE2EEPublicKeys を避ける */
 const e2eeIdentityEnsuredAt = new Map<string, number>();
@@ -890,6 +936,48 @@ function requireClient(accountId: string) {
   return client;
 }
 
+async function fetchPremiumStatus(accountId: string): Promise<PremiumStatus> {
+  const now = Date.now();
+  const cached = premiumStatusCache.get(accountId);
+  if (cached && now - cached.at < PREMIUM_STATUS_CACHE_MS) {
+    return cached.premium;
+  }
+
+  const client = requireClient(accountId);
+  let premium: PremiumStatus = { active: false };
+  try {
+    const status = (await client.base.request.request(
+      LINEStruct.getPremiumStatus_args({ req: {} as never }),
+      "getPremiumStatus",
+      4,
+      true,
+      "/EXT/line-premium/common/thrift/status",
+    )) as {
+      active?: boolean;
+      planType?: string | number;
+      validUntil?: number | bigint;
+      onFreeTrial?: boolean;
+      willExpire?: boolean;
+    };
+    premium = {
+      active: Boolean(status?.active),
+      onFreeTrial: Boolean(status?.onFreeTrial),
+      willExpire: Boolean(status?.willExpire),
+    };
+    if (status?.planType != null) premium.planType = status.planType;
+    if (status?.validUntil != null) premium.validUntil = Number(status.validUntil);
+  } catch (err) {
+    log.debug(
+      { accountId, err: err instanceof Error ? err.message : String(err) },
+      "getPremiumStatus failed",
+    );
+  }
+
+  premiumStatusCache.set(accountId, { at: Date.now(), premium });
+  void updateSessionMeta(accountId, { premium });
+  return premium;
+}
+
 /** 自分のプロフィール取得（メモリ / base.profile / Vyline 優先、RPC は短タイムアウト） */
 export async function fetchProfile(accountId: string): Promise<LineProfile> {
   // Refresh token before making profile requests to ensure it's valid
@@ -899,7 +987,11 @@ export async function fetchProfile(accountId: string): Promise<LineProfile> {
   const now = Date.now();
   const mem = myProfileCache.get(accountId);
   if (mem && now - mem.at < MY_PROFILE_CACHE_MS) {
-    return mem.profile;
+    if (mem.profile.premium) return mem.profile;
+    const premium = premiumStatusCache.get(accountId)?.premium ?? (await fetchPremiumStatus(accountId));
+    const next = { ...mem.profile, premium };
+    myProfileCache.set(accountId, { at: mem.at, profile: next });
+    return next;
   }
 
   const client = requireClient(accountId);
@@ -919,7 +1011,10 @@ export async function fetchProfile(accountId: string): Promise<LineProfile> {
       backgroundUrl?: string;
     },
     birthday: LineBirthday | null = null,
+    premium: PremiumStatus | null = null,
   ): LineProfile => {
+    // ふりがな / profileId / pictureStatus / birthday は backend で保持しておく。
+    // 現在の UI では出さないが、将来の再表示やデバッグ用にレスポンス形は残す。
     const pictureStatus = String(raw.pictureStatus ?? raw.picturePath ?? "");
     const thumbnailUrl = pictureStatusToUrl(pictureStatus) ?? "";
     const out: LineProfile = {
@@ -936,6 +1031,7 @@ export async function fetchProfile(accountId: string): Promise<LineProfile> {
       profileId: String(raw.profileId ?? ""),
       backgroundUrl: raw.backgroundUrl || undefined,
       birthday,
+      ...(premium ? { premium } : {}),
     };
     return out;
   };
@@ -952,8 +1048,8 @@ export async function fetchProfile(accountId: string): Promise<LineProfile> {
         statusMessage?: string;
         musicProfile?: string;
         videoProfile?: string;
-        profileId?: string;
-      }
+      profileId?: string;
+    }
     | undefined;
 
   const persistAndReturn = (out: LineProfile): LineProfile => {
@@ -980,6 +1076,7 @@ export async function fetchProfile(accountId: string): Promise<LineProfile> {
       if (out.birthday?.display) put.birthday = out.birthday.display;
       if (out.backgroundUrl) put.backgroundUrl = out.backgroundUrl;
       void vylinePutProfile(accountId, put);
+      if (out.premium) void updateSessionMeta(accountId, { premium: out.premium });
     }
     return out;
   };
@@ -993,6 +1090,7 @@ export async function fetchProfile(accountId: string): Promise<LineProfile> {
           MY_PROFILE_RPC_TIMEOUT_MS,
           "getProfile.bg",
         );
+        const premium = await fetchPremiumStatus(accountId);
         let birthday: LineBirthday | null = mem?.profile.birthday ?? null;
         try {
           const ext = await withTimeout(
@@ -1012,7 +1110,7 @@ export async function fetchProfile(accountId: string): Promise<LineProfile> {
         } catch {
           /* optional */
         }
-        persistAndReturn(mapRaw(profile as never, birthday));
+        persistAndReturn(mapRaw(profile as never, birthday, premium));
       } catch (err) {
         log.debug({ accountId, err }, "fetchProfile background refresh failed");
       }
@@ -1025,7 +1123,7 @@ export async function fetchProfile(accountId: string): Promise<LineProfile> {
   }
 
   if (baseProf?.mid && baseProf.displayName) {
-    const quick = mapRaw(baseProf, mem?.profile.birthday ?? null);
+    const quick = mapRaw(baseProf, mem?.profile.birthday ?? null, mem?.profile.premium ?? null);
     persistAndReturn(quick);
     refreshInBg();
     return quick;
@@ -1037,6 +1135,7 @@ export async function fetchProfile(accountId: string): Promise<LineProfile> {
     const profile = await vylineGetProfile(accountId, String(knownMid));
     if (profile?.displayName) {
       const mapped = lineProfileFromVyline(profile);
+      mapped.premium = premiumStatusCache.get(accountId)?.premium ?? (await fetchPremiumStatus(accountId));
       myProfileCache.set(accountId, { at: now, profile: mapped });
       refreshInBg();
       return mapped;
@@ -1049,6 +1148,7 @@ export async function fetchProfile(accountId: string): Promise<LineProfile> {
       MY_PROFILE_RPC_TIMEOUT_MS,
       "getProfile",
     );
+    const premium = await fetchPremiumStatus(accountId);
     let birthday: LineBirthday | null = null;
     try {
       const ext = await withTimeout(
@@ -1069,13 +1169,16 @@ export async function fetchProfile(accountId: string): Promise<LineProfile> {
       log.debug({ accountId, err }, "getExtendedProfile skipped");
     }
 
-    const out = persistAndReturn(mapRaw(profile as never, birthday));
+    const out = persistAndReturn(mapRaw(profile as never, birthday, premium));
     log.debug({ accountId, mid: out.mid, hasThumb: Boolean(out.thumbnailUrl) }, "profile fetched");
     return out;
   } catch (err) {
     log.debug({ accountId, err }, "fetchProfile timed out — fallback");
     if (mem) return mem.profile;
-    if (baseProf?.mid) return persistAndReturn(mapRaw(baseProf, null));
+    if (baseProf?.mid) {
+      const premium = await fetchPremiumStatus(accountId).catch(() => null);
+      return persistAndReturn(mapRaw(baseProf, null, premium));
+    }
     throw err;
   }
 }
@@ -3608,6 +3711,11 @@ function isMissingGroupKeyError(errMsg: string): boolean {
   );
 }
 
+function isRetryPlainError(errMsg: string): boolean {
+  const lower = errMsg.toLowerCase();
+  return errMsg.includes("E2EE_RETRY_PLAIN") || lower.includes("member settings off");
+}
+
 /**
  * グループ宛送信前: 最新共有鍵を用意。無ければ新規 register。
  * （uploadMediaByE2EE / Letter Sealing は鍵無しだと NOT_FOUND で落ちる）
@@ -3632,6 +3740,11 @@ async function ensureGroupKeyReadyForSend(
     return;
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
+    if (isRetryPlainError(msg)) {
+      noE2eePeers.add(chatMid);
+      log.debug({ accountId, chatMid, err: msg }, "ensureGroupKeyReadyForSend: retry plain");
+      return;
+    }
     if (!isMissingGroupKeyError(msg)) {
       log.warn({ accountId, chatMid, err: msg }, "ensureGroupKeyReadyForSend: getLast failed");
       throw err;
@@ -3952,6 +4065,7 @@ export async function sendMedia(
           );
           plainMode = true;
         }
+        plainMode = plainMode || noE2eePeers.has(chatMid);
       }
 
       const mime = opts?.mimeType ?? "image/png";
@@ -4145,6 +4259,153 @@ export async function sendSticker(
   });
 }
 
+type CombinationStickerInput = {
+  packageId: string;
+  stickerId: string;
+};
+
+function buildCombinationStickerLayouts(items: CombinationStickerInput[]): {
+  metadata: CombinationStickerMetadata;
+  stickers: CombinationStickerStickerData[];
+} {
+  const canvasWidth = 512;
+  const canvasHeight = 512;
+  const count = Math.max(1, items.length);
+
+  const toLayoutInfo = (index: number): CombinationStickerLayoutInfo => {
+    switch (count) {
+      case 1:
+        return { width: 352, height: 352, rotation: 0, x: 80, y: 80 };
+      case 2:
+        return {
+          width: 216,
+          height: 216,
+          rotation: 0,
+          x: index === 0 ? 40 : 256,
+          y: 148,
+        };
+      case 3:
+        return index === 0
+          ? { width: 240, height: 240, rotation: 0, x: 136, y: 20 }
+          : {
+              width: 200,
+              height: 200,
+              rotation: 0,
+              x: index === 1 ? 44 : 268,
+              y: 248,
+            };
+      case 4: {
+        const col = index % 2;
+        const row = Math.floor(index / 2);
+        return { width: 192, height: 192, rotation: 0, x: 48 + col * 224, y: 48 + row * 224 };
+      }
+      case 5:
+        if (index < 2) {
+          return { width: 176, height: 176, rotation: 0, x: 68 + index * 204, y: 56 };
+        }
+        return { width: 160, height: 160, rotation: 0, x: 48 + (index - 2) * 148, y: 292 };
+      case 6: {
+        const col = index % 3;
+        const row = Math.floor(index / 3);
+        return {
+          width: 140,
+          height: 140,
+          rotation: 0,
+          x: 38 + col * 158,
+          y: 86 + row * 168,
+        };
+      }
+      default: {
+        const cols = count <= 8 ? 3 : 4;
+        const rows = Math.ceil(count / cols);
+        const cellW = Math.floor((canvasWidth - 72) / cols);
+        const cellH = Math.floor((canvasHeight - 72) / rows);
+        const col = index % cols;
+        const row = Math.floor(index / cols);
+        const size = Math.min(cellW, cellH) - 10;
+        return {
+          width: size,
+          height: size,
+          rotation: 0,
+          x: 36 + col * cellW + Math.floor((cellW - size) / 2),
+          y: 36 + row * cellH + Math.floor((cellH - size) / 2),
+        };
+      }
+    }
+  };
+
+  const metadata: CombinationStickerMetadata = {
+    version: 1,
+    canvasWidth,
+    canvasHeight,
+    stickerLayouts: items.map((item, index) => ({
+      layoutInfo: toLayoutInfo(index),
+      stickerInfo: {
+        stickerId: Number(item.stickerId),
+        productId: Number(item.packageId),
+        stickerHash: "",
+        stickerOptions: "",
+        stickerVersion: 1,
+      },
+    })),
+  };
+
+  return {
+    metadata,
+    stickers: items.map((item) => ({
+      packageId: item.packageId,
+      stickerId: item.stickerId,
+      version: 1,
+    })),
+  };
+}
+
+export async function canCreateCombinationSticker(
+  accountId: string,
+  packageIds: string[],
+): Promise<{ canCreate: boolean; usablePackageIds: string[] }> {
+  const client = requireClient(accountId);
+  return await client.base.shop.canCreateCombinationSticker({
+    request: {
+      packageIds,
+    },
+  });
+}
+
+export async function isStickerAvailableForCombinationSticker(
+  accountId: string,
+  packageId: string,
+): Promise<{ availableForCombinationSticker: boolean }> {
+  const client = requireClient(accountId);
+  return await client.base.shop.isStickerAvailableForCombinationSticker({
+    request: {
+      packageId,
+    },
+  });
+}
+
+export async function createCombinationSticker(
+  accountId: string,
+  items: CombinationStickerInput[],
+  opts?: { idOfPreviousVersionOfCombinationSticker?: string },
+): Promise<{ id: string }> {
+  if (items.length === 0) {
+    throw new Error("at least one sticker is required");
+  }
+  return await runSendRpc(accountId, async () => {
+    const client = requireClient(accountId);
+    const payload = buildCombinationStickerLayouts(items);
+    const result = await client.base.shop.createCombinationSticker({
+      request: {
+        ...payload,
+        idOfPreviousVersionOfCombinationSticker:
+          opts?.idOfPreviousVersionOfCombinationSticker ?? "",
+      },
+    });
+    return { id: String(result?.id ?? "") };
+  });
+}
+
 /** LINE 絵文字 (sticon) 送信 */
 export async function sendLineEmoji(
   accountId: string,
@@ -4218,6 +4479,18 @@ export async function sendLineEmoji(
 export async function unsendMessage(accountId: string, messageId: string): Promise<void> {
   // 送信と同じキューで直列化（送信中と同時に H2 セッションを使うと取り消しが落ちることがある）
   return runSendRpc(accountId, async () => {
+    const found = await findStoredMessageById(accountId, messageId);
+    if (found) {
+      const stored = found.message;
+      if (
+        stored.revokedSnapshot ||
+        stored.messageState?.startsWith("revoked") ||
+        stored.contentType === "UNSENT" ||
+        stored.contentType === "UNSEND"
+      ) {
+        throw new Error("MESSAGE_ALREADY_REVOKED: this message was already unsent once");
+      }
+    }
     const client = requireClient(accountId);
     await client.base.talk.unsendMessage({
       seq: await client.base.getReqseq(),
@@ -4295,7 +4568,7 @@ export async function getMessageEditNotice(
 // ─── Profile / Chat admin / Contacts (domain facade) ───────────────────────
 // Desktop: TalkService_updateProfileAttributes / updateChat / updateContactSetting
 
-/** 自分プロフィール属性更新（表示名・ステメ・誕生日等） */
+/** 自分プロフィール属性更新（表示名・ステメ等） */
 export async function updateMyProfile(
   accountId: string,
   input: ProfileUpdateInput,
@@ -4305,7 +4578,7 @@ export async function updateMyProfile(
 
   // musicProfile は ANDROIDSECONDARY 等で "music profile update not allowed"
   // → 書き込みは行わずログのみ（取得・表示は fetchProfile 側）
-  const { musicProfile, birthday, ...attrs } = input;
+  const { musicProfile, ...attrs } = input;
   if (musicProfile !== undefined) {
     log.info({ accountId }, "musicProfile write skipped (server rejects on this device type)");
   }
@@ -4313,41 +4586,6 @@ export async function updateMyProfile(
   const attrInput: ProfileUpdateInput = { ...attrs };
   if (Object.keys(attrInput).length > 0) {
     await session.profile.update(attrInput);
-  }
-
-  if (birthday) {
-    try {
-      await session.profile.update({ birthday });
-    } catch (err1) {
-      log.debug({ accountId, err: err1 }, "birthday update attr 0 failed — retry attr 1");
-      try {
-        const day = birthday.day.replace(/[^0-9]/g, "").slice(0, 4);
-        const year = (birthday.year ?? "").replace(/[^0-9]/g, "").slice(0, 4);
-        await client.base.talk.updateExtendedProfileAttribute({
-          reqSeq: await client.base.getReqseq(),
-          attr: 1,
-          extendedProfile: {
-            birthday: {
-              year,
-              day,
-              yearEnabled: birthday.yearEnabled ?? Boolean(year),
-              dayEnabled: birthday.dayEnabled ?? true,
-              yearPrivacyLevelType: birthday.yearPrivacy ?? "PRIVATE",
-              dayPrivacyLevelType: birthday.dayPrivacy ?? "PUBLIC",
-            },
-          },
-        });
-      } catch (err2) {
-        // ANDROIDSECONDARY 等では x-lc:500 / 空ボディで失敗することがある
-        log.info(
-          {
-            accountId,
-            err: err2 instanceof Error ? err2.message : String(err2),
-          },
-          "birthday update skipped (not supported on this device)",
-        );
-      }
-    }
   }
 
   myMidCache.delete(accountId);
@@ -4370,14 +4608,6 @@ export async function updateMyProfile(
       musicProfile: musicProfile ?? "",
       videoProfile: "",
       profileId: "",
-      birthday: birthday
-        ? formatBirthdayDisplay({
-            day: birthday.day,
-            ...(birthday.year !== undefined ? { year: birthday.year } : {}),
-            ...(birthday.yearEnabled !== undefined ? { yearEnabled: birthday.yearEnabled } : {}),
-            ...(birthday.dayEnabled !== undefined ? { dayEnabled: birthday.dayEnabled } : {}),
-          })
-        : null,
     };
   }
 }
@@ -5563,34 +5793,7 @@ export async function fetchStickersCatalog(
 
   const client = requireClient(accountId);
 
-  let premium: StickersCatalog["premium"] = { active: false };
-  try {
-    const status = (await client.base.request.request(
-      LINEStruct.getPremiumStatus_args({ req: {} as never }),
-      "getPremiumStatus",
-      4,
-      true,
-      "/EXT/line-premium/common/thrift/status",
-    )) as {
-      active?: boolean;
-      planType?: string | number;
-      validUntil?: number | bigint;
-      onFreeTrial?: boolean;
-      willExpire?: boolean;
-    };
-    premium = {
-      active: Boolean(status?.active),
-      onFreeTrial: Boolean(status?.onFreeTrial),
-      willExpire: Boolean(status?.willExpire),
-    };
-    if (status?.planType != null) premium.planType = status.planType;
-    if (status?.validUntil != null) premium.validUntil = Number(status.validUntil);
-  } catch (err) {
-    log.debug(
-      { accountId, err: err instanceof Error ? err.message : String(err) },
-      "getPremiumStatus failed",
-    );
-  }
+  const premium = await fetchPremiumStatus(accountId);
 
   const stickerIds = [
     ...DEFAULT_STICKER_PACKS,

--- a/Vyline/backend/src/service/lineService.ts
+++ b/Vyline/backend/src/service/lineService.ts
@@ -76,7 +76,6 @@ import {
   markMessageRevoked,
   restoreRevokedMessage,
   getMessageHistory,
-  findStoredMessageById,
   warmAccountCache,
   saveBoxOrder,
   type BootstrapPayload,
@@ -4386,7 +4385,16 @@ export async function canCreateCombinationSticker(
   packageIds: string[],
 ): Promise<{ canCreate: boolean; usablePackageIds: string[] }> {
   const client = requireClient(accountId);
-  return await client.base.shop.canCreateCombinationSticker({
+  const shop = (
+    client.base as unknown as {
+      shop: {
+        canCreateCombinationSticker: (input: {
+          request: { packageIds: string[] };
+        }) => Promise<{ canCreate: boolean; usablePackageIds: string[] }>;
+      };
+    }
+  ).shop;
+  return await shop.canCreateCombinationSticker({
     request: {
       packageIds,
     },
@@ -4398,7 +4406,16 @@ export async function isStickerAvailableForCombinationSticker(
   packageId: string,
 ): Promise<{ availableForCombinationSticker: boolean }> {
   const client = requireClient(accountId);
-  return await client.base.shop.isStickerAvailableForCombinationSticker({
+  const shop = (
+    client.base as unknown as {
+      shop: {
+        isStickerAvailableForCombinationSticker: (input: {
+          request: { packageId: string };
+        }) => Promise<{ availableForCombinationSticker: boolean }>;
+      };
+    }
+  ).shop;
+  return await shop.isStickerAvailableForCombinationSticker({
     request: {
       packageId,
     },
@@ -4425,7 +4442,16 @@ async function createCombinationStickerCore(
 ): Promise<{ id: string }> {
   const client = requireClient(accountId);
   const payload = buildCombinationStickerLayouts(items);
-  const result = await client.base.shop.createCombinationSticker({
+  const shop = (
+    client.base as unknown as {
+      shop: {
+        createCombinationSticker: (input: {
+          request: typeof payload & { idOfPreviousVersionOfCombinationSticker: string };
+        }) => Promise<{ id: string | number | null | undefined }>;
+      };
+    }
+  ).shop;
+  const result = await shop.createCombinationSticker({
     request: {
       ...payload,
       idOfPreviousVersionOfCombinationSticker: opts?.idOfPreviousVersionOfCombinationSticker ?? "",
@@ -4597,7 +4623,8 @@ export async function sendLineEmoji(
 export async function unsendMessage(accountId: string, messageId: string): Promise<void> {
   // 送信と同じキューで直列化（送信中と同時に H2 セッションを使うと取り消しが落ちることがある）
   return runSendRpc(accountId, async () => {
-    const found = await findStoredMessageById(accountId, messageId);
+    const found = await findStoredMessageByIdLocal(accountId, messageId);
+    const chatMid = found?.chatMid;
     if (found) {
       const stored = found.message;
       if (
@@ -4614,8 +4641,27 @@ export async function unsendMessage(accountId: string, messageId: string): Promi
       seq: await client.base.getReqseq(),
       messageId,
     });
+    if (chatMid) {
+      await markMessageRevoked(accountId, chatMid, messageId);
+    }
     log.info({ accountId, messageId }, "message unsent");
   });
+}
+
+async function findStoredMessageByIdLocal(
+  accountId: string,
+  messageId: string,
+): Promise<{
+  chatMid: string;
+  message: Awaited<ReturnType<typeof getStoredMessages>>[number];
+} | null> {
+  const chats = await getStoredChats(accountId);
+  for (const chat of chats) {
+    const messages = await getStoredMessages(accountId, chat.mid, Number.MAX_SAFE_INTEGER);
+    const message = messages.find((m) => m.id === messageId);
+    if (message) return { chatMid: chat.mid, message };
+  }
+  return null;
 }
 
 /** メッセージ編集（Desktop: editMessage） */

--- a/Vyline/backend/src/storage/tokenStore.ts
+++ b/Vyline/backend/src/storage/tokenStore.ts
@@ -39,6 +39,13 @@ export interface TokenEntry {
   displayName?: string;
   picturePath?: string;
   statusMessage?: string;
+  premium?: {
+    active: boolean;
+    planType?: string | number;
+    validUntil?: number;
+    onFreeTrial?: boolean;
+    willExpire?: boolean;
+  };
 }
 
 export type TokenMap = Record<string, TokenEntry>;
@@ -48,6 +55,13 @@ export type SessionMeta = {
   displayName?: string;
   picturePath?: string;
   statusMessage?: string;
+  premium?: {
+    active: boolean;
+    planType?: string | number;
+    validUntil?: number;
+    onFreeTrial?: boolean;
+    willExpire?: boolean;
+  };
 };
 
 async function ensureDataDir(): Promise<void> {
@@ -113,10 +127,12 @@ export async function saveToken(
   const displayName = meta?.displayName ?? existing?.displayName;
   const picturePath = meta?.picturePath ?? existing?.picturePath;
   const statusMessage = meta?.statusMessage ?? existing?.statusMessage;
+  const premium = meta?.premium ?? existing?.premium;
   if (mid) entry.mid = mid;
   if (displayName) entry.displayName = displayName;
   if (picturePath) entry.picturePath = picturePath;
   if (statusMessage) entry.statusMessage = statusMessage;
+  if (premium) entry.premium = premium;
   tokens[accountId] = entry;
 
   await writeFile(TOKENS_FILE, JSON.stringify(tokens, null, 2), "utf-8");
@@ -131,6 +147,7 @@ export async function updateSessionMeta(accountId: string, meta: SessionMeta): P
   if (meta.displayName != null) existing.displayName = meta.displayName;
   if (meta.picturePath != null) existing.picturePath = meta.picturePath;
   if (meta.statusMessage != null) existing.statusMessage = meta.statusMessage;
+  if (meta.premium != null) existing.premium = meta.premium;
   existing.savedAt = new Date().toISOString();
   tokens[accountId] = existing;
   await writeFile(TOKENS_FILE, JSON.stringify(tokens, null, 2), "utf-8");
@@ -170,6 +187,7 @@ export async function listSavedSessions(): Promise<
         displayName?: string;
         picturePath?: string;
         statusMessage?: string;
+        premium?: TokenEntry["premium"];
         hasToken: boolean;
       } = {
         accountId,
@@ -180,6 +198,7 @@ export async function listSavedSessions(): Promise<
       if (entry.displayName) row.displayName = entry.displayName;
       if (entry.picturePath) row.picturePath = entry.picturePath;
       if (entry.statusMessage) row.statusMessage = entry.statusMessage;
+      if (entry.premium) row.premium = entry.premium;
       return row;
     })
     .sort((a, b) => (a.savedAt < b.savedAt ? 1 : -1));

--- a/Vyline/packages/protocol/src/domain/profile.ts
+++ b/Vyline/packages/protocol/src/domain/profile.ts
@@ -10,7 +10,6 @@ import type { ProfileUpdateInput } from "./types.js";
 import {
   getMyExtendedProfile,
   getMyProfile,
-  updateMyBirthday,
   updateMyProfile,
   uploadMyProfileBackground,
   uploadMyProfileImage,
@@ -42,11 +41,10 @@ export class ProfileDomain {
     }
     if (input.hiddenFromList !== undefined) update.hiddenFromList = input.hiddenFromList;
     const hasAttrs = Object.keys(update).length > 0;
-    if (!hasAttrs && !input.birthday) {
+    if (!hasAttrs) {
       throw new Error("ProfileDomain.update: empty update");
     }
     if (hasAttrs) await updateMyProfile(this.client, update);
-    if (input.birthday) await updateMyBirthday(this.client, input.birthday);
   }
 
   async uploadAvatar(data: Blob) {

--- a/Vyline/packages/protocol/src/domain/types.ts
+++ b/Vyline/packages/protocol/src/domain/types.ts
@@ -12,14 +12,6 @@ export interface ProfileUpdateInput {
   allowSearchByUserid?: boolean;
   allowSearchByEmail?: boolean;
   hiddenFromList?: boolean;
-  birthday?: {
-    year?: string;
-    day: string;
-    yearEnabled?: boolean;
-    dayEnabled?: boolean;
-    yearPrivacy?: "PUBLIC" | "PRIVATE";
-    dayPrivacy?: "PUBLIC" | "PRIVATE";
-  };
 }
 
 export type ChatUpdateAttribute = "NAME" | "PICTURE_STATUS";

--- a/Vyline/packages/protocol/src/protocol/profileOps.ts
+++ b/Vyline/packages/protocol/src/protocol/profileOps.ts
@@ -29,21 +29,6 @@ export interface MyProfileUpdate {
   hiddenFromList?: boolean;
 }
 
-/** ExtendedProfile.birthday — Desktop: TalkService_updateExtendedProfileAttribute */
-export interface MyBirthdayUpdate {
-  /** "YYYY" — 空で年非表示 */
-  year?: string;
-  /** "MMDD" */
-  day: string;
-  yearEnabled?: boolean;
-  dayEnabled?: boolean;
-  yearPrivacy?: "PUBLIC" | "PRIVATE";
-  dayPrivacy?: "PUBLIC" | "PRIVATE";
-}
-
-/** ExtendedProfileAttribute.BIRTHDAY（Thrift: attr i32、誕生日のみ） */
-const EXTENDED_PROFILE_ATTR_BIRTHDAY = 0;
-
 function bool(v: boolean): string {
   return v ? "true" : "false";
 }
@@ -85,28 +70,6 @@ export async function updateMyProfile(client: Client, update: MyProfileUpdate): 
 
 export async function getMyExtendedProfile(client: Client) {
   return client.base.talk.getExtendedProfile({ syncReason: "INTERNAL" });
-}
-
-export async function updateMyBirthday(client: Client, birthday: MyBirthdayUpdate): Promise<void> {
-  const day = birthday.day.replace(/[^0-9]/g, "").slice(0, 4);
-  if (day.length !== 4) {
-    throw new Error("birthday.day must be MMDD");
-  }
-  const year = (birthday.year ?? "").replace(/[^0-9]/g, "").slice(0, 4);
-  await client.base.talk.updateExtendedProfileAttribute({
-    reqSeq: await client.base.getReqseq(),
-    attr: EXTENDED_PROFILE_ATTR_BIRTHDAY,
-    extendedProfile: {
-      birthday: {
-        year,
-        day,
-        yearEnabled: birthday.yearEnabled ?? Boolean(year),
-        dayEnabled: birthday.dayEnabled ?? true,
-        yearPrivacyLevelType: birthday.yearPrivacy ?? "PRIVATE",
-        dayPrivacyLevelType: birthday.dayPrivacy ?? "PUBLIC",
-      },
-    },
-  });
 }
 
 export async function uploadMyProfileImage(

--- a/Vyline/packages/types/src/index.ts
+++ b/Vyline/packages/types/src/index.ts
@@ -125,6 +125,20 @@ export interface MessageContentMeta {
   [key: string]: string | undefined;
 }
 
+export type RetryIntent =
+  | {
+      kind: "text";
+      text: string;
+      relatedMessageId?: string;
+      contentMetadata?: Record<string, string>;
+    }
+  | { kind: "sticker"; packageId: string; stickerId: string; isPremium?: boolean }
+  | {
+      kind: "combinationSticker";
+      items: Array<{ packageId: string; stickerId: string; x?: number; y?: number; size?: number }>;
+    }
+  | { kind: "emoji"; packageId: string; sticonId: string };
+
 export interface Message {
   id: string;
   from: string;

--- a/Vyline/packages/types/src/index.ts
+++ b/Vyline/packages/types/src/index.ts
@@ -35,6 +35,14 @@ export interface LineProfile {
   birthday?: LineBirthday | null | undefined;
   /** アカウント種別: USER=1 / BOT=2（公式アカウントは BOT） */
   userType?: number;
+  /** LYP Premium の加入状態 */
+  premium?: {
+    active: boolean;
+    planType?: string | number;
+    validUntil?: number;
+    onFreeTrial?: boolean;
+    willExpire?: boolean;
+  };
 }
 
 /** VylineCache から返す軽量プロフィール */
@@ -156,7 +164,11 @@ export interface Message {
     contentType: string;
     updatedTime: number;
   }>;
+  /** 取り消し前のメッセージ本体スナップショット */
+  revokedSnapshot?: MessageSnapshot;
 }
+
+export type MessageSnapshot = Omit<Message, "history" | "revokedSnapshot">;
 
 export interface MessageReaction {
   /** リアクションしたユーザー mid */
@@ -230,6 +242,13 @@ export type SavedSession = {
   displayName?: string;
   picturePath?: string;
   statusMessage?: string;
+  premium?: {
+    active: boolean;
+    planType?: string | number;
+    validUntil?: number;
+    onFreeTrial?: boolean;
+    willExpire?: boolean;
+  };
 };
 
 export type AccountsResponse = ApiResult<{

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -113,6 +113,12 @@ bun run typecheck
 | `desktop-e2ee-keys.json` / token をコミット | 秘密情報                 |
 | Desktop 未検証のまま path を変える          | 実機 x-lc:400 の温床     |
 
+### Vyline では公開しない項目
+
+- 自分プロフィールの「誕生日（MMDD / YYYYMMDD）」更新は扱わない。
+- これは Desktop 側でも主に primary 寄りのデバイスタイプでしか安定しないため、Vyline では入力欄を出さず、backend でも更新経路を持たない。
+- 表示用に取得済みの誕生日データは残してよいが、編集導線は追加しない。
+
 ---
 
 ## コード規約（短く）


### PR DESCRIPTION
## 変更内容
- 取り消し済みメッセージを再起動後も revoked 状態として永続化
- 取り消し後の表示を通常バブルではなく点線バブルで維持
- revokedSnapshot / history / messageState を使って再同期でも空表示・通常表示に戻りにくく修正

## 確認
- bunx biome check Vyline/backend/src/service/lineService.ts Vyline/apps/desktop/src/components/message-bubble.tsx Vyline/apps/desktop/src/lib/store.ts
- push 前の bun run --cwd Vyline/apps/desktop build
