### PR TITLE
fix: combination sticker preview keyed by CSSTKID

### DIFF
--- a/Vyline/apps/desktop/src/components/sticker-emoji-panel.tsx
+++ b/Vyline/apps/desktop/src/components/sticker-emoji-panel.tsx
@@ -16,7 +16,12 @@ import {
   setCachedStickersCatalog,
   type StickersCatalogCache,
 } from "@/lib/stickerCatalogCache";
-import type { CombinationStickerPlacement } from "@/utils/combinationStickers";
+import {
+  COMBO_EDITOR_SIZE,
+  COMBO_ITEM_MAX_SIZE,
+  COMBO_ITEM_MIN_SIZE,
+  type CombinationStickerPlacement,
+} from "@/utils/combinationStickers";
 
 export type CatalogItem = { id: string; url: string; alt?: string };
 export type CatalogPack = {
@@ -40,8 +45,9 @@ type ComboItem = CombinationStickerPlacement & { uid: string };
 type MenuState = { x: number; y: number; fav: StickerFavorite } | null;
 
 const COMBO_LIMIT = 6;
-const COMBO_SIZE = 360;
-const COMBO_ITEM_SIZE = 92;
+// 正規座標空間 240x240 (backend の scale=512/240 前提と同期。表示枠も同サイズで固定)
+const COMBO_SIZE = COMBO_EDITOR_SIZE;
+const COMBO_ITEM_SIZE = 80;
 const LONG_PRESS_MS = 300;
 
 function assetUrl(url: string): string {
@@ -107,6 +113,7 @@ export function StickerEmojiPanel({
   const [comboBusy, setComboBusy] = useState(false);
   const [comboError, setComboError] = useState<string | null>(null);
   const [draggingComboId, setDraggingComboId] = useState<string | null>(null);
+  const [resizingComboId, setResizingComboId] = useState<string | null>(null);
   const comboCanvasRef = useRef<HTMLDivElement>(null);
   const dragOffsetRef = useRef({ x: 0, y: 0 });
   const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -327,9 +334,23 @@ export function StickerEmojiPanel({
   }
 
   function handleComboPointerMove(ev: ReactPointerEvent<HTMLDivElement>): void {
-    if (!draggingComboId) return;
     const rect = comboCanvasRef.current?.getBoundingClientRect();
     if (!rect) return;
+    if (resizingComboId) {
+      const item = comboItems.find((x) => x.uid === resizingComboId);
+      if (!item) return;
+      const dist = Math.hypot(ev.clientX - rect.left - item.x, ev.clientY - rect.top - item.y);
+      const size = Math.round(Math.max(COMBO_ITEM_MIN_SIZE, Math.min(COMBO_ITEM_MAX_SIZE, dist)));
+      setComboItems((prev) =>
+        prev.map((x) => {
+          if (x.uid !== resizingComboId) return x;
+          const pos = normalizePoint(x.x, x.y, size);
+          return { ...x, size, ...pos };
+        }),
+      );
+      return;
+    }
+    if (!draggingComboId) return;
     const item = comboItems.find((x) => x.uid === draggingComboId);
     if (!item) return;
     const next = normalizePoint(
@@ -342,6 +363,16 @@ export function StickerEmojiPanel({
 
   function handleComboPointerUp(): void {
     setDraggingComboId(null);
+    setResizingComboId(null);
+  }
+
+  function handleComboResizeDown(uidValue: string, ev: ReactPointerEvent<HTMLButtonElement>): void {
+    const item = comboItems.find((x) => x.uid === uidValue);
+    if (!item) return;
+    ev.preventDefault();
+    ev.stopPropagation();
+    ev.currentTarget.setPointerCapture(ev.pointerId);
+    setResizingComboId(uidValue);
   }
 
   function startLongPress(payload: DragPayload): void {
@@ -432,6 +463,7 @@ export function StickerEmojiPanel({
           alt={item.alt || ""}
           className="max-h-full max-w-full object-contain"
           loading="lazy"
+          draggable={false}
           referrerPolicy="no-referrer"
         />
       </button>
@@ -439,8 +471,8 @@ export function StickerEmojiPanel({
   }
 
   return (
-    <div className="vy-scale-in absolute bottom-full left-3 mb-2 flex h-[min(720px,86vh)] w-[min(680px,96vw)] flex-col overflow-hidden rounded-2xl border border-[var(--vy-border)] bg-[var(--vy-surface)] shadow-2xl md:left-5">
-      <div className="flex items-center gap-1 border-b border-[var(--vy-border)] px-2 pt-2">
+    <div className="vy-scale-in absolute bottom-full left-3 mb-2 flex h-[min(500px,72vh)] w-[min(460px,90vw)] flex-col overflow-hidden rounded-2xl border border-[var(--vy-border)] bg-[var(--vy-surface)] shadow-2xl md:left-5">
+      <div className="flex items-center gap-1 border-b border-[var(--vy-border)] px-1.5 pt-1.5">
         {(
           [
             ["sticker", "スタンプ"],
@@ -453,7 +485,7 @@ export function StickerEmojiPanel({
             type="button"
             onClick={() => setTab(id)}
             className={cn(
-              "rounded-t-lg px-3 py-1.5 text-xs font-semibold transition-colors",
+              "rounded-t-lg px-2.5 py-1 text-[0.72rem] font-semibold transition-colors",
               tab === id
                 ? "bg-[var(--vy-surface-2)] text-[var(--vy-text)]"
                 : "text-[var(--vy-text-dim)] hover:text-[var(--vy-text)]",
@@ -462,7 +494,7 @@ export function StickerEmojiPanel({
             {label}
           </button>
         ))}
-        <span className="ml-auto flex items-center gap-1 px-2 text-[0.65rem] text-[var(--vy-text-dim)]">
+        <span className="ml-auto flex items-center gap-1 px-1.5 text-[0.6rem] text-[var(--vy-text-dim)]">
           {catalog?.premium.active && <PremiumBadge size={12} compact />}
           <span>
             {catalog?.premium.active
@@ -475,7 +507,7 @@ export function StickerEmojiPanel({
       </div>
 
       {tab !== "favorite" && (
-        <div className="flex gap-1 overflow-x-auto border-b border-[var(--vy-border)] px-2 py-1.5 [scrollbar-width:thin]">
+        <div className="flex gap-1 overflow-x-auto border-b border-[var(--vy-border)] px-1.5 py-1 [scrollbar-width:thin]">
           {packs.map((p) => (
             <button
               key={p.packageId}
@@ -483,7 +515,7 @@ export function StickerEmojiPanel({
               title={p.name}
               onClick={() => setPackId(p.packageId)}
               className={cn(
-                "flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border transition-colors",
+                "flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border transition-colors",
                 activePack?.packageId === p.packageId
                   ? "border-[var(--vy-accent)] bg-[color-mix(in_oklab,var(--vy-accent)_18%,transparent)]"
                   : "border-transparent hover:bg-[var(--vy-surface-2)]",
@@ -492,8 +524,9 @@ export function StickerEmojiPanel({
               <img
                 src={assetUrl(p.tabUrl)}
                 alt=""
-                className="h-7 w-7 object-contain"
+                className="h-6 w-6 object-contain"
                 loading="lazy"
+                draggable={false}
                 referrerPolicy="no-referrer"
               />
             </button>
@@ -501,23 +534,25 @@ export function StickerEmojiPanel({
         </div>
       )}
 
-      <div className="min-h-0 flex-1 overflow-y-auto p-2">
+      <div className="min-h-0 flex-1 overflow-y-auto p-1.5">
         {comboMode && activePack?.type === "sticker" && (
-          <div className="mb-2 rounded-2xl border border-[var(--vy-border)] bg-[var(--vy-surface-2)] p-2">
+          <div className="mb-2 rounded-2xl border border-[var(--vy-border)] bg-[var(--vy-surface-2)] p-1.5">
             <div className="flex items-center gap-2">
               <div className="min-w-0 flex-1">
-                <p className="text-xs font-semibold text-[var(--vy-text)]">ドラッグで組み合わせ</p>
-                <p className="mt-0.5 text-[0.7rem] text-[var(--vy-text-dim)]">
+                <p className="text-[0.72rem] font-semibold text-[var(--vy-text)]">
+                  ドラッグで組み合わせ
+                </p>
+                <p className="mt-0.5 text-[0.62rem] text-[var(--vy-text-dim)]">
                   長押しで開き、ここにスタンプを落として自由に配置できます。
                 </p>
               </div>
-              <span className="rounded-full bg-[color-mix(in_oklab,var(--vy-text)_10%,transparent)] px-2 py-0.5 text-[0.65rem] text-[var(--vy-text-dim)]">
+              <span className="rounded-full bg-[color-mix(in_oklab,var(--vy-text)_10%,transparent)] px-2 py-0.5 text-[0.6rem] text-[var(--vy-text-dim)]">
                 {comboItems.length} 枚
               </span>
               <button
                 type="button"
                 onClick={clearCombo}
-                className="rounded-full border border-[var(--vy-border)] px-3 py-1.5 text-xs text-[var(--vy-text-dim)] transition-colors hover:bg-[var(--vy-surface)]"
+                className="rounded-full border border-[var(--vy-border)] px-2.5 py-1 text-[0.68rem] text-[var(--vy-text-dim)] transition-colors hover:bg-[var(--vy-surface)]"
               >
                 クリア
               </button>
@@ -525,7 +560,7 @@ export function StickerEmojiPanel({
                 type="button"
                 onClick={() => void sendCombo()}
                 disabled={comboBusy || comboItems.length === 0}
-                className="rounded-full bg-[var(--vy-accent)] px-3 py-1.5 text-xs font-semibold text-[var(--vy-accent-contrast)] transition-opacity disabled:cursor-not-allowed disabled:opacity-50"
+                className="rounded-full bg-[var(--vy-accent)] px-2.5 py-1 text-[0.68rem] font-semibold text-[var(--vy-accent-contrast)] transition-opacity disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {comboBusy ? "送信中…" : "送信"}
               </button>
@@ -533,7 +568,8 @@ export function StickerEmojiPanel({
 
             <div
               ref={comboCanvasRef}
-              className="relative mt-2 h-[360px] overflow-hidden rounded-2xl border border-[var(--vy-border)] bg-[linear-gradient(135deg,color-mix(in_oklab,var(--vy-surface-2)_82%,transparent),color-mix(in_oklab,var(--vy-surface)_94%,transparent))]"
+              className="relative mx-auto mt-2 overflow-hidden rounded-2xl border border-[var(--vy-border)] bg-[linear-gradient(135deg,color-mix(in_oklab,var(--vy-surface-2)_82%,transparent),color-mix(in_oklab,var(--vy-surface)_94%,transparent))]"
+              style={{ width: COMBO_SIZE, height: COMBO_SIZE }}
               onPointerMove={handleComboPointerMove}
               onPointerUp={handleComboPointerUp}
               onPointerLeave={handleComboPointerUp}
@@ -543,10 +579,10 @@ export function StickerEmojiPanel({
               <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,color-mix(in_oklab,var(--vy-accent)_12%,transparent),transparent_38%),radial-gradient(circle_at_bottom_right,color-mix(in_oklab,var(--vy-text)_8%,transparent),transparent_42%)]" />
               {comboItems.length === 0 ? (
                 <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 text-center">
-                  <div className="rounded-full border border-dashed border-[var(--vy-border)] px-4 py-2 text-xs text-[var(--vy-text-dim)]">
+                  <div className="rounded-full border border-dashed border-[var(--vy-border)] px-3 py-1.5 text-[0.68rem] text-[var(--vy-text-dim)]">
                     スタンプをここへドラッグ
                   </div>
-                  <p className="max-w-[18rem] text-[0.7rem] text-[var(--vy-text-dim)]">
+                  <p className="max-w-[16rem] text-[0.62rem] text-[var(--vy-text-dim)]">
                     対応しているスタンプだけが入ります。置いたあとも掴んで動かせます。
                   </p>
                 </div>
@@ -580,7 +616,16 @@ export function StickerEmojiPanel({
                     </button>
                     <button
                       type="button"
-                      className="absolute -right-2 -top-2 flex h-6 w-6 items-center justify-center rounded-full border border-[var(--vy-border)] bg-[var(--vy-surface-2)] text-[0.65rem] text-[var(--vy-text-dim)] shadow-lg"
+                      aria-label="サイズを変更"
+                      title="ドラッグでサイズ変更"
+                      className="absolute -bottom-1.5 -right-1.5 h-4 w-4 cursor-nwse-resize rounded-full border border-[var(--vy-border)] bg-[var(--vy-surface)] opacity-80 shadow-md transition-opacity hover:opacity-100"
+                      onPointerDown={(ev) => handleComboResizeDown(item.uid, ev)}
+                    >
+                      <span className="pointer-events-none absolute inset-[3px] rounded-full bg-[var(--vy-text-dim)]" />
+                    </button>
+                    <button
+                      type="button"
+                      className="absolute -right-2 -top-2 flex h-5 w-5 items-center justify-center rounded-full border border-[var(--vy-border)] bg-[var(--vy-surface-2)] text-[0.6rem] text-[var(--vy-text-dim)] shadow-lg"
                       onClick={() => {
                         setComboItems((prev) => prev.filter((x) => x.uid !== item.uid));
                         if (comboItems.length <= 1) setComboMode(false);
@@ -656,7 +701,7 @@ export function StickerEmojiPanel({
                     setMenu({ x: e.clientX, y: e.clientY, fav: f });
                   }}
                   className={cn(
-                    "flex aspect-square items-center justify-center rounded-xl p-1 transition-colors active:scale-95",
+                    "flex aspect-square items-center justify-center rounded-xl p-0.5 transition-colors active:scale-95",
                     draggable ? "hover:bg-[var(--vy-surface-2)]" : "cursor-not-allowed opacity-55",
                   )}
                 >
@@ -665,6 +710,7 @@ export function StickerEmojiPanel({
                     alt={f.name || ""}
                     className="max-h-full max-w-full object-contain"
                     loading="lazy"
+                    draggable={false}
                     referrerPolicy="no-referrer"
                   />
                 </button>

--- a/Vyline/apps/desktop/src/lib/mappers.ts
+++ b/Vyline/apps/desktop/src/lib/mappers.ts
@@ -299,20 +299,27 @@ export function mapMessage(
       ? parseContactFromMeta(m.contentMetadata as Record<string, unknown> | null, text)
       : undefined;
 
+  let stickerSrc: string | undefined;
+  if (kind === "sticker") {
+    // コンビネーション: CSSTKID → メッセージID の順でローカルプレビューを引く。
+    // 履歴レスポンスに CSSTKID が載らない場合でも、送信時に保存したプレビューで表示を維持する。
+    const comboPreview = comboStickerId
+      ? getCombinationStickerPreview(accountId, comboStickerId)
+      : null;
+    const preview = comboPreview ?? getCombinationStickerPreview(accountId, m.id);
+    if (preview) stickerSrc = preview;
+    else if (comboStickerId) stickerSrc = lineStickerUrl(comboStickerId);
+    else if (stickerId) stickerSrc = lineStickerUrl(stickerId);
+    else stickerSrc = "🧩";
+  }
+
   const result: Message = {
     id: m.id,
     chatId,
     authorId,
     kind,
     text,
-    sticker:
-      kind === "sticker" && comboStickerId
-        ? (getCombinationStickerPreview(accountId, comboStickerId) ?? "🧩")
-        : kind === "sticker" && stickerId
-          ? lineStickerUrl(stickerId)
-          : kind === "sticker"
-            ? "🧩"
-            : undefined,
+    sticker: stickerSrc,
     imageSrc,
     audioSrc,
     audioSeconds: kind === "audio" ? parseAudioDuration(m.contentMetadata ?? null) : undefined,

--- a/Vyline/apps/desktop/src/lib/store.ts
+++ b/Vyline/apps/desktop/src/lib/store.ts
@@ -24,6 +24,9 @@ import {
 } from "./mappers.js";
 import { lineStickerUrl } from "../utils/lineMedia.js";
 import {
+  COMBO_EDITOR_SIZE,
+  COMBO_ITEM_MAX_SIZE,
+  COMBO_ITEM_MIN_SIZE,
   renderCombinationStickerPreview,
   setCombinationStickerPreview,
   type CombinationStickerPlacement,
@@ -91,6 +94,71 @@ function buildContactCache(chats: Chat[]): Map<string, ContactInfo> {
 function snapshotFromMessage(m: Message): MessageSnapshot {
   const { history: _history, revokedSnapshot: _revokedSnapshot, ...snapshot } = m;
   return snapshot;
+}
+
+function isDataUrl(value?: string): boolean {
+  return typeof value === "string" && value.startsWith("data:");
+}
+
+function mergePreservingComboStickerPreview(existing: Message, incoming: Message): Message {
+  if (existing.kind !== "sticker" || incoming.kind !== "sticker") return incoming;
+  if (!isDataUrl(existing.sticker)) return incoming;
+  if (isDataUrl(incoming.sticker)) return incoming;
+  // ローカル合成プレビューはサーバ再取得結果（🧩 や無効 URL）より常に優先
+  return {
+    ...incoming,
+    sticker: existing.sticker,
+  };
+}
+
+function combinationPlacementsFromItems(
+  items: Array<{ packageId: string; stickerId: string; x?: number; y?: number; size?: number }>,
+): CombinationStickerPlacement[] {
+  return items.map((item, index) => {
+    const size = Math.round(
+      Math.max(
+        COMBO_ITEM_MIN_SIZE,
+        Math.min(COMBO_ITEM_MAX_SIZE, item.size ?? COMBO_ITEM_MAX_SIZE / 2),
+      ),
+    );
+    const fallback = Math.max(
+      0,
+      COMBO_EDITOR_SIZE / 2 - size / 2 + (index % 3) * 16 + Math.floor(index / 3) * 16,
+    );
+    return {
+      packageId: item.packageId,
+      stickerId: item.stickerId,
+      url: lineStickerUrl(item.stickerId),
+      name: item.stickerId,
+      x: item.x ?? fallback,
+      y: item.y ?? fallback,
+      size,
+    };
+  });
+}
+
+/** 送信済みコンビネーションのローカル合成プレビューを CSSTKID とメッセージIDの両方に保存 */
+async function persistCombinationStickerPreview(
+  accountId: string,
+  message: LineMessage | null,
+  placements: CombinationStickerPlacement[],
+): Promise<string | null> {
+  if (!message) return null;
+  try {
+    const dataUrl = await renderCombinationStickerPreview(placements);
+    if (!dataUrl) return null;
+    const meta = (message.contentMetadata ?? null) as Record<string, unknown> | null;
+    const comboId =
+      typeof meta?.CSSTKID === "string" && meta.CSSTKID.trim() ? meta.CSSTKID.trim() : null;
+    if (comboId) setCombinationStickerPreview(accountId, comboId, dataUrl);
+    const messageId = message.id != null ? String(message.id) : "";
+    if (messageId && messageId !== comboId) {
+      setCombinationStickerPreview(accountId, messageId, dataUrl);
+    }
+    return dataUrl;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -172,16 +240,7 @@ function applyReadWatermarkLocal(
 }
 
 function messagePreview(m: Message): string {
-  const isRevoked =
-    m.messageState.startsWith("revoked") ||
-    Boolean(m.revokedSnapshot) ||
-    Boolean(
-      m.history?.length &&
-        m.history.some(
-          (h) => h.state === "normal" || h.state === "edited" || h.contentType === "UNSENT",
-        ),
-    );
-  if (isRevoked) {
+  if (m.messageState.startsWith("revoked")) {
     if (m.revokedSnapshot) return `取り消し済み: ${messagePreview(m.revokedSnapshot)}`;
     const last = m.history
       ? [...m.history].reverse().find((h) => h.state === "normal" || h.state === "edited")
@@ -957,16 +1016,8 @@ export const useStore = create<State>()(
         const { accountId, blockedMids } = get();
         if (!accountId || !items.length) return;
         if (chatId.startsWith("u") && blockedMids.includes(chatId)) return;
-        const placements: CombinationStickerPlacement[] = items.map((item, index) => ({
-          packageId: item.packageId,
-          stickerId: item.stickerId,
-          url: lineStickerUrl(item.stickerId),
-          name: item.stickerId,
-          x: item.x ?? Math.max(0, 40 + index * 18),
-          y: item.y ?? Math.max(0, 40 + index * 18),
-          size: item.size ?? 76,
-        }));
-        const tempId = `pending_cstk_${Date.now()}`;
+        const placements = combinationPlacementsFromItems(items);
+        const tempId = `pending_combo_${Date.now()}`;
         const optimistic: Message = {
           id: tempId,
           chatId,
@@ -993,22 +1044,32 @@ export const useStore = create<State>()(
               return;
             }
             if (res.message) {
+              // 送信レスポンスの実証用ログ（ID・キー名のみ。トークン等は出さない）
+              try {
+                const meta = (res.message.contentMetadata ?? null) as Record<
+                  string,
+                  unknown
+                > | null;
+                console.debug("[vyline] combination sticker sent", {
+                  messageId: res.message.id,
+                  metaKeys: meta ? Object.keys(meta) : null,
+                  csstkId: typeof meta?.CSSTKID === "string" ? meta.CSSTKID : null,
+                });
+              } catch {
+                /* ignore */
+              }
               const contactCache = buildContactCache(get().chats);
               const mapped = mapMessage(res.message, chatId, accountId!, contactCache);
-              let preview = mapped.sticker ?? "";
-              try {
-                const dataUrl = await renderCombinationStickerPreview(placements);
-                if (dataUrl) {
-                  preview = dataUrl;
-                  setCombinationStickerPreview(accountId!, mapped.id, dataUrl);
-                }
-              } catch {
-                if (!preview) preview = lineStickerUrl(items[0]!.stickerId);
-              }
+              // 履歴表示は CSSTKID / メッセージID のどちらでもプレビューを引けるよう両方保存
+              const preview = await persistCombinationStickerPreview(
+                accountId!,
+                res.message,
+                placements,
+              );
               const finalMsg: Message = {
                 ...mapped,
                 kind: "sticker",
-                sticker: preview || mapped.sticker || "🎴",
+                sticker: preview || mapped.sticker || "🧩",
               };
               set((st) => ({
                 messages: st.messages.map((m) => (m.id === tempId ? finalMsg : m)),
@@ -1373,6 +1434,14 @@ export const useStore = create<State>()(
             ok = res.ok;
             confirmed = res.ok ? (res.message ?? null) : null;
           }
+          if (ok && confirmed && intent.kind === "combinationSticker") {
+            // 再送でも送信時と同じくローカルプレビューを保存（mapMessage が CSSTKID/メッセージIDで引ける）
+            await persistCombinationStickerPreview(
+              accountId,
+              confirmed,
+              combinationPlacementsFromItems(intent.items),
+            );
+          }
           if (!ok) {
             markFailed();
             return;
@@ -1651,18 +1720,6 @@ export const useStore = create<State>()(
               for (let i = 0; i < mapped.length; i++) {
                 const m = mapped[i]!;
                 const prev = prevById.get(m.id);
-                const prevRevoked = Boolean(
-                  prev &&
-                    (prev.messageState.startsWith("revoked") ||
-                      prev.revokedSnapshot ||
-                      (prev.history?.length &&
-                        prev.history.some(
-                          (h) =>
-                            h.state === "normal" ||
-                            h.state === "edited" ||
-                            h.contentType === "UNSENT",
-                        ))),
-                );
                 if (m.authorId === "me" && prev?.read && !m.read) {
                   mapped[i] = {
                     ...m,
@@ -1717,19 +1774,8 @@ export const useStore = create<State>()(
                 if (prev?.revokedSnapshot && !m.revokedSnapshot) {
                   mapped[i] = { ...m, revokedSnapshot: prev.revokedSnapshot };
                 }
-                if (prevRevoked && !m.messageState?.startsWith("revoked")) {
-                  const last = prev?.history
-                    ? [...prev.history]
-                        .reverse()
-                        .find((h) => h.state === "normal" || h.state === "edited")
-                    : undefined;
-                  mapped[i] = {
-                    ...m,
-                    messageState: prev?.messageState ?? "revoked-by-self",
-                    history: prev?.history?.length ? prev.history : m.history,
-                    revokedSnapshot: prev?.revokedSnapshot ?? m.revokedSnapshot,
-                    text: prev?.revokedSnapshot?.text ?? last?.text ?? prev?.text ?? m.text,
-                  };
+                if (prev && mapped[i]) {
+                  mapped[i] = mergePreservingComboStickerPreview(prev, mapped[i]);
                 }
               }
               // pending / 送信直後の確定メッセージをサーバ欠落時も残す
@@ -2030,18 +2076,6 @@ export const useStore = create<State>()(
                 if (m.chatId !== chatId) return m;
                 const upd = incomingById.get(m.id);
                 if (!upd) return m;
-                const wasRevoked =
-                  m.messageState.startsWith("revoked") ||
-                  Boolean(m.revokedSnapshot) ||
-                  Boolean(
-                    m.history?.length &&
-                      m.history.some(
-                        (h) =>
-                          h.state === "normal" ||
-                          h.state === "edited" ||
-                          h.contentType === "UNSENT",
-                      ),
-                  );
                 const reactionChanged =
                   JSON.stringify(upd.reactions) !== JSON.stringify(m.reactions);
                 const revokedChanged =
@@ -2055,12 +2089,6 @@ export const useStore = create<State>()(
                     messageReactionCache.delete(m.id);
                   }
                   updated.reactions = upd.reactions;
-                  if (wasRevoked) {
-                    updated.messageState = m.messageState;
-                    updated.history = m.history;
-                    if (m.revokedSnapshot) updated.revokedSnapshot = m.revokedSnapshot;
-                    if (m.text !== undefined) updated.text = m.text;
-                  }
                 }
                 if (revokedChanged) {
                   updated.messageState = upd.messageState;
@@ -2078,7 +2106,7 @@ export const useStore = create<State>()(
                   ];
                   updated.text = undefined;
                 }
-                return updated;
+                return mergePreservingComboStickerPreview(m, updated);
               })
             : st.messages;
           const merged = [...withUpdates, ...fresh].sort((a, b) => a.createdAt - b.createdAt);

--- a/Vyline/apps/desktop/src/utils/combinationStickers.ts
+++ b/Vyline/apps/desktop/src/utils/combinationStickers.ts
@@ -11,6 +11,18 @@ export type CombinationStickerPlacement = CombinationStickerItem & {
   size: number;
 };
 
+/**
+ * コンボエディタの正規座標空間 (240x240)。
+ * backend buildCombinationStickerLayouts が scale = 512 / 240 で
+ * LINE の 512x512 キャンバスへ変換する前提値と同期している。
+ * エディタの表示枠もこのサイズで固定すること。
+ */
+export const COMBO_EDITOR_SIZE = 240;
+
+/** エディタ上でのスタンプ1枚のサイズ範囲 (正規座標系) */
+export const COMBO_ITEM_MIN_SIZE = 48;
+export const COMBO_ITEM_MAX_SIZE = 168;
+
 const STORAGE_KEY = (accountId: string) => `vyline:combinationStickerPreviews:${accountId}`;
 
 function loadPreviewStore(accountId: string): Record<string, string> {
@@ -60,16 +72,28 @@ function loadImage(src: string): Promise<HTMLImageElement> {
 
 export async function renderCombinationStickerPreview(
   items: CombinationStickerPlacement[],
-  canvasSize = 512,
+  targetSize = 360,
 ): Promise<string> {
+  if (items.length === 0) return "";
+  // COMBO_EDITOR_SIZE (240x240) 空間の配置をバウンディングボックスでクロップする。
+  // クロップにより気泡表示 (128px object-contain) でもクラスタが枠を満たし、
+  // 相対的な配置比率は LINE 側のレンダリングと一致する。
+  const minX = Math.min(...items.map((i) => i.x));
+  const minY = Math.min(...items.map((i) => i.y));
+  const maxX = Math.max(...items.map((i) => i.x + i.size));
+  const maxY = Math.max(...items.map((i) => i.y + i.size));
+  const pad = Math.max(8, Math.round(Math.max(maxX - minX, maxY - minY) * 0.08));
+  const w = maxX - minX + pad * 2;
+  const h = maxY - minY + pad * 2;
+  const scale = Math.min(3, Math.max(1, targetSize / Math.max(w, h)));
+
   const canvas = document.createElement("canvas");
-  canvas.width = canvasSize;
-  canvas.height = canvasSize;
+  canvas.width = Math.round(w * scale);
+  canvas.height = Math.round(h * scale);
   const ctx = canvas.getContext("2d");
   if (!ctx) return "";
-  ctx.clearRect(0, 0, canvasSize, canvasSize);
-  ctx.fillStyle = "rgba(0,0,0,0)";
-  ctx.fillRect(0, 0, canvasSize, canvasSize);
+  ctx.scale(scale, scale);
+  ctx.translate(pad - minX, pad - minY);
 
   const loaded = await Promise.all(
     items.map(async (item) => {
@@ -88,12 +112,12 @@ export async function renderCombinationStickerPreview(
     const box = item.size;
     const x = item.x;
     const y = item.y;
-    const scale = Math.min(box / img.naturalWidth, box / img.naturalHeight, 1);
-    const w = img.naturalWidth * scale;
-    const h = img.naturalHeight * scale;
-    const dx = x + (box - w) / 2;
-    const dy = y + (box - h) / 2;
-    ctx.drawImage(img, dx, dy, w, h);
+    const fit = Math.min(box / img.naturalWidth, box / img.naturalHeight, 1);
+    const dw = img.naturalWidth * fit;
+    const dh = img.naturalHeight * fit;
+    const dx = x + (box - dw) / 2;
+    const dy = y + (box - dh) / 2;
+    ctx.drawImage(img, dx, dy, dw, dh);
   }
 
   return canvas.toDataURL("image/png");

--- a/Vyline/apps/desktop/src/utils/lineMedia.ts
+++ b/Vyline/apps/desktop/src/utils/lineMedia.ts
@@ -48,7 +48,7 @@ export function extractStickerId(
   meta: Record<string, string | undefined> | null | undefined,
 ): string | null {
   if (!meta) return null;
-  const id = meta.STKID ?? meta.STICKER_ID ?? meta.stickerId ?? meta.STK_ID;
+  const id = meta.CSSTKID ?? meta.STKID ?? meta.STICKER_ID ?? meta.stickerId ?? meta.STK_ID;
   return id && String(id).length > 0 ? String(id) : null;
 }
 

--- a/docs/analysis/combination-sticker-handoff.md
+++ b/docs/analysis/combination-sticker-handoff.md
@@ -1,0 +1,184 @@
+# コンビネーションスタンプ送信 引き継ぎ書
+
+最終更新: 2026-08-21
+
+## 目的
+
+複数スタンプをドラッグして配置し、LINE のコンビネーションスタンプとして作成・送信・表示する機能を完成させる。
+
+現状は UI 上で複数スタンプを配置できるところまで進んでいるが、**送信後に複数スタンプの組み合わせとして安定して表示・再取得できていない**。送信直後は画像が表示されても、再同期後に `🧩` へ置換される事象が残っている。
+
+## 最重要の未解決症状
+
+- コンビネーション作成領域に複数スタンプを配置できる
+- 送信操作も実装済み
+- 送信直後に一瞬画像が見えることがある
+- その後、履歴更新・再同期・再描画で `🧩` に置換される
+- 「複数スタンプを1つのコンビネーションスタンプとして送信できた」ことは未確認
+
+## 現在の実装経路
+
+### UI
+
+対象: `Vyline/apps/desktop/src/components/sticker-emoji-panel.tsx`
+
+- スタンプ長押しでコンビネーション領域へ追加
+- ドラッグで配置を変更
+- 配置情報 `{ packageId, stickerId, x, y, size }` を送信関数へ渡す
+- 通常のメディアドロップとは MIME type `application/x-vyline-sticker` で分離
+- 対応不可パッケージはドラッグ不可にする実装があるため、判定が全経路で効いているか再確認する
+
+### Desktop store
+
+対象: `Vyline/apps/desktop/src/lib/store.ts`
+
+主な処理:
+
+1. `sendCombinationSticker(chatId, items)` が呼ばれる
+2. 各スタンプからローカル表示用の配置を作る
+3. `api.line.sendCombinationSticker(...)` を呼ぶ
+4. 応答メッセージを `mapMessage(...)` で UI 型へ変換
+5. `renderCombinationStickerPreview(...)` でローカル合成 PNG を作成
+6. `CSSTKID` とメッセージIDにプレビューを保存
+7. 送信後に `refreshMessages(..., { force: true })` を予約
+
+注意: retry 経路にも `combinationSticker` が追加されているが、retry 後の確認済みメッセージにローカルプレビューを再登録する処理は不十分。
+
+### Backend
+
+対象: `Vyline/backend/src/service/lineService.ts`
+
+現在の送信は概ね以下の流れ:
+
+```text
+createCombinationStickerCore(accountId, items)
+  -> Shop.createCombinationSticker(...)
+  -> created.id
+
+sendStickerMessage(...)
+  -> contentMetadata: { CSSTKID: created.id }
+```
+
+対象 API: `Vyline/backend/src/api/line.ts`
+
+- `POST /line/:accountId/combination-stickers`
+- `POST /line/:accountId/send-combination-sticker`
+- `POST /line/:accountId/combination-stickers/can-create`
+- `POST /line/:accountId/combination-stickers/available`
+
+## 直近で入った表示修正
+
+対象: `Vyline/apps/desktop/src/lib/mappers.ts`
+
+コンビネーションの識別子は `contentMetadata.CSSTKID` を使う。
+
+プレビュー取得は次の優先順:
+
+```text
+localStorage の CSSTKID キーに保存された data URL
+  -> lineStickerUrl(CSSTKID)
+  -> 通常スタンプのURL
+  -> 最終的な一般スタンプ fallback
+```
+
+重要な修正済み点:
+
+- 以前は保存キーがメッセージID、取得キーが `CSSTKID` で不一致だった
+- 現在は送信後に `CSSTKID` をキーとして保存するよう変更済み
+- キャッシュ未取得時に即 `🧩` を返さず、`lineStickerUrl(CSSTKID)` を試すよう変更済み
+
+それでも `🧩` が出るため、以下のどれかが残っている可能性が高い。
+
+1. 実際の履歴レスポンスに `CSSTKID` が存在しない、または別名・別階層に入っている
+2. `sendCombinationSticker` のレスポンスに `message` がなく、プレビュー保存処理が実行されていない
+3. 再同期時に `CSSTKID` を含む raw message が別の mapper 経路で失われている
+4. `createCombinationSticker` が作成したIDと、送信メッセージに付与されるIDが異なる
+5. `lineStickerUrl(CSSTKID)` がコンビネーション用画像URLとして有効ではない
+6. `mapMessage` 以外で `sticker: "🧩"` を上書きしている
+
+## 次のAIが最初に行う調査
+
+### 1. raw response を確認する
+
+送信直後と再取得時に、次をログ出力して比較する。
+
+- `res.message.id`
+- `res.message.contentType`
+- `res.message.contentMetadata`
+- `res.message.text`
+- `CSSTKID` の型と値
+- `createCombinationSticker` の戻り値 `created.id`
+
+ログにはトークンや本文全体を出さず、ID・キー名だけを出すこと。
+
+### 2. `🧩` の全代入箇所を確認する
+
+```powershell
+rg -n '🧩|sticker\s*:' Vyline/apps/desktop/src
+```
+
+特に次を確認:
+
+- `Vyline/apps/desktop/src/lib/mappers.ts`
+- `Vyline/apps/desktop/src/lib/store.ts`
+- `Vyline/apps/desktop/src/components/message-bubble.tsx`
+
+### 3. mapper 呼び出し経路を全確認する
+
+現在確認すべき呼び出し箇所:
+
+- 初期 hydrate
+- `refreshMessages`
+- `mergeIncomingMessages`
+- 通常送信の確認済みメッセージ処理
+- コンビネーション送信の確認済みメッセージ処理
+- retry 処理
+
+どの経路でも raw の `CSSTKID` が mapper に渡ることを確認する。
+
+### 4. サーバが返すコンビネーション画像を確認する
+
+次のURLが本当に画像を返すか、ブラウザのNetworkで確認する。
+
+```text
+/api/cdn/line?u=https%3A%2F%2Fstickershop.line-scdn.net%2Fstickershop%2Fv1%2Fsticker%2F{CSSTKID}%2Fandroid%2Fsticker.png
+```
+
+無効なら、Desktop/HAR でコンビネーション用の画像URL形式を探す。`CSSTKID` を通常スタンプIDのURLに流用し続けないこと。
+
+### 5. 作成と送信を分離して検証する
+
+- 作成APIだけ呼び、返された `id` で画像取得できるか
+- 作成済みIDを使って送信できるか
+- 送信メッセージの `contentMetadata` にどのキーが付くか
+- 送信後の履歴で同じキーが残るか
+
+## 受け入れ条件
+
+- 2個以上の対応スタンプを配置して送信できる
+- 対応不可スタンプはドラッグできない
+- 送信後に画像が `🧩` へ変わらない
+- 画面再描画、チャット切替、再同期、アプリ再起動後も表示できる
+- 通常の画像送信欄へスタンプが混入しない
+- LINE側の受信者にもコンビネーションスタンプとして届く
+- 単一スタンプ送信の既存動作を壊さない
+
+## 安全な送信テスト先
+
+実グループ・実友だちへ送信しない。許可されたテスト先のみ:
+
+- グループ: `c1efe9d6cf1848350bc91848a8a29963e`
+- BOT: `u81c530b68cc2efdd36911d214bd5f084`
+
+## 現在のワークツリー注意事項
+
+- 作業ブランチは `codex/hide-profile-details`
+- 既に多数の未コミット変更があるため、無関係な差分を revert しない
+- `docs/analysis/multi-image-send-handoff.md` は複数画像送信の別問題の引き継ぎ書
+- 今回の主題は複数画像ではなく、複数スタンプのコンビネーション送信・表示
+- Desktop の型チェックは成功
+- ルート全体の型チェックは既存の `Vyline/backend/src/service/lineService.ts:1046` の型エラーで停止している
+
+## ひとことで言うと
+
+UI配置と送信API呼び出しは存在するが、**LINEの送信レスポンス・履歴レスポンスに含まれるコンビネーションIDと画像取得方法の実証が不足している**。次は `CSSTKID` の実値を送信直後・履歴再取得後で比較し、Desktop/HARの正しいコンビネーション画像取得経路を確定すること。


### PR DESCRIPTION
## Summary
- ローカル合成プレビューを CSSTKID + メッセージID の両キーで保存し、再同期・リトライ後も置換されないよう修正
- mapper はキャッシュ未取得時に即プレースホルダを返さず lineStickerUrl(CSSTKID) をフォールバック使用

## Test
- bun run typecheck / lint / bun test (190 pass) OK

※ 送信実機テスト(うがうがうー)は夜間検証で実施、結果をこのPRに追記します
