### PR TITLE
feat: multi-image batch send via OBS reqseq chain

### DIFF
--- a/Vyline/apps/desktop/src/components/chat-area.tsx
+++ b/Vyline/apps/desktop/src/components/chat-area.tsx
@@ -46,6 +46,7 @@ type MsgRow =
       key: string;
       kind: "msg";
       message: Message;
+      mediaGroup?: Message[];
       index: number;
       sameAuthorAsPrev: boolean;
       sameAuthorAsNext: boolean;
@@ -56,6 +57,21 @@ type MsgRow =
       highlight?: string;
     };
 
+function canGroupImageMessage(message: Message): boolean {
+  return message.kind === "image" && Boolean(message.imageSrc) && !message.replyToId;
+}
+
+function shouldGroupAdjacentImages(left: Message, right: Message): boolean {
+  return (
+    canGroupImageMessage(left) &&
+    canGroupImageMessage(right) &&
+    left.authorId === right.authorId &&
+    left.chatId === right.chatId &&
+    dayLabel(left.createdAt) === dayLabel(right.createdAt) &&
+    Math.abs(right.createdAt - left.createdAt) <= 30_000
+  );
+}
+
 export function ChatArea() {
   const activeChatId = useStore((s) => s.activeChatId);
   const chats = useStore((s) => s.chats);
@@ -65,7 +81,6 @@ export function ChatArea() {
   const profileOpen = useStore((s) => s.profileDrawerOpen);
   const setProfileDrawer = useStore((s) => s.setProfileDrawer);
   const streamerMode = useStore((s) => s.settings.streamerMode);
-  const showBackground = useStore((s) => s.settings.showBackground);
   const theme = useStore((s) => s.theme);
   const toggleMute = useStore((s) => s.toggleMute);
   const memberProfile = useStore((s) => s.memberProfile);
@@ -160,40 +175,57 @@ export function ChatArea() {
     let lastDay = "";
     const searching = search.open && search.q.trim().length > 0;
     const q = search.q.trim();
-    chatMessages.forEach((m, i) => {
+    for (let i = 0; i < chatMessages.length; i++) {
+      const m = chatMessages[i]!;
       const dl = dayLabel(m.createdAt);
       if (dl !== lastDay) {
         lastDay = dl;
         out.push({ key: `day-${m.id}`, item: { key: `day-${m.id}`, kind: "day", label: dl } });
       }
       const prev = chatMessages[i - 1];
+      const mediaGroup = canGroupImageMessage(m) ? [m] : undefined;
+      if (mediaGroup) {
+        while (
+          i + 1 < chatMessages.length &&
+          shouldGroupAdjacentImages(mediaGroup[mediaGroup.length - 1]!, chatMessages[i + 1]!)
+        ) {
+          mediaGroup.push(chatMessages[i + 1]!);
+          i++;
+        }
+      }
+      const lastInRow = mediaGroup?.[mediaGroup.length - 1] ?? m;
       const next = chatMessages[i + 1];
       const sameAuthorAsNext =
-        next && next.authorId === m.authorId && dayLabel(next.createdAt) === dl;
+        next && next.authorId === lastInRow.authorId && dayLabel(next.createdAt) === dl;
       const sameAuthorAsPrev =
         prev && prev.authorId === m.authorId && dayLabel(prev.createdAt) === lastDay;
+      const groupIds = mediaGroup?.map((item) => item.id) ?? [m.id];
       out.push({
         key: `msg-${m.id}`,
         item: {
           key: `msg-${m.id}`,
           kind: "msg",
           message: m,
+          mediaGroup: mediaGroup && mediaGroup.length > 1 ? mediaGroup : undefined,
           index: i,
           sameAuthorAsPrev: Boolean(sameAuthorAsPrev),
           sameAuthorAsNext: Boolean(sameAuthorAsNext),
-          isMatch: matches.includes(m.id),
-          isActive: m.id === activeMatchId,
-          flash: m.id === highlightMessageId,
+          isMatch: groupIds.some((id) => matches.includes(id)),
+          isActive: groupIds.includes(activeMatchId ?? ""),
+          flash: groupIds.includes(highlightMessageId ?? ""),
           searching,
           highlight: searching ? q : undefined,
         },
       });
-    });
+    }
     return out;
   }, [chatMessages, matches, search.open, search.q, activeMatchId, highlightMessageId]);
 
   const estimateMsgHeight = useCallback((row: MsgRow): number => {
     if (row.kind === "day") return 40;
+    if (row.mediaGroup && row.mediaGroup.length > 1) {
+      return row.mediaGroup.length <= 2 ? 210 : 300;
+    }
     const m = row.message!;
     if (m.kind === "sticker") return 160;
     if (m.kind === "image" || m.kind === "video") return 320;
@@ -494,78 +526,60 @@ export function ChatArea() {
         })()}
 
         {/* messages */}
-        {(() => {
-          const friendBg =
-            showBackground && chat && chat.type === "friend" && !chat.isSelf && chat.backgroundUrl
-              ? chat.backgroundUrl
-              : undefined;
-          return (
-            <div
-              ref={containerRef}
-              onScroll={onScroll}
-              onContextMenu={(e) => {
-                e.preventDefault();
-                setPanel({ x: e.clientX, y: e.clientY });
-              }}
-              className="vy-scroll vy-chat-surface vy-chat-messages flex-1 overflow-y-auto px-3 py-4 md:px-6"
-              data-pattern={theme.pattern}
-              data-image={friendBg || theme.chatImage ? "" : undefined}
-              style={
-                friendBg
-                  ? {
-                      backgroundImage: `linear-gradient(color-mix(in oklab, ${theme.chatBg} 62%, transparent), color-mix(in oklab, ${theme.chatBg} 62%, transparent)), url(${friendBg})`,
-                    }
-                  : undefined
-              }
-            >
-              <div className="mx-auto flex w-full max-w-3xl flex-col">
-                <div className="mb-4 flex justify-center">
-                  <span className="rounded-xl bg-[color-mix(in_oklab,var(--vy-text)_10%,transparent)] px-4 py-2 text-center text-xs leading-relaxed text-[var(--vy-text-dim)]">
-                    {chat.type === "group"
-                      ? "▲ ここがトークの一番上です"
-                      : "▲ ここから会話が始まります"}
+        <div
+          ref={containerRef}
+          onScroll={onScroll}
+          onContextMenu={(e) => {
+            e.preventDefault();
+            setPanel({ x: e.clientX, y: e.clientY });
+          }}
+          className="vy-scroll vy-chat-surface vy-chat-messages flex-1 overflow-y-auto px-3 py-4 md:px-6"
+          data-pattern={theme.pattern}
+          data-image={theme.chatImage ? "" : undefined}
+        >
+          <div className="mx-auto flex w-full max-w-3xl flex-col">
+            <div className="mb-4 flex justify-center">
+              <span className="rounded-xl bg-[color-mix(in_oklab,var(--vy-text)_10%,transparent)] px-4 py-2 text-center text-xs leading-relaxed text-[var(--vy-text-dim)]">
+                {chat.type === "group"
+                  ? "▲ ここがトークの一番上です"
+                  : "▲ ここから会話が始まります"}
+              </span>
+            </div>
+            {topSpacer > 0 && <div style={{ height: topSpacer }} aria-hidden />}
+            {visibleRows.map(({ key, item }) =>
+              item.kind === "day" ? (
+                <div key={key} ref={(el) => measure(key, el)} className="my-3 flex justify-center">
+                  <span className="rounded-full bg-[color-mix(in_oklab,var(--vy-text)_12%,transparent)] px-3 py-1 text-[0.7rem] font-medium text-[var(--vy-text)] backdrop-blur">
+                    {item.label}
                   </span>
                 </div>
-                {topSpacer > 0 && <div style={{ height: topSpacer }} aria-hidden />}
-                {visibleRows.map(({ key, item }) =>
-                  item.kind === "day" ? (
-                    <div
-                      key={key}
-                      ref={(el) => measure(key, el)}
-                      className="my-3 flex justify-center"
-                    >
-                      <span className="rounded-full bg-[color-mix(in_oklab,var(--vy-text)_12%,transparent)] px-3 py-1 text-[0.7rem] font-medium text-[var(--vy-text)] backdrop-blur">
-                        {item.label}
-                      </span>
-                    </div>
-                  ) : (
-                    <div
-                      key={key}
-                      id={key}
-                      ref={(el) => measure(key, el)}
-                      className={cnRow(
-                        item.searching,
-                        item.isMatch,
-                        item.isActive,
-                        item.sameAuthorAsPrev,
-                        item.flash,
-                      )}
-                    >
-                      <MessageBubble
-                        message={item.message}
-                        chat={chat}
-                        showAvatar={!item.sameAuthorAsNext}
-                        showName={!item.sameAuthorAsPrev}
-                        highlight={item.searching ? (item.highlight as string) : undefined}
-                      />
-                    </div>
-                  ),
-                )}
-                {bottomSpacer > 0 && <div style={{ height: bottomSpacer }} aria-hidden />}
-              </div>
-            </div>
-          );
-        })()}
+              ) : (
+                <div
+                  key={key}
+                  id={key}
+                  ref={(el) => measure(key, el)}
+                  className={cnRow(
+                    item.searching,
+                    item.isMatch,
+                    item.isActive,
+                    item.sameAuthorAsPrev,
+                    item.flash,
+                  )}
+                >
+                  <MessageBubble
+                    message={item.message}
+                    mediaGroup={item.mediaGroup}
+                    chat={chat}
+                    showAvatar={!item.sameAuthorAsNext}
+                    showName={!item.sameAuthorAsPrev}
+                    highlight={item.searching ? (item.highlight as string) : undefined}
+                  />
+                </div>
+              ),
+            )}
+            {bottomSpacer > 0 && <div style={{ height: bottomSpacer }} aria-hidden />}
+          </div>
+        </div>
 
         {/* input */}
         {callHint && (

--- a/Vyline/apps/desktop/src/components/message-bubble.tsx
+++ b/Vyline/apps/desktop/src/components/message-bubble.tsx
@@ -453,12 +453,14 @@ export const MessageBubble = memo(
     showAvatar,
     showName,
     highlight,
+    mediaGroup,
   }: {
     message: Message;
     chat: Chat;
     showAvatar: boolean;
     showName: boolean;
     highlight?: string;
+    mediaGroup?: Message[];
   }) {
     const isMe = message.authorId === "me";
     const settings = useStore((s) => s.settings);
@@ -485,10 +487,12 @@ export const MessageBubble = memo(
     const [history, setHistory] = useState<NonNullable<Message["history"]>>([]);
     const [historyLoading, setHistoryLoading] = useState(false);
     const [lightbox, setLightbox] = useState(false);
+    const [lightboxMedia, setLightboxMedia] = useState<Message | null>(null);
     const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
     const longPressFired = useRef(false);
 
     const author = chat.members?.find((m) => m.id === message.authorId);
+    const mediaItems = mediaGroup?.filter((item) => item.kind === "image" && item.imageSrc) ?? [];
     const repliedAuthor =
       replied?.authorId === "me"
         ? self.name
@@ -1160,7 +1164,49 @@ export const MessageBubble = memo(
               }}
             >
               {replyQuote}
-              {(message.kind === "image" || message.kind === "video") &&
+              {mediaItems.length > 1 && !streamerMode && (
+                <div
+                  className={cn(
+                    "grid overflow-hidden rounded-xl",
+                    mediaItems.length === 2 ? "grid-cols-2" : "grid-cols-3",
+                  )}
+                >
+                  {mediaItems.map((item) => (
+                    <button
+                      key={item.id}
+                      type="button"
+                      className="group relative aspect-square overflow-hidden bg-black/5"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setLightboxMedia(item);
+                        setLightbox(true);
+                      }}
+                      aria-label="画像を拡大"
+                    >
+                      <img
+                        src={item.imageSrc}
+                        alt="送信された画像"
+                        onError={hideBrokenMedia}
+                        className="h-full w-full object-cover transition-opacity group-hover:opacity-95"
+                      />
+                    </button>
+                  ))}
+                </div>
+              )}
+              {mediaItems.length > 1 && streamerMode && (
+                <div
+                  className={cn(
+                    "grid gap-1",
+                    mediaItems.length === 2 ? "grid-cols-2" : "grid-cols-3",
+                  )}
+                >
+                  {mediaItems.map((item) => (
+                    <SpoilerMedia key={item.id} src={item.imageSrc!} alt="送信された画像" />
+                  ))}
+                </div>
+              )}
+              {mediaItems.length <= 1 &&
+                (message.kind === "image" || message.kind === "video") &&
                 message.imageSrc &&
                 (streamerMode ? (
                   <SpoilerMedia
@@ -1174,6 +1220,7 @@ export const MessageBubble = memo(
                     className="group relative block overflow-hidden rounded-xl text-left"
                     onClick={(e) => {
                       e.stopPropagation();
+                      setLightboxMedia(message);
                       setLightbox(true);
                     }}
                     aria-label={message.kind === "video" ? "動画を拡大" : "画像を拡大"}
@@ -1202,10 +1249,10 @@ export const MessageBubble = memo(
                     )}
                   </button>
                 ))}
-              {message.kind === "audio" && message.audioSrc && (
+              {mediaItems.length <= 1 && message.kind === "audio" && message.audioSrc && (
                 <AudioBubble src={message.audioSrc} seconds={message.audioSeconds} />
               )}
-              {message.kind === "text" && (
+              {mediaItems.length <= 1 && message.kind === "text" && (
                 <div>
                   {showOriginal && message.originalText && (
                     <div className="mb-1 flex items-center justify-between border-b border-current/15 pb-1 text-[0.65rem] opacity-70">
@@ -1273,10 +1320,10 @@ export const MessageBubble = memo(
             onClose={() => setEditing(false)}
           />
         )}
-        {lightbox && message.imageSrc && (
+        {lightbox && (lightboxMedia?.imageSrc ?? message.imageSrc) && (
           <MediaLightbox
-            src={message.imageSrc}
-            kind={message.kind === "video" ? "video" : "image"}
+            src={(lightboxMedia?.imageSrc ?? message.imageSrc)!}
+            kind={(lightboxMedia?.kind ?? message.kind) === "video" ? "video" : "image"}
             onClose={() => setLightbox(false)}
           />
         )}

--- a/Vyline/apps/desktop/src/components/message-input.tsx
+++ b/Vyline/apps/desktop/src/components/message-input.tsx
@@ -106,58 +106,6 @@ async function blobToBase64(blob: Blob): Promise<string> {
   return btoa(binary);
 }
 
-async function composeImageGrid(files: Blob[]): Promise<Blob> {
-  const bitmaps = await Promise.all(files.map((file) => createImageBitmap(file)));
-  try {
-    const count = bitmaps.length;
-    const cols = count <= 1 ? 1 : count === 2 ? 2 : count <= 4 ? 2 : count <= 9 ? 3 : 4;
-    const rows = Math.ceil(count / cols);
-    const candidates = [720, 640, 512, 384];
-
-    for (const cellSize of candidates) {
-      const canvas = document.createElement("canvas");
-      canvas.width = cols * cellSize;
-      canvas.height = rows * cellSize;
-      const ctx = canvas.getContext("2d");
-      if (!ctx) continue;
-
-      ctx.fillStyle = "#ffffff";
-      ctx.fillRect(0, 0, canvas.width, canvas.height);
-
-      for (let index = 0; index < bitmaps.length; index++) {
-        const bitmap = bitmaps[index]!;
-        const col = index % cols;
-        const row = Math.floor(index / cols);
-        const slotX = col * cellSize;
-        const slotY = row * cellSize;
-        const padding = Math.max(12, Math.round(cellSize * 0.04));
-        const slotWidth = cellSize - padding * 2;
-        const slotHeight = cellSize - padding * 2;
-        const scale = Math.min(slotWidth / bitmap.width, slotHeight / bitmap.height);
-        const drawWidth = Math.max(1, Math.round(bitmap.width * scale));
-        const drawHeight = Math.max(1, Math.round(bitmap.height * scale));
-        const drawX = slotX + Math.round((cellSize - drawWidth) / 2);
-        const drawY = slotY + Math.round((cellSize - drawHeight) / 2);
-        ctx.drawImage(bitmap, drawX, drawY, drawWidth, drawHeight);
-      }
-
-      const blob = await new Promise<Blob | null>((resolve) =>
-        canvas.toBlob(resolve, "image/jpeg", 0.9),
-      );
-      if (blob && blob.size > 0 && blob.size <= 11_000_000) {
-        return blob;
-      }
-      if (blob && blob.size > 0 && cellSize === candidates.at(-1)) {
-        return blob;
-      }
-    }
-
-    throw new Error("画像の結合に失敗しました");
-  } finally {
-    for (const bitmap of bitmaps) bitmap.close();
-  }
-}
-
 export function MessageInput({ chatId }: { chatId: string }) {
   const draft = useStore((s) => s.drafts[chatId] ?? "");
   const setDraft = useStore((s) => s.setDraft);
@@ -408,61 +356,34 @@ export function MessageInput({ chatId }: { chatId: string }) {
     setSendingMediaBatch(true);
     try {
       const highQuality = useStore.getState().settings.highQualityImages;
-      const allImages = pendingMedia.every((item) => item.kind === "image");
-
-      if (allImages && pendingMedia.length > 1) {
-        const preparedImages = await Promise.all(
-          pendingMedia.map(async (item) => {
-            const prepared = highQuality
-              ? { blob: item.file, mime: item.file.type || "image/jpeg" }
-              : await compressImageFile(item.file);
-            if (!prepared.mime.startsWith("image/")) {
-              throw new Error(`画像として扱えないファイルです: ${item.file.name}`);
-            }
-            return prepared.blob;
-          }),
-        );
-        const mergedBlob = await composeImageGrid(preparedImages);
-        const dataBase64 = await blobToBase64(mergedBlob);
-        const res = await api.line.sendMedia(accountId, chatId, dataBase64, {
-          mimeType: "image/jpeg",
-          filename: `vyline-images-${pendingMedia.length}.jpg`,
-          mediaType: "image",
-        });
-        if (!res.ok) {
-          window.alert(res.error ?? "画像のまとめ送信に失敗しました");
-          return;
-        }
-      } else {
-        const items = await Promise.all(
-          pendingMedia.map(async (item) => {
-            const prepared =
-              item.kind === "video"
+      const items = await Promise.all(
+        pendingMedia.map(async (item) => {
+          const prepared =
+            item.kind === "video"
+              ? { blob: item.file, mime: item.file.type || "application/octet-stream" }
+              : highQuality
                 ? { blob: item.file, mime: item.file.type || "application/octet-stream" }
-                : highQuality
-                  ? { blob: item.file, mime: item.file.type || "application/octet-stream" }
-                  : await compressImageFile(item.file);
-            if (prepared.blob.size > 11_000_000) {
-              throw new Error(
-                prepared.blob === item.file
-                  ? `ファイルが大きすぎます: ${item.file.name}`
-                  : `画像が大きすぎます（圧縮後も 11MB 超）: ${item.file.name}`,
-              );
-            }
-            const dataBase64 = await blobToBase64(prepared.blob);
-            return {
-              dataBase64,
-              mimeType: prepared.mime,
-              filename: item.file.name || (item.kind === "video" ? "video.mp4" : "image.jpg"),
-              mediaType: item.kind,
-            };
-          }),
-        );
-        const res = await api.line.sendMediaBatch(accountId, chatId, items);
-        if (!res.ok) {
-          window.alert(res.error ?? "まとめて送信に失敗しました");
-          return;
-        }
+                : await compressImageFile(item.file);
+          if (prepared.blob.size > 11_000_000) {
+            throw new Error(
+              prepared.blob === item.file
+                ? `ファイルが大きすぎます: ${item.file.name}`
+                : `画像が大きすぎます（圧縮後も 11MB 超）: ${item.file.name}`,
+            );
+          }
+          const dataBase64 = await blobToBase64(prepared.blob);
+          return {
+            dataBase64,
+            mimeType: prepared.mime,
+            filename: item.file.name || (item.kind === "video" ? "video.mp4" : "image.jpg"),
+            mediaType: item.kind,
+          };
+        }),
+      );
+      const res = await api.line.sendMediaBatch(accountId, chatId, items);
+      if (!res.ok) {
+        window.alert(res.error ?? "まとめて送信に失敗しました");
+        return;
       }
       clearPendingMedia();
       await useStore.getState().refreshMessages(chatId, { force: true });

--- a/Vyline/backend/src/api/line.ts
+++ b/Vyline/backend/src/api/line.ts
@@ -39,6 +39,7 @@ import {
   fetchMessageMedia,
   sendMessage,
   sendMedia,
+  sendMediaBatch,
   sendSticker,
   canCreateCombinationSticker,
   createCombinationSticker,
@@ -689,23 +690,34 @@ lineRouter.post("/:accountId/send-media-batch", async (c) => {
   }
 
   try {
-    let count = 0;
-    for (const item of body.items) {
-      if (!item?.dataBase64) continue;
+    const items = body.items
+      .filter((item): item is NonNullable<typeof item> & { dataBase64: string } =>
+        Boolean(item?.dataBase64),
+      )
+      .map((item) => {
+        const opts: {
+          dataBase64: string;
+          mimeType?: string;
+          filename?: string;
+          mediaType?: "image" | "video" | "audio" | "file" | "gif";
+        } = { dataBase64: item.dataBase64 };
+        if (item.mimeType) opts.mimeType = item.mimeType;
+        if (item.filename) opts.filename = item.filename;
+        if (item.mediaType) opts.mediaType = item.mediaType;
+        return opts;
+      });
+
+    if (items.length === 0) {
+      return c.json({ ok: false, error: "items required" }, 400);
+    }
+
+    for (const item of items) {
       if (item.dataBase64.length > 12_000_000) {
         return c.json({ ok: false, error: "file too large" }, 413);
       }
-      const opts: {
-        mimeType?: string;
-        filename?: string;
-        mediaType?: "image" | "video" | "audio" | "file" | "gif";
-      } = {};
-      if (item.mimeType) opts.mimeType = item.mimeType;
-      if (item.filename) opts.filename = item.filename;
-      if (item.mediaType) opts.mediaType = item.mediaType;
-      await sendMedia(accountId, body.chatMid, item.dataBase64, opts);
-      count++;
     }
+
+    const count = await sendMediaBatch(accountId, body.chatMid, items);
     return c.json({ ok: true, count });
   } catch (err) {
     return handleError(err, c);

--- a/Vyline/backend/src/service/lineService.ts
+++ b/Vyline/backend/src/service/lineService.ts
@@ -151,7 +151,7 @@ export function backgroundObjToUrl(objId: string | undefined | null): string | n
   if (!objId || !String(objId).trim()) return null;
   const s = String(objId).trim();
   if (s.startsWith("https://") || s.startsWith("http://")) return s;
-  return `https://obs.line-scdn.net/myhome/h/${s}`;
+  return `https://obs.line-apps.com/r/myhome/h/${s}`;
 }
 
 // ─── プロフィール背景（他ユーザー）────────────────
@@ -221,7 +221,17 @@ const HOME_BACKGROUND_CACHE_MS = 30 * 60 * 1000; // 30 分
 const HOME_BACKGROUND_RPC_TIMEOUT_MS = 6_000;
 
 /**
- * VOOM ホームプロフィール API からユーザーのプロフィール背景 URL を取得する。
+ * 相手のプロフィール背景（カバー画像）URL を取得する。
+ *
+ * 実データは HOME チャネルの home/cover API が正解（live-verified 2026-08-21）:
+ *   GET gw.line.naver.jp/hm/api/v1/home/cover.json?homeId=<mid>
+ *   ヘッダ X-Line-ChannelToken = issueChannelToken(HOME).channelAccessToken
+ * レスポンス:
+ *   { code:0, result:{ coverObsInfo:{ objectId, obsNamespace:"c", serviceName:"myhome" }, isDefaultCover:false } }
+ * 画像 URL: https://obs.line-apps.com/r/myhome/<obsNamespace>/<objectId>
+ *
+ * 注: ルーティングは MYHOME_RENEWAL(/hm)。HOMEAPI(/ma) や MYHOME(/mh) は 401/404 になる。
+ * チャネルトークンは voom.call("HOME", ...) が自動で発行する(channelAccessToken を使用)。
  * 失敗時は null（タイムアウト・権限なし・未設定などは静かに握りつぶす）。
  */
 async function fetchHomeProfileBackgroundUrl(
@@ -232,32 +242,37 @@ async function fetchHomeProfileBackgroundUrl(
   const key = `${accountId}:${targetMid}`;
   const cached = homeBackgroundCache.get(key);
   if (cached && Date.now() - cached.at < HOME_BACKGROUND_CACHE_MS) {
-    return cached.url;
+    return cached.url || null;
   }
   try {
     const client = requireClient(accountId);
-    const fetchHomeBackground = async (path: string, label: string): Promise<string | null> => {
-      const res = await withTimeout(
-        (async () => {
-          const r = await client.voomRest<unknown>({
-            routing: "HOMEAPI",
-            path: `${path}?homeId=${encodeURIComponent(targetMid)}`,
-          });
-          return r;
-        })(),
-        HOME_BACKGROUND_RPC_TIMEOUT_MS,
-        label,
-      );
-      const result = (res as { result?: unknown })?.result;
-      return result ? extractBackgroundUrl(result) : null;
-    };
-    const url =
-      (await fetchHomeBackground("/api/v1/home/profile.json", "homeProfile")) ??
-      (await fetchHomeBackground("/api/v1/home/cover.json", "homeCover"));
-    homeBackgroundCache.set(key, { at: Date.now(), url: url ?? "" });
-    return url;
+    const res = await withTimeout(
+      client.voom.call("HOME", {
+        routing: "MYHOME_RENEWAL",
+        path: `/api/v1/home/cover.json?homeId=${encodeURIComponent(targetMid)}`,
+      }),
+      HOME_BACKGROUND_RPC_TIMEOUT_MS,
+      "homeCover",
+    );
+    const result = (res as { result?: unknown }).result as
+      | {
+          coverObsInfo?: { objectId?: string; obsNamespace?: string };
+          isDefaultCover?: boolean;
+        }
+      | null
+      | undefined;
+    const info = result?.coverObsInfo;
+    // isDefaultCover=true は LINE の既定カバー（未設定）とみなし表示しない
+    if (info?.objectId && result?.isDefaultCover !== true) {
+      const ns = info.obsNamespace || "c";
+      const url = `https://obs.line-apps.com/r/myhome/${ns}/${info.objectId}`;
+      homeBackgroundCache.set(key, { at: Date.now(), url });
+      return url;
+    }
+    homeBackgroundCache.set(key, { at: Date.now(), url: "" });
+    return null;
   } catch (err) {
-    log.debug({ accountId, targetMid, err }, "homeProfile background fetch failed");
+    log.debug({ accountId, targetMid, err }, "home cover background fetch failed");
     homeBackgroundCache.set(key, { at: Date.now(), url: "" });
     return null;
   }
@@ -1043,7 +1058,7 @@ export async function fetchProfile(accountId: string): Promise<LineProfile> {
       musicProfile: String(raw.musicProfile ?? ""),
       videoProfile: String(raw.videoProfile ?? ""),
       profileId: String(raw.profileId ?? ""),
-      backgroundUrl: raw.backgroundUrl || undefined,
+      backgroundUrl: raw.backgroundUrl || extractBackgroundUrl(raw) || undefined,
       birthday,
       ...(premium ? { premium } : {}),
     };
@@ -1908,7 +1923,11 @@ async function fetchContactProfileInner(
       const raw = await resolveUserContactV3Like(client, targetMid);
       if (!raw) return null;
       const profile = mapContactV3Like(raw, targetMid);
-      // プロフィール背景は homeProfile API から（別途・短タイムアウト・失敗許容）
+      // getProfile / contact raw に背景が入ることがあるのでまずそこを優先する。
+      const rawBackground = extractBackgroundUrl(raw);
+      if (rawBackground) profile.backgroundUrl = rawBackground;
+
+      // プロフィール背景は homeProfile API も別途試す（失敗許容の保険）
       try {
         const bg = await fetchHomeProfileBackgroundUrl(accountId, targetMid);
         if (bg) profile.backgroundUrl = bg;
@@ -4049,10 +4068,64 @@ export async function sendMessage(
 }
 
 export type MediaSendType = "image" | "video" | "audio" | "file" | "gif";
+export type MediaBatchItem = {
+  dataBase64: string;
+  mimeType?: string;
+  filename?: string;
+  mediaType?: MediaSendType;
+};
 
 /** スクショ／画像など E2EE メディア送信 */
 /** メディア送信は E2EE 鍵整備 + OBS アップロード + プレビューで時間がかかるため通常より長め */
 const MEDIA_SEND_TIMEOUT_MS = 90_000;
+const MEDIA_FLOW_REQSEQ = 1;
+const mediaFlowCache = new Map<string, { flowMap: Record<string, number>; expiresAt: number }>();
+
+function mediaContentTypeNumber(mediaType: MediaSendType): number {
+  if (mediaType === "video") return 2;
+  if (mediaType === "audio") return 3;
+  if (mediaType === "file") return 14;
+  return 1;
+}
+
+async function determinePlainMediaFlow(
+  client: ReturnType<typeof requireClient>,
+  accountId: string,
+  chatMid: string,
+  mediaTypes: MediaSendType[],
+): Promise<boolean> {
+  const now = Date.now();
+  const cached = mediaFlowCache.get(chatMid);
+  let flowMap = cached && cached.expiresAt > now ? cached.flowMap : undefined;
+  if (!flowMap) {
+    try {
+      const res = await client.base.talk.determineMediaMessageFlow({
+        request: { chatMid },
+      });
+      flowMap = Object.fromEntries(
+        Object.entries(res.flowMap ?? {}).map(([key, value]) => [String(key), Number(value)]),
+      );
+      const ttl =
+        typeof res.cacheTtlMillis === "bigint"
+          ? Number(res.cacheTtlMillis)
+          : Number(res.cacheTtlMillis ?? 0);
+      mediaFlowCache.set(chatMid, {
+        flowMap,
+        expiresAt: now + Math.max(60_000, Math.min(ttl || 0, 6 * 60 * 60 * 1000)),
+      });
+      log.info({ accountId, chatMid, flowMap }, "media message flow determined");
+    } catch (err) {
+      log.warn(
+        { accountId, chatMid, err: err instanceof Error ? err.message : String(err) },
+        "determineMediaMessageFlow failed",
+      );
+      return false;
+    }
+  }
+  return mediaTypes.every(
+    (type) => flowMap[String(mediaContentTypeNumber(type))] === MEDIA_FLOW_REQSEQ,
+  );
+}
 
 export async function sendMedia(
   accountId: string,
@@ -4083,27 +4156,6 @@ export async function sendMedia(
         log.warn({ accountId, err }, "E2EE ensure before media send failed");
       }
 
-      // グループは既存の共有鍵があれば E2EE、無ければ plain（uploadObjTalk）で送る。
-      // 鍵が無いのに勝手に新規登録すると本家クライアントと不整合になり画像が見えなくなるため、
-      // 新規 register はしない（テキストは plain フォールバックで問題ない）
-      let plainMode = noE2eePeers.has(chatMid);
-      if ((chatMid.startsWith("c") || chatMid.startsWith("r")) && !plainMode) {
-        try {
-          await ensureGroupE2EEKey(client, chatMid);
-          if (groupKeyWarmFailed.has(chatMid)) {
-            groupKeyWarmFailed.delete(chatMid);
-            await ensureGroupKeyReadyForSend(client, accountId, chatMid);
-          }
-        } catch (err) {
-          log.warn(
-            { accountId, chatMid, err: err instanceof Error ? err.message : String(err) },
-            "group E2EE key setup failed — sending media as plain",
-          );
-          plainMode = true;
-        }
-        plainMode = plainMode || noE2eePeers.has(chatMid);
-      }
-
       const mime = opts?.mimeType ?? "image/png";
       const mediaType: MediaSendType =
         opts?.mediaType ??
@@ -4124,6 +4176,32 @@ export async function sendMedia(
         (mediaType === "image" || mediaType === "gif"
           ? `screenshot.${mime.includes("jpeg") ? "jpg" : "png"}`
           : "file.bin");
+
+      // Desktop 準拠: REFRESH_MEDIA_FLOW を待たず、送信前にメディア flow を確認する。
+      // flow=1 は OBS /r/talk/m/reqseq でサーバー側に message を作らせる。
+      let plainMode =
+        noE2eePeers.has(chatMid) ||
+        (await determinePlainMediaFlow(client, accountId, chatMid, [mediaType]));
+
+      // グループは既存の共有鍵があれば E2EE、無ければ plain（uploadObjTalk）で送る。
+      // 鍵が無いのに勝手に新規登録すると本家クライアントと不整合になり画像が見えなくなるため、
+      // 新規 register はしない（テキストは plain フォールバックで問題ない）
+      if ((chatMid.startsWith("c") || chatMid.startsWith("r")) && !plainMode) {
+        try {
+          await ensureGroupE2EEKey(client, chatMid);
+          if (groupKeyWarmFailed.has(chatMid)) {
+            groupKeyWarmFailed.delete(chatMid);
+            await ensureGroupKeyReadyForSend(client, accountId, chatMid);
+          }
+        } catch (err) {
+          log.warn(
+            { accountId, chatMid, err: err instanceof Error ? err.message : String(err) },
+            "group E2EE key setup failed — sending media as plain",
+          );
+          plainMode = true;
+        }
+        plainMode = plainMode || noE2eePeers.has(chatMid);
+      }
 
       const tryUpload = async () => {
         await client.base.obs.uploadMediaByE2EE({
@@ -4228,6 +4306,231 @@ export async function sendMedia(
   );
 }
 
+export async function sendMediaBatch(
+  accountId: string,
+  chatMid: string,
+  items: MediaBatchItem[],
+): Promise<number> {
+  if (chatMid.startsWith("u")) {
+    const blocked = await fetchBlockedContactIds(accountId);
+    if (blocked.includes(chatMid)) {
+      log.info({ accountId, chatMid }, "sendMediaBatch blocked: user is blocked");
+      return 0;
+    }
+  }
+
+  return runSendRpc(
+    accountId,
+    async () => {
+      const client = requireClient(accountId);
+      await resolveMyMid(client, accountId);
+      try {
+        await ensureE2EEIdentityCached(client, accountId);
+      } catch (err) {
+        log.warn({ accountId, err }, "E2EE ensure before media batch send failed");
+      }
+
+      const batchMediaTypes = items.map((item) => {
+        const mime = item.mimeType ?? "image/png";
+        return (
+          item.mediaType ??
+          (mime.startsWith("video/")
+            ? "video"
+            : mime.startsWith("audio/")
+              ? "audio"
+              : mime === "image/gif"
+                ? "gif"
+                : mime.startsWith("image/")
+                  ? "image"
+                  : "file")
+        );
+      });
+      let plainMode =
+        noE2eePeers.has(chatMid) ||
+        (await determinePlainMediaFlow(client, accountId, chatMid, batchMediaTypes));
+      if ((chatMid.startsWith("c") || chatMid.startsWith("r")) && !plainMode) {
+        try {
+          await ensureGroupE2EEKey(client, chatMid);
+          if (groupKeyWarmFailed.has(chatMid)) {
+            groupKeyWarmFailed.delete(chatMid);
+            await ensureGroupKeyReadyForSend(client, accountId, chatMid);
+          }
+        } catch (err) {
+          log.warn(
+            { accountId, chatMid, err: err instanceof Error ? err.message : String(err) },
+            "group E2EE key setup failed — sending media batch as plain",
+          );
+          plainMode = true;
+        }
+        plainMode = plainMode || noE2eePeers.has(chatMid);
+      }
+
+      if (plainMode) {
+        let previousMessageId: string | undefined;
+        let count = 0;
+        for (let i = 0; i < items.length; i++) {
+          const item = items[i]!;
+          const mime = item.mimeType ?? "image/png";
+          const mediaType = batchMediaTypes[i] ?? "image";
+          const binary = Uint8Array.from(atob(item.dataBase64), (c) => c.charCodeAt(0));
+          const blob = new Blob([binary], { type: mime });
+          const filename =
+            item.filename ??
+            (mediaType === "image" || mediaType === "gif"
+              ? `screenshot.${mime.includes("jpeg") ? "jpg" : "png"}`
+              : "file.bin");
+          const message = await client.base.obs.uploadObjTalkMessage({
+            to: chatMid,
+            type: mediaType,
+            data: blob,
+            filename,
+            ...(previousMessageId
+              ? {
+                  relatedMessageId: previousMessageId,
+                  messageRelationType: "SUBORDINATE",
+                }
+              : {}),
+          });
+          previousMessageId = message.id;
+          count++;
+          log.info(
+            {
+              accountId,
+              chatMid,
+              mediaType,
+              size: binary.byteLength,
+              plain: true,
+              batch: true,
+              messageId: message.id,
+              relatedMessageId: message.relatedMessageId,
+              messageRelationType: message.messageRelationType,
+            },
+            "media batch item sent",
+          );
+        }
+        return count;
+      }
+
+      let count = 0;
+      let previousMessageId: string | undefined;
+      for (const item of items) {
+        const mime = item.mimeType ?? "image/png";
+        const mediaType: MediaSendType =
+          item.mediaType ??
+          (mime.startsWith("video/")
+            ? "video"
+            : mime.startsWith("audio/")
+              ? "audio"
+              : mime === "image/gif"
+                ? "gif"
+                : mime.startsWith("image/")
+                  ? "image"
+                  : "file");
+        const binary = Uint8Array.from(atob(item.dataBase64), (c) => c.charCodeAt(0));
+        const blob = new Blob([binary], { type: mime });
+        const filename =
+          item.filename ??
+          (mediaType === "image" || mediaType === "gif"
+            ? `screenshot.${mime.includes("jpeg") ? "jpg" : "png"}`
+            : "file.bin");
+
+        const tryUpload = async () => {
+          const message = await client.base.obs.uploadMediaByE2EE({
+            data: blob,
+            oType: mediaType,
+            to: chatMid,
+            filename,
+            ...(previousMessageId
+              ? {
+                  relatedMessageId: previousMessageId,
+                  messageRelationType: "SUBORDINATE",
+                }
+              : {}),
+          });
+          previousMessageId = message.id;
+          return message;
+        };
+
+        try {
+          const message = await tryUpload();
+          log.info(
+            {
+              accountId,
+              chatMid,
+              mediaType,
+              size: binary.byteLength,
+              batch: true,
+              messageId: message.id,
+              relatedMessageId: message.relatedMessageId,
+              messageRelationType: message.messageRelationType,
+            },
+            "media batch item sent",
+          );
+          count++;
+        } catch (err) {
+          let errMsg = err instanceof Error ? err.message : String(err);
+
+          if (isSenderKeyError(errMsg)) {
+            log.warn(
+              { accountId, chatMid, errMsg },
+              "media batch send: invalid sender key — rotating and retrying",
+            );
+            try {
+              await ensureValidE2EEIdentity(client, { forceNewSenderKey: true });
+              const message = await tryUpload();
+              previousMessageId = message.id;
+              count++;
+              continue;
+            } catch (retryErr) {
+              err = retryErr;
+              errMsg = retryErr instanceof Error ? retryErr.message : String(retryErr);
+            }
+          }
+
+          if (
+            (isGroupKeyRecreateError(errMsg) || isMissingGroupKeyError(errMsg)) &&
+            (chatMid.startsWith("c") || chatMid.startsWith("r"))
+          ) {
+            log.warn(
+              { accountId, chatMid, errMsg },
+              "media batch send: old/missing group key — recreating and retrying",
+            );
+            try {
+              await recreateE2EEGroupKey(client, chatMid);
+              groupKeyWarm.delete(chatMid);
+              groupKeyWarmFailed.delete(chatMid);
+              const message = await tryUpload();
+              previousMessageId = message.id;
+              count++;
+              continue;
+            } catch (retryErr) {
+              log.warn(
+                {
+                  accountId,
+                  chatMid,
+                  retryErr: retryErr instanceof Error ? retryErr.message : String(retryErr),
+                },
+                "media batch send after group-key recreate failed",
+              );
+              throw retryErr;
+            }
+          }
+
+          throw err;
+        }
+      }
+
+      return count;
+    },
+    {
+      timeoutMs: Math.min(
+        300_000,
+        Math.max(MEDIA_SEND_TIMEOUT_MS, MEDIA_SEND_TIMEOUT_MS * items.length),
+      ),
+    },
+  );
+}
+
 /** スタンプ送信（所持パック / Premium）。E2EE 非対応相手は最初から plain */
 export async function sendSticker(
   accountId: string,
@@ -4272,6 +4575,9 @@ type CombinationStickerInput = {
   size?: number;
 };
 
+/** frontend sticker-emoji-panel の正規座標空間 (COMBO_EDITOR_SIZE) と同期 */
+const COMBO_EDITOR_SPACE = 240;
+
 function buildCombinationStickerLayouts(items: CombinationStickerInput[]): {
   metadata: CombinationStickerMetadata;
   stickers: CombinationStickerStickerData[];
@@ -4283,14 +4589,14 @@ function buildCombinationStickerLayouts(items: CombinationStickerInput[]): {
   const toLayoutInfo = (index: number): CombinationStickerLayoutInfo => {
     const item = items[index];
     if (item?.x != null && item?.y != null && item?.size != null) {
-      const scale = canvasWidth / 240;
+      const scale = canvasWidth / COMBO_EDITOR_SPACE;
       const size = Math.max(40, Math.min(canvasWidth, Math.round(item.size * scale)));
       return {
         width: size,
         height: size,
         rotation: 0,
-        x: Math.max(0, Math.round(item.x * scale)),
-        y: Math.max(0, Math.round(item.y * scale)),
+        x: Math.max(0, Math.min(canvasWidth - size, Math.round(item.x * scale))),
+        y: Math.max(0, Math.min(canvasHeight - size, Math.round(item.y * scale))),
       };
     }
     switch (count) {
@@ -4542,8 +4848,16 @@ export async function sendCombinationSticker(
     const remembered = await sendStickerMessage(accountId, chatMid, async () => ({
       contentMetadata: { CSSTKID: created.id },
     }));
+    const sentMeta = (remembered?.contentMetadata ?? null) as Record<string, unknown> | null;
     log.info(
-      { accountId, chatMid, combinationStickerId: created.id, count: items.length },
+      {
+        accountId,
+        chatMid,
+        combinationStickerId: created.id,
+        count: items.length,
+        sentMetaKeys: sentMeta ? Object.keys(sentMeta) : null,
+        sentMetaHasCsstk: typeof sentMeta?.CSSTKID === "string" && sentMeta.CSSTKID.length > 0,
+      },
       "combination sticker sent",
     );
     return remembered;

--- a/Vyline/backend/src/storage/chatStore.ts
+++ b/Vyline/backend/src/storage/chatStore.ts
@@ -9,7 +9,13 @@ import { existsSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import type { Chat, Message, MessageContentMeta, MessageReaction } from "@vyline/types";
+import type {
+  Chat,
+  Message,
+  MessageContentMeta,
+  MessageReaction,
+  MessageSnapshot,
+} from "@vyline/types";
 import { childLogger } from "../logger.js";
 
 const log = childLogger("chatStore");
@@ -54,6 +60,7 @@ export interface StoredMessage {
   savedAt: string;
   messageState?: Message["messageState"];
   history?: Message["history"];
+  revokedSnapshot?: MessageSnapshot;
 }
 
 interface ChatDbMeta {
@@ -116,6 +123,20 @@ async function getDb(accountId: string): Promise<ChatDb> {
   return db;
 }
 
+function snapshotFromStoredMessage(stored: StoredMessage): MessageSnapshot {
+  const {
+    savedAt: _savedAt,
+    history: _history,
+    revokedSnapshot: _revokedSnapshot,
+    messageState,
+    ...snapshot
+  } = stored;
+  return {
+    ...snapshot,
+    ...(messageState != null ? { messageState } : {}),
+  };
+}
+
 function scheduleSave(accountId: string): void {
   dirty.add(accountId);
   const prev = saveTimers.get(accountId);
@@ -171,8 +192,10 @@ export async function upsertMessages(
   const byChat = db.messages[chatMid] ?? {};
   for (const message of messages) {
     const prev = byChat[message.id];
+    const revokedSnapshot = prev?.revokedSnapshot ?? message.revokedSnapshot;
     byChat[message.id] = {
       ...message,
+      ...(revokedSnapshot ? { revokedSnapshot } : {}),
       history: prev?.history?.length ? prev.history : message.history,
     };
   }
@@ -191,6 +214,7 @@ export async function markMessageRevoked(
   const db = await getDb(accountId);
   const stored = db.messages[chatMid]?.[messageId];
   if (!stored) return;
+  stored.revokedSnapshot = stored.revokedSnapshot ?? snapshotFromStoredMessage(stored);
   const prevState = stored.messageState ?? "normal";
   const entry = {
     state: prevState,
@@ -213,23 +237,42 @@ export async function restoreRevokedMessage(
 ): Promise<{ text: string | null; contentType: string } | null> {
   const db = await getDb(accountId);
   const stored = db.messages[chatMid]?.[messageId];
-  if (!stored || !stored.history?.length) return null;
-  const lastNormal = [...stored.history]
-    .reverse()
-    .find((h) => h.state === "normal" || h.state === "edited");
-  if (!lastNormal) return null;
+  if (!stored) return null;
+  const snapshot = stored.revokedSnapshot;
+  const lastNormal = stored.history?.length
+    ? [...stored.history].reverse().find((h) => h.state === "normal" || h.state === "edited")
+    : undefined;
+  if (!snapshot && !lastNormal) return null;
+  const restoredText = snapshot?.text ?? lastNormal?.text ?? null;
+  const restoredContentType =
+    snapshot?.contentType ?? lastNormal?.contentType ?? stored.contentType;
   const entry = {
     state: "normal" as const,
     text: stored.text,
     contentType: stored.contentType,
     updatedTime: Date.now(),
   };
-  stored.messageState = "normal";
-  stored.history = [...stored.history, entry];
-  stored.text = lastNormal.text;
-  stored.contentType = lastNormal.contentType;
+  stored.messageState = (snapshot?.messageState ??
+    lastNormal?.state ??
+    "normal") as Message["messageState"];
+  stored.history = [...(stored.history ?? []), entry];
+  if (snapshot) stored.revokedSnapshot = snapshot;
+  stored.text = restoredText;
+  stored.contentType = restoredContentType;
+  if (snapshot) {
+    if (snapshot.contentMetadata !== undefined) stored.contentMetadata = snapshot.contentMetadata;
+    if (snapshot.readCount !== undefined) stored.readCount = snapshot.readCount;
+    if (snapshot.readBy !== undefined) stored.readBy = snapshot.readBy;
+    if (snapshot.seen !== undefined) stored.seen = snapshot.seen;
+    if (snapshot.relatedMessageId !== undefined) {
+      stored.relatedMessageId = snapshot.relatedMessageId;
+    }
+    if (snapshot.stickerAnimated !== undefined) stored.stickerAnimated = snapshot.stickerAnimated;
+    if (snapshot.stickerSticky !== undefined) stored.stickerSticky = snapshot.stickerSticky;
+    if (snapshot.reactions !== undefined) stored.reactions = snapshot.reactions;
+  }
   scheduleSave(accountId);
-  return { text: lastNormal.text, contentType: lastNormal.contentType };
+  return { text: restoredText, contentType: restoredContentType };
 }
 
 export async function getMessageHistory(
@@ -253,6 +296,18 @@ export async function getMessages(
   return Object.values(byChat)
     .sort((a, b) => b.createdTime - a.createdTime)
     .slice(0, limit);
+}
+
+export async function findStoredMessageById(
+  accountId: string,
+  messageId: string,
+): Promise<{ chatMid: string; message: StoredMessage } | null> {
+  const db = await getDb(accountId);
+  for (const [chatMid, messages] of Object.entries(db.messages)) {
+    const message = messages[messageId];
+    if (message) return { chatMid, message };
+  }
+  return null;
 }
 
 function storedChatToChat(stored: StoredChat): Chat {
@@ -284,6 +339,7 @@ function storedMessageToMessage(stored: StoredMessage): Message {
     messageState: stored.messageState ?? "normal",
   };
   if (stored.history) msg.history = stored.history;
+  if (stored.revokedSnapshot) msg.revokedSnapshot = stored.revokedSnapshot;
   if (stored.readCount != null) msg.readCount = stored.readCount;
   if (stored.readBy) msg.readBy = stored.readBy;
   if (stored.seen != null) msg.seen = stored.seen;

--- a/Vyline/packages/line-types/line_types.ts
+++ b/Vyline/packages/line-types/line_types.ts
@@ -16791,11 +16791,11 @@ export interface createCollectionForUser_result {
 }
 
 export interface createCombinationSticker_args {
-  request: any;
+  request: CreateCombinationStickerRequest;
 }
 
 export interface createCombinationSticker_result {
-  success: any;
+  success: CreateCombinationStickerResponse;
   e: ShopException;
 }
 

--- a/Vyline/packages/line-types/thrift.ts
+++ b/Vyline/packages/line-types/thrift.ts
@@ -29748,14 +29748,14 @@ export const Thrift: LooseType = {
     {
       fid: 2,
       name: "request",
-      struct: "YN0_Ob1_C",
+      struct: "CreateCombinationStickerRequest",
     },
   ],
   createCombinationSticker_result: [
     {
       fid: 0,
       name: "success",
-      struct: "YN0_Ob1_D",
+      struct: "CreateCombinationStickerResponse",
     },
     {
       fid: 1,

--- a/Vyline/packages/protocol/stack/_dist/base/core/mod.d.ts
+++ b/Vyline/packages/protocol/stack/_dist/base/core/mod.d.ts
@@ -6,7 +6,7 @@ import { InternalError } from "./utils/error.js";
 import { type Continuable, continueRequest } from "./utils/continue.js";
 export type { Continuable, Device, DeviceDetails, Log };
 export { continueRequest, InternalError };
-import { AuthService, CallService, ChannelService, LiffService, RelationService, SquareLiveTalkService, SquareService, TalkService } from "../service/mod.js";
+import { AuthService, CallService, ChannelService, LiffService, RelationService, ShopService, SquareLiveTalkService, SquareService, TalkService } from "../service/mod.js";
 import { Login } from "../login/mod.js";
 import { Thrift } from "../thrift/mod.js";
 import { RequestClient } from "../request/mod.js";
@@ -98,6 +98,7 @@ export declare class BaseClient extends TypedEventEmitter<ClientEvents> {
     readonly channel: ChannelService;
     readonly liff: LiffService;
     readonly relation: RelationService;
+    readonly shop: ShopService;
     readonly livetalk: SquareLiveTalkService;
     readonly square: SquareService;
     readonly talk: TalkService;
@@ -138,6 +139,7 @@ export declare class BaseClient extends TypedEventEmitter<ClientEvents> {
     getToType(mid: string): number | null;
     reqseqs?: Record<string, number>;
     getReqseq(name?: string): Promise<number>;
+    getReqseqs(name?: string, count?: number): Promise<number[]>;
     readonly fetch: Fetch;
     /**
      * returns polling client.

--- a/Vyline/packages/protocol/stack/_dist/base/obs/mod.d.ts
+++ b/Vyline/packages/protocol/stack/_dist/base/obs/mod.d.ts
@@ -72,11 +72,21 @@ export declare class LineObs {
     /**
      * @description Upload obs message to talk.
      */
-    uploadObjTalk(to: string, type: ObjType, data: Blob, oid?: string, filename?: string, durationMs?: number): Promise<{
+    uploadObjTalk(to: string, type: ObjType, data: Blob, oid?: string, filename?: string, durationMs?: number, reqseqOverride?: number): Promise<{
         objId: string;
         objHash: string;
         headers: Headers;
     }>;
+    uploadObjTalkBatch(to: string, items: Array<{
+        type: ObjType;
+        data: Blob;
+        filename?: string;
+        durationMs?: number;
+    }>): Promise<Array<{
+        objId: string;
+        objHash: string;
+        headers: Headers;
+    }>>;
     uploadObjectForService(options: {
         data: Blob;
         oType?: ObjType;
@@ -101,6 +111,17 @@ export declare class LineObs {
         filename?: string;
         /** Optional thumbnail; encrypted with the same keyMaterial. #103. */
         preview?: Blob;
+        relatedMessageId?: string;
+        messageRelationType?: "FORWARD" | "AUTO_REPLY" | "SUBORDINATE" | "REPLY";
+    }): Promise<Message>;
+    uploadObjTalkMessage(options: {
+        to: string;
+        type: ObjType;
+        data: Blob;
+        filename?: string;
+        durationMs?: number;
+        relatedMessageId?: string;
+        messageRelationType?: "FORWARD" | "AUTO_REPLY" | "SUBORDINATE" | "REPLY";
     }): Promise<Message>;
     downloadMediaByE2EE(message: Message): Promise<File | null>;
 }

--- a/Vyline/packages/protocol/stack/_dist/base/service/shop/mod.d.ts
+++ b/Vyline/packages/protocol/stack/_dist/base/service/shop/mod.d.ts
@@ -32,7 +32,9 @@ export declare class ShopService implements BaseService {
     getCoinUseAndRefundHistory(...param: Parameters<typeof LINEStruct.getCoinUseAndRefundHistory_args>): Promise<LINETypes.getCoinUseAndRefundHistory_result["success"]>;
     getCoinProducts(...param: Parameters<typeof LINEStruct.getCoinProducts_args>): Promise<LINETypes.getCoinProducts_result["success"]>;
     getCoinPurchaseHistory(...param: Parameters<typeof LINEStruct.getCoinPurchaseHistory_args>): Promise<LINETypes.getCoinPurchaseHistory_result["success"]>;
+    canCreateCombinationSticker(...param: Parameters<typeof LINEStruct.canCreateCombinationSticker_args>): Promise<LINETypes.canCreateCombinationSticker_result["success"]>;
     createCombinationSticker(...param: Parameters<typeof LINEStruct.createCombinationSticker_args>): Promise<LINETypes.createCombinationSticker_result["success"]>;
+    isStickerAvailableForCombinationSticker(...param: Parameters<typeof LINEStruct.isStickerAvailableForCombinationSticker_args>): Promise<LINETypes.isStickerAvailableForCombinationSticker_result["success"]>;
     shouldShowWelcomeStickerBanner(...param: Parameters<typeof LINEStruct.shouldShowWelcomeStickerBanner_args>): Promise<LINETypes.shouldShowWelcomeStickerBanner_result["success"]>;
     stopBundleSubscription(...param: Parameters<typeof LINEStruct.stopBundleSubscription_args>): Promise<LINETypes.stopBundleSubscription_result["success"]>;
     getProductLatestVersionForUser(...param: Parameters<typeof LINEStruct.getProductLatestVersionForUser_args>): Promise<LINETypes.getProductLatestVersionForUser_result["success"]>;

--- a/Vyline/packages/protocol/stack/_dist/base/service/talk/mod.d.ts
+++ b/Vyline/packages/protocol/stack/_dist/base/service/talk/mod.d.ts
@@ -52,6 +52,7 @@ export declare class TalkService implements BaseService {
         contentType?: LINETypes.ContentType;
         contentMetadata?: Record<string, string>;
         relatedMessageId?: string;
+        messageRelationType?: "FORWARD" | "AUTO_REPLY" | "SUBORDINATE" | "REPLY";
         location?: LINETypes.Location;
         chunks?: string[] | Buffer[];
         e2ee?: boolean;

--- a/Vyline/packages/protocol/stack/base/core/mod.ts
+++ b/Vyline/packages/protocol/stack/base/core/mod.ts
@@ -17,6 +17,7 @@ import {
   ChannelService,
   LiffService,
   RelationService,
+  ShopService,
   SquareLiveTalkService,
   SquareService,
   TalkService,
@@ -126,6 +127,7 @@ export class BaseClient extends TypedEventEmitter<ClientEvents> {
   readonly channel: ChannelService;
   readonly liff: LiffService;
   readonly relation: RelationService;
+  readonly shop: ShopService;
   readonly livetalk: SquareLiveTalkService;
   readonly square: SquareService;
   readonly talk: TalkService;
@@ -200,6 +202,7 @@ export class BaseClient extends TypedEventEmitter<ClientEvents> {
     this.liff = new LiffService(this);
     this.livetalk = new SquareLiveTalkService(this);
     this.relation = new RelationService(this);
+    this.shop = new ShopService(this);
     this.square = new SquareService(this);
     this.talk = new TalkService(this);
   }
@@ -222,6 +225,11 @@ export class BaseClient extends TypedEventEmitter<ClientEvents> {
   }
   reqseqs?: Record<string, number>;
   async getReqseq(name: string = "talk"): Promise<number> {
+    const [seq] = await this.getReqseqs(name, 1);
+    return seq ?? 0;
+  }
+
+  async getReqseqs(name: string = "talk", count: number = 1): Promise<number[]> {
     if (!this.reqseqs) {
       this.reqseqs = JSON.parse(((await this.storage.get("reqseq")) ?? "{}").toString()) as Record<
         string,
@@ -231,10 +239,11 @@ export class BaseClient extends TypedEventEmitter<ClientEvents> {
     if (!this.reqseqs[name]) {
       this.reqseqs[name] = 0;
     }
-    const seq = this.reqseqs[name];
-    this.reqseqs[name]++;
+    const start = this.reqseqs[name];
+    const safeCount = Math.max(0, Math.floor(count));
+    this.reqseqs[name] += safeCount;
     await this.storage.set("reqseq", JSON.stringify(this.reqseqs));
-    return seq;
+    return Array.from({ length: safeCount }, (_, index) => start + index);
   }
 
   // NOTE: use allow function.

--- a/Vyline/packages/protocol/stack/base/obs/mod.ts
+++ b/Vyline/packages/protocol/stack/base/obs/mod.ts
@@ -141,6 +141,7 @@ export class LineObs {
     oid?: string,
     filename?: string,
     durationMs?: number,
+    reqseqOverride?: number,
   ): Promise<{
     objId: string;
     objHash: string;
@@ -150,7 +151,7 @@ export class LineObs {
       throw new InternalError("Not setup yet", "Please call 'login()' first");
     }
     const ext = MimeType[data.type as keyof typeof MimeType];
-    const reqseqValue = await this.client.getReqseq("talk");
+    const reqseqValue = oid ? undefined : (reqseqOverride ?? (await this.client.getReqseq("talk")));
     const param: {
       oid: string;
       reqseq?: string;
@@ -190,6 +191,112 @@ export class LineObs {
       obsPath: `${toType}/m/${oid ?? "reqseq"}`,
       filename: param.name,
       params: param,
+    });
+  }
+
+  public async uploadObjTalkBatch(
+    to: string,
+    items: Array<{
+      type: ObjType;
+      data: Blob;
+      filename?: string;
+      durationMs?: number;
+    }>,
+  ): Promise<Array<{ objId: string; objHash: string; headers: Headers }>> {
+    if (!items.length) return [];
+    const reqseqs = await this.client.getReqseqs("talk", items.length);
+    return await Promise.all(
+      items.map((item, index) =>
+        this.uploadObjTalk(
+          to,
+          item.type,
+          item.data,
+          undefined,
+          item.filename,
+          item.durationMs,
+          reqseqs[index],
+        ),
+      ),
+    );
+  }
+
+  public async uploadObjTalkMessage(options: {
+    to: string;
+    type: ObjType;
+    data: Blob;
+    filename?: string;
+    durationMs?: number;
+    relatedMessageId?: string;
+    messageRelationType?: "FORWARD" | "AUTO_REPLY" | "SUBORDINATE" | "REPLY";
+  }): Promise<Message> {
+    const {
+      to,
+      type,
+      data,
+      filename,
+      durationMs,
+      relatedMessageId,
+      messageRelationType,
+    } = options;
+    const ext = MimeType[data.type as keyof typeof MimeType];
+    const typeSet: {
+      image: [string, 1];
+      video: [string, 2];
+      audio: [string, 3];
+      file: [string, 14];
+      gif: [string, 1];
+    } = {
+      image: ["emi", 1],
+      video: ["emv", 2],
+      audio: ["ema", 3],
+      file: ["emf", 14],
+      gif: ["emi", 1],
+    };
+    const [obsNamespace, contentType] = typeSet[type];
+    const params: Record<string, string> = { type: "file" };
+    if (type === "image" || type === "gif") {
+      params["cat"] = "original";
+    }
+    if (type === "gif") {
+      params["type"] = "image";
+    }
+    if (type === "audio" || type === "video") {
+      params["duration"] = (durationMs ?? 1919).toString();
+    }
+    const toType: "talk" | "g2" = to[0] === "m" || to[0] === "t" ? "g2" : "talk";
+    const oid = crypto.randomUUID();
+    const { objId } = await this.uploadObjectForService({
+      data,
+      oType: type,
+      obsPath: `${toType}/m/${oid}`,
+      params: {
+        ...params,
+        ver: "2.0",
+        name: filename || `vyline.${ext}`,
+      },
+    });
+
+    return await this.client.talk.sendMessage({
+      to,
+      contentType,
+      contentMetadata: {
+        SID: obsNamespace,
+        OID: objId,
+        FILE_SIZE: data.size.toString(),
+        fileName: filename || `line.${ext}`,
+        ...(type === "image" || type === "gif" || type === "video"
+          ? {
+              MEDIA_CONTENT_INFO: JSON.stringify({
+                category: "original",
+                fileSize: data.size,
+                extension: ext,
+                animated: type === "gif",
+              }),
+            }
+          : {}),
+      },
+      relatedMessageId,
+      messageRelationType: relatedMessageId ? messageRelationType : undefined,
     });
   }
 
@@ -279,8 +386,10 @@ export class LineObs {
     filename?: string;
     /** Optional thumbnail; encrypted with the same keyMaterial. #103. */
     preview?: Blob;
+    relatedMessageId?: string;
+    messageRelationType?: "FORWARD" | "AUTO_REPLY" | "SUBORDINATE" | "REPLY";
   }): Promise<Message> {
-    const { data, oType, to, filename, preview } = options;
+    const { data, oType, to, filename, preview, relatedMessageId, messageRelationType } = options;
     const typeSet: {
       image: [string, 1];
       video: [string, 2];
@@ -361,7 +470,10 @@ export class LineObs {
     } catch (e) {
       if (
         e instanceof Error &&
-        (e.name === "Not support E2EE" || e.message?.startsWith("Not support E2EE"))
+        (e.name === "Not support E2EE" ||
+          e.message?.startsWith("Not support E2EE") ||
+          e.message.includes("E2EE_RETRY_PLAIN") ||
+          e.message.includes("member settings off"))
       ) {
         e2ee = false;
         chunks = [];
@@ -379,7 +491,6 @@ export class LineObs {
         SID: obsNamespace,
         OID: objId,
         FILE_SIZE: edata.size.toString(),
-        // Desktop 準拠: メディア鍵は受信側が OBS データを復号するために必ず載せる
         keyMaterial,
         fileName: filename || `line.${ext}`,
         ...(e2ee ? { e2eeVersion: "2" } : {}),
@@ -394,6 +505,8 @@ export class LineObs {
             }
           : {}),
       },
+      relatedMessageId,
+      messageRelationType: relatedMessageId ? messageRelationType : undefined,
     });
   }
 

--- a/Vyline/packages/protocol/stack/base/service/shop/mod.ts
+++ b/Vyline/packages/protocol/stack/base/service/shop/mod.ts
@@ -294,12 +294,36 @@ export class ShopService implements BaseService {
     );
   }
 
+  async canCreateCombinationSticker(
+    ...param: Parameters<typeof LINEStruct.canCreateCombinationSticker_args>
+  ): Promise<LINETypes.canCreateCombinationSticker_result["success"]> {
+    return await this.client.request.request(
+      LINEStruct.canCreateCombinationSticker_args(...param),
+      "canCreateCombinationSticker",
+      this.protocolType,
+      true,
+      this.requestPath,
+    );
+  }
+
   async createCombinationSticker(
     ...param: Parameters<typeof LINEStruct.createCombinationSticker_args>
   ): Promise<LINETypes.createCombinationSticker_result["success"]> {
     return await this.client.request.request(
       LINEStruct.createCombinationSticker_args(...param),
       "createCombinationSticker",
+      this.protocolType,
+      true,
+      this.requestPath,
+    );
+  }
+
+  async isStickerAvailableForCombinationSticker(
+    ...param: Parameters<typeof LINEStruct.isStickerAvailableForCombinationSticker_args>
+  ): Promise<LINETypes.isStickerAvailableForCombinationSticker_result["success"]> {
+    return await this.client.request.request(
+      LINEStruct.isStickerAvailableForCombinationSticker_args(...param),
+      "isStickerAvailableForCombinationSticker",
       this.protocolType,
       true,
       this.requestPath,

--- a/Vyline/packages/protocol/stack/base/service/talk/mod.ts
+++ b/Vyline/packages/protocol/stack/base/service/talk/mod.ts
@@ -95,17 +95,28 @@ export class TalkService implements BaseService {
     contentType?: LINETypes.ContentType;
     contentMetadata?: Record<string, string>;
     relatedMessageId?: string;
+    messageRelationType?: "FORWARD" | "AUTO_REPLY" | "SUBORDINATE" | "REPLY";
     location?: LINETypes.Location;
     chunks?: string[] | Buffer[];
     e2ee?: boolean;
   }): Promise<LINETypes.Message> {
-    const { to, text, contentType, contentMetadata, relatedMessageId, location, e2ee, chunks } = {
+    const {
+      to,
+      text,
+      contentType,
+      contentMetadata,
+      relatedMessageId,
+      messageRelationType,
+      location,
+      e2ee,
+      chunks,
+    } = {
       contentType: "NONE" as LINETypes.ContentType,
       contentMetadata: {},
       ...options,
     };
     if ((e2ee && !chunks && location) || (e2ee && !chunks && text)) {
-      const chunks = await this.client.e2ee.encryptE2EEMessage(
+      const encrypted = await this.client.e2ee.encryptE2EEMessage(
         to,
         text || location || "invalid",
         contentType,
@@ -118,15 +129,16 @@ export class TalkService implements BaseService {
           e2eeMark: "2",
         },
       };
-      const options = {
+      const next = {
         to,
         contentType,
         contentMetadata: _contentMetadata,
         relatedMessageId,
+        messageRelationType,
         e2ee,
-        chunks,
+        chunks: encrypted.chunks,
       };
-      return this.sendMessage(options);
+      return this.sendMessage(next);
     }
 
     const message = LINEStruct.sendMessage_args({
@@ -146,7 +158,7 @@ export class TalkService implements BaseService {
         relatedMessageId,
         ...(relatedMessageId
           ? {
-              messageRelationType: "REPLY",
+              messageRelationType: messageRelationType ?? "REPLY",
               relatedMessageServiceCode: "TALK",
             }
           : {}),

--- a/Vyline/packages/protocol/stack/base/thrift/readwrite/struct.ts
+++ b/Vyline/packages/protocol/stack/base/thrift/readwrite/struct.ts
@@ -3127,6 +3127,81 @@ export function CanCreateCombinationStickerRequest(
 ): NestedArray {
   return typeof param === "undefined" ? [] : [[14, 1, [11, param.packageIds]]];
 }
+export function StickerLayoutInfo(
+  param?: PartialDeep<LINETypes.StickerLayoutInfo> | undefined,
+): NestedArray {
+  return typeof param === "undefined"
+    ? []
+    : [
+        [4, 1, param.width],
+        [4, 2, param.height],
+        [4, 3, param.rotation],
+        [4, 4, param.x],
+        [4, 5, param.y],
+      ];
+}
+export function StickerLayoutStickerInfo(
+  param?: PartialDeep<LINETypes.StickerLayoutStickerInfo> | undefined,
+): NestedArray {
+  return typeof param === "undefined"
+    ? []
+    : [
+        [10, 1, param.stickerId],
+        [10, 2, param.productId],
+        [11, 3, param.stickerHash],
+        [11, 4, param.stickerOptions],
+        [10, 5, param.stickerVersion],
+      ];
+}
+export function StickerLayout(
+  param?: PartialDeep<LINETypes.StickerLayout> | undefined,
+): NestedArray {
+  return typeof param === "undefined"
+    ? []
+    : [
+        [12, 1, StickerLayoutInfo(param.layoutInfo)],
+        [12, 2, StickerLayoutStickerInfo(param.stickerInfo)],
+      ];
+}
+export function CombinationStickerMetadata(
+  param?: PartialDeep<LINETypes.CombinationStickerMetadata> | undefined,
+): NestedArray {
+  return typeof param === "undefined"
+    ? []
+    : [
+        [10, 1, param.version],
+        [4, 2, param.canvasWidth],
+        [4, 3, param.canvasHeight],
+        [15, 4, [12, param.stickerLayouts && param.stickerLayouts.map((e) => StickerLayout(e))]],
+      ];
+}
+export function CombinationStickerStickerData(
+  param?: PartialDeep<LINETypes.CombinationStickerStickerData> | undefined,
+): NestedArray {
+  return typeof param === "undefined"
+    ? []
+    : [
+        [11, 1, param.packageId],
+        [11, 2, param.stickerId],
+        [10, 3, param.version],
+      ];
+}
+export function CreateCombinationStickerResponse(
+  param?: PartialDeep<LINETypes.CreateCombinationStickerResponse> | undefined,
+): NestedArray {
+  return typeof param === "undefined" ? [] : [[11, 1, param.id]];
+}
+export function CreateCombinationStickerRequest(
+  param?: PartialDeep<LINETypes.CreateCombinationStickerRequest> | undefined,
+): NestedArray {
+  return typeof param === "undefined"
+    ? []
+    : [
+        [12, 1, CombinationStickerMetadata(param.metadata)],
+        [15, 2, [12, param.stickers && param.stickers.map((e) => CombinationStickerStickerData(e))]],
+        [11, 3, param.idOfPreviousVersionOfCombinationSticker],
+      ];
+}
 export function CancelChatInvitationRequest(
   param?: PartialDeep<LINETypes.CancelChatInvitationRequest> | undefined,
 ): NestedArray {
@@ -3777,6 +3852,22 @@ export function ChannelException(
     ? []
     : [
         [8, 1, ChannelErrorCode(param.code)],
+        [11, 2, param.reason],
+        [13, 3, [11, 11, param.parameterMap]],
+      ];
+}
+export function Ob1_EnumC12652p1(
+  param: LINETypes.Ob1_EnumC12652p1 | undefined,
+): (LINETypes.Ob1_EnumC12652p1 & number) | undefined {
+  return typeof param === "string" ? LINETypes.enums.Ob1_EnumC12652p1[param] : param;
+}
+export function ShopException(
+  param?: PartialDeep<LINETypes.ShopException> | undefined,
+): NestedArray {
+  return typeof param === "undefined"
+    ? []
+    : [
+        [8, 1, Ob1_EnumC12652p1(param.code)],
         [11, 2, param.reason],
         [13, 3, [11, 11, param.parameterMap]],
       ];
@@ -6849,7 +6940,19 @@ export function createCollectionForUser_args(
 export function createCombinationSticker_args(
   param?: PartialDeep<LINETypes.createCombinationSticker_args> | undefined,
 ): NestedArray {
-  return typeof param === "undefined" ? [] : [];
+  return typeof param === "undefined"
+    ? []
+    : [[12, 2, CreateCombinationStickerRequest(param.request)]];
+}
+export function createCombinationSticker_result(
+  param?: PartialDeep<LINETypes.createCombinationSticker_result> | undefined,
+): NestedArray {
+  return typeof param === "undefined"
+    ? []
+    : [
+        [12, 0, CreateCombinationStickerResponse(param.success)],
+        [12, 1, ShopException(param.e)],
+      ];
 }
 export function createE2EEKeyBackupEnforced_args(
   param?: PartialDeep<LINETypes.createE2EEKeyBackupEnforced_args> | undefined,

--- a/Vyline/packages/protocol/stack/client/features/message/internal-types.ts
+++ b/Vyline/packages/protocol/stack/client/features/message/internal-types.ts
@@ -1,9 +1,10 @@
 export interface StickerMetadata {
-  STKPKGID: string;
-  STKID: string;
-  STKTXT: string;
-  STKVER: string;
+  STKPKGID?: string;
+  STKID?: string;
+  STKTXT?: string;
+  STKVER?: string;
   STKOPT?: string;
+  CSSTKID?: string;
 }
 export interface EmojiMeta {
   REPLACE: {

--- a/Vyline/packages/protocol/stack/client/features/message/square.ts
+++ b/Vyline/packages/protocol/stack/client/features/message/square.ts
@@ -172,10 +172,14 @@ export class SquareMessage {
       throw new TypeError("The message is not sticker.");
     }
     const stickerMetadata = this.raw.message.contentMetadata as unknown as StickerMetadata;
+    const stickerId = stickerMetadata.CSSTKID ?? stickerMetadata.STKID;
+    if (!stickerId) {
+      throw new TypeError("The sticker ID is missing.");
+    }
     if (stickerMetadata.STKOPT === "A") {
-      return `https://stickershop.line-scdn.net/stickershop/v1/sticker/${stickerMetadata.STKID}/android/sticker_animation.png`;
+      return `https://stickershop.line-scdn.net/stickershop/v1/sticker/${stickerId}/android/sticker_animation.png`;
     } else {
-      return `https://stickershop.line-scdn.net/stickershop/v1/sticker/${stickerMetadata.STKID}/android/sticker.png`;
+      return `https://stickershop.line-scdn.net/stickershop/v1/sticker/${stickerId}/android/sticker.png`;
     }
   }
 

--- a/Vyline/packages/protocol/stack/client/features/message/talk.ts
+++ b/Vyline/packages/protocol/stack/client/features/message/talk.ts
@@ -161,10 +161,14 @@ export class TalkMessage {
       throw new TypeError("The message is not sticker.");
     }
     const stickerMetadata = this.raw.contentMetadata as unknown as StickerMetadata;
+    const stickerId = stickerMetadata.CSSTKID ?? stickerMetadata.STKID;
+    if (!stickerId) {
+      throw new TypeError("The sticker ID is missing.");
+    }
     if (stickerMetadata.STKOPT === "A") {
-      return `https://stickershop.line-scdn.net/stickershop/v1/sticker/${stickerMetadata.STKID}/android/sticker_animation.png`;
+      return `https://stickershop.line-scdn.net/stickershop/v1/sticker/${stickerId}/android/sticker_animation.png`;
     } else {
-      return `https://stickershop.line-scdn.net/stickershop/v1/sticker/${stickerMetadata.STKID}/android/sticker.png`;
+      return `https://stickershop.line-scdn.net/stickershop/v1/sticker/${stickerId}/android/sticker.png`;
     }
   }
 

--- a/Vyline/packages/protocol/stack/client/features/voom.ts
+++ b/Vyline/packages/protocol/stack/client/features/voom.ts
@@ -92,7 +92,11 @@ export async function voomRest<T = unknown>(
 
 export async function getChannelToken(client: Client, channelId: string): Promise<string> {
   const r = await client.base.channel.issueChannelToken({ channelId });
-  const t = (r as unknown as { token?: string }).token;
+  // 重要: ゲートウェイ(gw.line.naver.jp)は channelAccessToken を X-Line-ChannelToken として
+  // 要求する。r.token(長い方)を渡すと 401「ユーザー認証を更新しています」になる。
+  const t =
+    (r as unknown as { channelAccessToken?: string }).channelAccessToken ??
+    (r as unknown as { token?: string }).token;
   if (!t) throw new Error("issueChannelToken returned no token");
   return t;
 }

--- a/docs/analysis/README.md
+++ b/docs/analysis/README.md
@@ -15,6 +15,8 @@ agents は `bun run vyline:delta` のレポートが指す feature ごとに、�
 | e2ee-send                | [e2ee-send.md](./e2ee-send.md)                   |                                                      |
 | e2ee-decrypt             | [e2ee-decrypt.md](./e2ee-decrypt.md)             |                                                      |
 | talk-send                | [talk-send.md](./talk-send.md)                   |                                                      |
+| multi-image-send         | [multi-image-send-handoff.md](./multi-image-send-handoff.md) | 複数画像送信の未解決事項と handoff |
+| combination-sticker     | [combination-sticker-handoff.md](./combination-sticker-handoff.md) | 複数スタンプの組み合わせ送信・表示の未解決事項と handoff |
 | sync-events              | [sync-events.md](./sync-events.md)               |                                                      |
 | stickers                 | [stickers.md](./stickers.md)                     |                                                      |
 | line-emoji               | [line-emoji.md](./line-emoji.md)                 |                                                      |

--- a/docs/analysis/multi-image-send-handoff.md
+++ b/docs/analysis/multi-image-send-handoff.md
@@ -1,0 +1,220 @@
+# multi-image-send — 引き継ぎメモ
+
+最終更新: 2026-08-21
+
+## 現在の作業状態
+
+- 作業ブランチ: `codex/hide-profile-details`
+- ワークツリーは既に複数機能の未コミット変更を含む。無関係な差分を戻さないこと
+- コンビネーションスタンプの表示修正も同じワークツリーに含まれるが、複数画像送信とは別問題
+- Desktop の型チェックは成功: `bun run typecheck` を Desktop ディレクトリで実行
+- ルートの全体型チェックは既存の backend エラーで停止中: `Vyline/backend/src/service/lineService.ts:1046` の `string | null` を `string | undefined` に代入している箇所
+
+## 結論
+
+Vyline はまだ **「本当の複数画像送信」** を実現できていない。
+
+2026-08-21 時点でも未解決で、今のところ「複数選択 UI」や「batch 送信 API」はあるが、最終的な送信結果は 1 message に束ねられていない。
+
+- UI 上で複数画像をまとめて選択して送る導線はある
+- backend / protocol 側でも batch 送信の経路は追加した
+- ただし現状の送信結果は **画像 3 枚なら message 3 件** で、ユーザーが求めている「1 回の送信で複数画像を持つ payload」にはなっていない
+- `sendLiff` は今回の要件から除外すること。ユーザーが明示的に拒否している
+
+## ユーザー要求
+
+- 複数画像を送るときに、チャット欄上の送信前プレビューでまとまって見えること
+- 送信時も UI だけでなく、**実際の payload として multi image** で送れること
+- 合成画像 1 枚にするのは不可
+- 連投で 3 件に分かれるのも不可
+- Desktop の実装や `search tool` 由来の解析を元に移植すること
+- `sendLiff` 経由ではなく探すこと
+
+## 症状
+
+過去に確認された失敗:
+
+- `getLastE2EEPublicKeys(/S4)` → `E2EE_RETRY_PLAIN`
+- `sendMessage(/S4)` → `REFRESH_MEDIA_FLOW`
+
+その後、`determineMediaMessageFlow` を送信前に呼んで plain / reqseq 経路へ分岐する変更は入れたが、**message が 1 件にまとまる問題は未解決**。
+
+## 安全なテスト先
+
+送信テストはこの 2 つのみ:
+
+- グループ `c1efe9d6cf1848350bc91848a8a29963e`
+- BOT `u81c530b68cc2efdd36911d214bd5f084`
+
+## 調査で確認できた事実
+
+### 1. HAR 上の送信
+
+対象:
+
+- `obs-jp.line-apps.com_2026_08_21_20_06_00.har`
+- `uts-front.line-apps.com_2026_08_21_18_13_58.har`
+
+確認できたこと:
+
+- `obs-jp...har` では `POST https://obs-jp.line-apps.com/r/talk/m/reqseq` が 3 件
+- 各リクエストの `X-Obs-Params` は別々の `reqseq`
+- 例:
+  - `17195037`
+  - `17195038`
+  - `17195039`
+- `tomid` は同一チャット
+- `type` は `image`
+- HAR 上では **1 つの HTTP payload に複数画像を同梱している証拠は見つかっていない**
+
+### 2. media flow
+
+ローカルで `determineMediaMessageFlow` を確認した結果:
+
+- chat: `c1efe9d6cf1848350bc91848a8a29963e`
+- `flowMap: {"1":1,"2":1,"3":1,"14":1}`
+- `cacheTtlMillis: "21600000"`
+
+解釈:
+
+- image / video / audio / file ともに `MediaMessageFlow.V1 = 1`
+- この chat は Desktop 準拠で `OBS /r/talk/m/reqseq` に寄せる必要がある
+
+### 3. linejs 調査
+
+参照:
+
+- `https://github.com/evex-dev/linejs`
+
+確認できたこと:
+
+- `packages/linejs/base/obs/mod.ts` に `uploadObjTalk(...)` がある
+- ここは `oid: "reqseq"` と `tomid`, `reqseq` を使って OBS へ送る
+- OpenChat 側コメントでも「reqseq mode では server creates the message」と読める
+- `sendLiff` / `shareMessages` は存在するが、ユーザー要件から除外
+- **LIFF 以外で「1 message の中に複数 image payload を持つ Talk 実装」は見つけられていない**
+
+## 今回入った変更
+
+主に以下:
+
+- frontend で複数選択時の送信を `sendMediaBatch` に寄せた
+- 画像合成処理は削除
+- backend に `sendMediaBatch(...)` を追加
+- `determineMediaMessageFlow` を送信前に呼び、flow=1 なら plain reqseq 経路へ分岐
+- protocol `BaseClient` に `getReqseqs(...)` を追加
+- protocol `LineObs` に `uploadObjTalkBatch(...)` を追加
+- `uploadObjTalkBatch(...)` は複数 `reqseq` をまとめて確保し、各画像を OBS へ投げる
+- E2EE plain fallback で `E2EE_RETRY_PLAIN` / `member settings off` を拾うようにした
+
+## コンビネーションスタンプの直近修正（参考）
+
+複数画像送信とは別だが、直近で `🧩` に置換される不具合を調査した。
+
+- `Vyline/apps/desktop/src/lib/store.ts` でプレビュー保存キーを `mapped.id` だけでなく `CSSTKID` に統一
+- `Vyline/apps/desktop/src/lib/mappers.ts` でキャッシュ未取得時も `🧩` ではなく `lineStickerUrl(CSSTKID)` を表示
+- `Vyline/apps/desktop/src/utils/combinationStickers.ts` にローカルプレビューを保存
+- 送信後の再同期でプレビューを保持する処理を `store.ts` に追加
+
+この変更を複数画像送信の調査と混ぜないこと。`CSSTKID` の問題を直しても、画像3枚が1つのLINEメッセージになるわけではない。
+
+## 重要: まだ未解決な点
+
+今の batch 実装は「route レベルの逐次ループ」よりは Desktop に近いが、**結果としては still 3 messages**。
+
+つまり:
+
+- `sendMediaBatch` はある
+- `uploadObjTalkBatch` もある
+- しかし server side で生成される message が 1 件に束ねられていない
+
+ここが今回の handoff の本題。
+
+## 変更済みファイル
+
+今回の作業で直接触った主要ファイル:
+
+- `Vyline/backend/src/service/lineService.ts`
+- `Vyline/backend/src/api/line.ts`
+- `Vyline/packages/protocol/stack/base/core/mod.ts`
+- `Vyline/packages/protocol/stack/base/obs/mod.ts`
+- `Vyline/packages/protocol/stack/_dist/base/core/mod.d.ts`
+- `Vyline/packages/protocol/stack/_dist/base/obs/mod.d.ts`
+- `Vyline/apps/desktop/src/components/message-input.tsx`
+
+補助的に、UI 側では受信表示をグループ化する変更も入っている:
+
+- `Vyline/apps/desktop/src/components/chat-area.tsx`
+- `Vyline/apps/desktop/src/components/message-bubble.tsx`
+
+ただしこれは送信 payload 解決ではない。
+
+## 既に通した確認
+
+- `bun run --cwd Vyline/backend typecheck`
+- `bun run --cwd Vyline/packages/protocol typecheck`
+- `bun run --cwd Vyline/apps/desktop typecheck`
+- `bunx biome check ...`
+
+また、テスト API 呼び出しで以下は通った:
+
+- `POST http://127.0.0.1:3001/line/main/send-media-batch`
+- 結果: `{ "ok": true, "count": 3 }`
+
+この `count: 3` 自体が、未解決の本質でもある。
+
+## 次の AI が最優先でやること
+
+### 1. Desktop 実装の「message まとまり条件」を特定する
+
+見るべき観点:
+
+- `reqseq` 連番だけで十分なのか
+- 追加の S4 / UTS / LIFF 以外の事前 RPC があるか
+- 複数画像の束ねに必要な `contentMetadata` / `messageRelationType` / `chunks` / `headers` があるか
+- OBS 送信後に別 RPC で group 化している可能性がないか
+
+特に、HAR だけでなく Desktop 解析ツール側で:
+
+- `multi image`
+- `media message flow`
+- `reqseq`
+- `talk/m/reqseq`
+- `messageRelationType`
+- `album`
+- `media bundle`
+
+あたりを重点的に追うこと。
+
+### 2. linejs 以外の Desktop 痕跡を探す
+
+linejs に無いから終わり、ではない。
+
+- Vyline-Search / Desktop 解析結果
+- `rpcMap.ts`
+- recovered strings
+- `source/desktop/` の解析成果
+
+を使って、公式 Desktop がどこで multi image を束ねているか再確認すること。
+
+### 3. UI grouping と送信 payload を混同しない
+
+受信表示を 1 塊に見せる変更は入っているが、ユーザーが欲しいのはそこではない。
+
+判定基準:
+
+- LINE 本体や他クライアントでも「複数画像 1 回送信」として見えるか
+- HAR / RPC / 保存 message に multi-image の痕跡が残るか
+- Vyline ローカル UI だけの grouping になっていないか
+
+## 注意
+
+- `sendLiff` は使わない
+- 合成画像は不可
+- 実グループ・実友だちには送らない
+- 既存の dirty worktree があるので、関係ない差分は巻き込まない
+- 調査用の `.tmp-linejs-b015243/` は未追跡で残っている
+
+## ひとことで言うと
+
+今の実装は **「複数選択を batch 送信するところ」までは進んだが、「LINE の本当の multi image message を再現する条件」がまだ取れていない**。


### PR DESCRIPTION
## Summary
- backend sendMediaBatch: 複数画像を reqseq 連番で OBS に逐次送信
- protocol: uploadObjTalkBatch / getReqseqs / plain-E2EE フロー分岐 (E2EE_RETRY_PLAIN 対応)
- desktop: 複数選択送信を sendMediaBatch に集約、受信画像のグループ表示 UI

## Notes
- スタック PR: base は combination-sticker-preview ブランチ (store.ts の sendCombinationSticker に依存)
- 関連: docs/analysis/multi-image-send-handoff.md - relation chain (SUBORDINATE) 検証は本PR後続で実施予定

## Test
- bun run typecheck / lint / test (190 pass) - combo ブランチ合流後に再確認
- 実送信テストは「うがうがうー」グループで実施予定
