### PR TITLE
Fix missing revoked message bubbles from local cache

### DIFF
--- a/Vyline/apps/desktop/src/api/client.ts
+++ b/Vyline/apps/desktop/src/api/client.ts
@@ -358,7 +358,7 @@ export const api = {
       request<EditNoticeResponse>("GET", `/line/${accountId}/edit-notice/${chatMid}`),
 
     messageHistory: (accountId: string, chatMid: string, messageId: string) =>
-      request<{ ok: true; history: Message["history"] }>(
+      request<{ ok: true; history: Message["history"]; message?: Message | null }>(
         "GET",
         `/line/${accountId}/messages/${encodeURIComponent(chatMid)}/${encodeURIComponent(messageId)}/history`,
       ),

--- a/Vyline/apps/desktop/src/lib/store.ts
+++ b/Vyline/apps/desktop/src/lib/store.ts
@@ -2139,6 +2139,8 @@ export const useStore = create<State>()(
       },
 
       applyRevoked: (chatId, messageId) => {
+        const accountId = get().accountId;
+        const hadLocal = get().messages.some((m) => m.chatId === chatId && m.id === messageId);
         set((st) => {
           const msgs = st.messages.map((m) => {
             if (m.chatId !== chatId || m.id !== messageId) return m;
@@ -2166,6 +2168,42 @@ export const useStore = create<State>()(
           if (msgs.every((m, i) => m === st.messages[i])) return st;
           return { messages: msgs };
         });
+        if (!hadLocal && accountId) {
+          setTimeout(() => {
+            void api.line
+              .messageHistory(accountId, chatId, messageId)
+              .then((res) => {
+                if (!res.ok || !res.message) return;
+                const message = res.message;
+                const {
+                  history: _history,
+                  revokedSnapshot: _revokedSnapshot,
+                  ...messageSnapshot
+                } = message;
+                const revokedMessage: LineMessage = message.messageState?.startsWith("revoked")
+                  ? message
+                  : {
+                      ...message,
+                      messageState: message.isMyMessage ? "revoked-by-self" : "revoked-by-other",
+                      history: message.history?.length
+                        ? message.history
+                        : [
+                            {
+                              state: message.messageState ?? "normal",
+                              text: message.text,
+                              contentType: message.contentType,
+                              updatedTime: Date.now(),
+                            },
+                          ],
+                      revokedSnapshot: message.revokedSnapshot ?? messageSnapshot,
+                      contentType: "UNSENT",
+                      text: null,
+                    };
+                get().mergeIncomingMessages(chatId, [revokedMessage], { silent: true });
+              })
+              .catch(() => undefined);
+          }, 250);
+        }
       },
 
       fetchMessageHistory: async (chatId, messageId) => {

--- a/Vyline/backend/src/api/line.ts
+++ b/Vyline/backend/src/api/line.ts
@@ -81,6 +81,7 @@ import {
   NotLoggedInError,
   restoreRevokedMessage,
   getMessageHistory,
+  getStoredMessage,
 } from "../service/lineService.js";
 import {
   LiffNotLoggedInError,
@@ -761,7 +762,8 @@ lineRouter.get("/:accountId/messages/:chatMid/:messageId/history", async (c) => 
 
   try {
     const history = await getMessageHistory(accountId, chatMid, messageId);
-    return c.json({ ok: true, history });
+    const message = await getStoredMessage(accountId, chatMid, messageId);
+    return c.json({ ok: true, history, message });
   } catch (err) {
     return handleError(err, c);
   }

--- a/Vyline/backend/src/service/lineService.ts
+++ b/Vyline/backend/src/service/lineService.ts
@@ -82,7 +82,11 @@ import {
   type StoredChat,
 } from "../storage/chatStore.js";
 
-export { restoreRevokedMessage, getMessageHistory } from "../storage/chatStore.js";
+export {
+  restoreRevokedMessage,
+  getMessageHistory,
+  getStoredMessage,
+} from "../storage/chatStore.js";
 import { CallNotAllowedError, callAllowlistHint, isAllowedCallTarget } from "../call/allowlist.js";
 import { appendMessageLog, type MessageLogEntry } from "../storage/messageLog.js";
 
@@ -3174,8 +3178,8 @@ async function processSingleOperation(
     const messageId = String(op.param1 ?? "");
     const chatMid = String(op.param2 ?? "");
     if (messageId && /^[ucr]/.test(chatMid)) {
+      await markMessageRevoked(accountId, chatMid, messageId).catch(() => undefined);
       pushTalkEvent(accountId, { kind: "revoke", chatMid, messageId });
-      void markMessageRevoked(accountId, chatMid, messageId).catch(() => undefined);
     }
     return;
   }

--- a/Vyline/backend/src/storage/chatStore.ts
+++ b/Vyline/backend/src/storage/chatStore.ts
@@ -276,6 +276,16 @@ export async function getMessages(
     .slice(0, limit);
 }
 
+export async function getStoredMessage(
+  accountId: string,
+  chatMid: string,
+  messageId: string,
+): Promise<Message | null> {
+  const db = await getDb(accountId);
+  const stored = db.messages[chatMid]?.[messageId];
+  return stored ? storedMessageToMessage(stored) : null;
+}
+
 function storedChatToChat(stored: StoredChat): Chat {
   const chat: Chat = {
     mid: stored.mid,


### PR DESCRIPTION
## 変更内容
- UI ストアに対象メッセージがない状態で revoke イベントを受けても、backend のローカル chatStore から該当メッセージを取り直して表示できるように修正
- message history API が保存済みメッセージ本体も返せるように拡張
- backend 側で revoke イベントを配信する前に chatStore へ取り消し状態を保存する順序へ変更
- 保存済みメッセージ取得 API を追加し、revokedSnapshot / history を含む取り消し済み状態を frontend に渡す

## 原因
revoke イベント時に対象メッセージが現在の UI store に存在しない場合、applyRevoked が何も更新できず、その後の delta 同期でも古い messageId は after 条件に引っかからないため、点線バブルとして再表示されないケースがありました。

## 確認
- bun run typecheck
- bun run lint
- bun run --cwd Vyline/apps/desktop build