### PR TITLE
docs: project vision README + mandatory agent skill policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,21 @@ RPC_DICTIONARY の `linejsName` フィールドが linejs との対応を示し�
 
 ---
 
+## Skill 方針（必須）
+
+大規模タスク（監査・リファクタ・API設計・plugin実装・docs整理）の前に、以下の skill を確認し使用する。
+
+| Skill | 用途 |
+|---|---|
+| `ponytail` / `ponytail-*` | YAGNI・最小実装・再利用優先（既定の思考モード） |
+| `caveman` / `caveman-compress` | 報告の圧縮のみ（コード/OpenAPI/YAML/docs本文には適用しない） |
+| `agent-skills-standard` 系 | 必要なときだけ必要な skill を階層ロード（一括読込禁止） |
+| `api-and-interface-design` など addyosmani/agent-skills 系 | 本番級レビュー・perf・API 設計（必要時のみ） |
+| `minimize-cursor-cost` (~/.agents/skills) | 再読込禁止・並列ツール呼び出し・無駄検証禁止 |
+
+優先順位: ユーザー指示 > セキュリティ > プライバシー > データ保護 > 既存機能互換 > 実リポジトリ挙動 > テスト結果 > Ponytail > 各skill推奨 > トークン削減。
+
+大型タスク開始時は最初の報告に Skill Bootstrap 表を含めること。
 ## 開発哲学 (最重要)
 
 **最大反復速度 (Maximum Iteration Speed)** を最優先とする。

--- a/README.md
+++ b/README.md
@@ -2,253 +2,991 @@
 
 <p align="center">
   <strong>Vision Beyond Limits.</strong><br/>
-  自前プロトコルで動く、LINE サードパーティクライアント（Web / React）
+  API-first, extensible third-party LINE client architecture for desktop, server, plugins, and custom clients.
 </p>
 
 <p align="center">
-  <img alt="version" src="https://img.shields.io/badge/version-0.5.1--beta-a78bfa?style=flat-square" />
+  <img alt="status" src="https://img.shields.io/badge/status-beta-a78bfa?style=flat-square" />
+  <img alt="runtime" src="https://img.shields.io/badge/runtime-Bun%201.6-f472b6?style=flat-square" />
   <img alt="license" src="https://img.shields.io/badge/license-MIT-22c55e?style=flat-square" />
-  <img alt="runtime" src="https://img.shields.io/badge/runtime-Bun-f472b6?style=flat-square" />
-  <img alt="stack" src="https://img.shields.io/badge/stack-Hono%20%2B%20React-0ea5e9?style=flat-square" />
-  <img alt="state" src="https://img.shields.io/badge/state-beta-a78bfa?style=flat-square" />
-  <img alt="PRs" src="https://img.shields.io/badge/PRs-welcome-22c55e?style=flat-square" />
 </p>
 
-<p align="center">
-  このさんさんとした太陽の下、Vyline を選んでくださるユーザーに出会えたことに感謝します。
-</p>
+---
 
-> **2026/08/20 beta 版 release 開始** — 本リポジトリは Vyline Beta 0.5.0 として公開されました。機能の安定性は保証されておらず、予期しない動作やアカウントリスクが含まれる可能性があります。
+## About
+
+Vyline is an independent third-party LINE client project.
+
+Vyline aims to become a clean, fast, extensible LINE client architecture with:
+
+- desktop client support
+- server mode support
+- separated frontend / backend
+- OpenAPI / Swagger based API
+- JavaScript / TypeScript plugin system
+- custom client support
+- multi-account support
+- grouped multi-image sending
+- storage management
+- backup / restore
+- Docker-friendly deployment
+- lightweight CPU / memory / network usage
+
+Vyline is currently in **Beta**.
+
+The project is still changing quickly. Some features are implemented, some are experimental, and some are planned.
 
 ---
 
-## ⚠️ ご利用前に必ずお読みください
+## Project Goals
 
-Vyline は LINE 非公式のサードパーティクライアントであり、LINE 株式会社・LY Corporation とは**無関係・未承認**です。
+Vyline is built around these goals:
 
-- **アカウントリスク**: LINE 利用規約に違反する可能性があり、アカウント停止等のリスクを伴います。**利用はすべて自己責任**です。
-- **同意ゲート**: ログイン直後に利用規約・免責事項を表示し、**同意しない限りアプリは一切動作しません**（同期・通信・表示を含む）。同意せず、または画面をスキップする等の手段で利用した場合も、**その時点で本規約に同意したものとみなされ**、開発者・Vyline のメンバーは一切の責任を負いません。
-- **目的の範囲**: 教育・学習・個人利用の範囲でご利用ください。第三者への攻撃・不正アクセス・迷惑行為・権利侵害は禁止です。
-- **データの扱い**: ログイン情報・セッション・暗号鍵・トーク履歴は端末内にのみ保存され、外部へ送信されません。
-- **解析ツール**: `tools/` 以下の解析ツールは [vyline-search](https://github.com/nezumi0627/vyline-search) リポジトリを Git Submodule としてリンクしたものです。Desktop LINE の unpack・逆コンパイルを行います。**教育・実験目的のみ**で使用し、解析結果を再配布しないでください。詳細: [docs/tools/DISCLAIMER.md](docs/tools/DISCLAIMER.md)
-- **開発者の免責**: 本ソフトウェアの利用により生じた一切の問題（アカウント停止、データ破損、法的問題等）について、開発者・Vyline のメンバーは責任を負いません。
+- provide a clean desktop client experience
+- separate frontend and backend completely
+- expose a stable backend API
+- provide Swagger / OpenAPI documentation
+- allow users to build custom clients
+- allow plugins written in JavaScript / TypeScript
+- isolate data per account
+- separate cache and saved media
+- make backup / restore reliable
+- run locally or on a server
+- support Docker / Docker Compose deployment
+- keep memory, CPU, and network usage low
+- keep documentation accurate and readable
 
-### 著作権表示
+Vyline should not become heavy or over-engineered.
 
-本ソフトウェアは [nezumi0627](https://github.com/nezumi0627) によって開発されています。改変・再配布・解説記事等では、必ず著作権表示（`nezumi0627`）を保持してください。ライセンス詳細は [LICENSE](LICENSE)（MIT）を参照してください。
-
----
-
-## Vyline とは
-
-**Vyline** は LINE にログインしてメッセージの送受信・Flex/Rich 表示・テーマカスタマイズを行うサードパーティクライアントです。外部サービスに依存せず、**自前のプロトコルスタック `@vyline/protocol`** で動作します。
-
-| 項目       | 内容                                     |
-| ---------- | ---------------------------------------- |
-| 誰向け     | UI を自分好みにしたい人・開発者          |
-| なにが違う | テーマ管理 / メンション / ローカル最適化 |
-| ライセンス | MIT                                      |
-| 状態       | Beta 0.5.0                               |
-
-### 主な機能
-
-| カテゴリ         | 内容                                                                                                                  |
-| ---------------- | --------------------------------------------------------------------------------------------------------------------- |
-| **ログイン**     | QR / Email ログイン、マルチアカウント、セッション復元                                                                 |
-| **メッセージ**   | 送受信 / 返信 / 取り消し / 既読制御 / 再送                                                                            |
-| **メンション**   | `@ALL` / `@名前`（LINE Desktop 準拠の `MENTION` metadata）                                                            |
-| **メディア**     | 画像・動画・音声（画像は自動圧縮、設定で高画質送信も可） / LINE 絵文字(sticon) / スタンプ全種                         |
-| **Flex / Rich**  | 公式準拠の描画、カルーセルのマウスドラッグ                                                                            |
-| **リアクション** | 1クリック、公式バッジ、既読者一覧                                                                                     |
-| **通話**         | 音声 / ビデオ通話（実験的）                                                                                           |
-| **チャット管理** | ピン / 非表示 / ミュート / ブロック / MID コピー / グループ作成・招待                                                 |
-| **VyTheme**      | フルカスタマイズテーマ、文字サイズ、密度、プロフィール背景                                                            |
-| **E2EE**         | Letter Sealing の復号・送信、Desktop 鍵 import                                                                        |
-| **プライバシー** | ストリーマーモード、PIN ロック                                                                                        |
-| **VylineBackup** | トーク履歴・メディアのスナップショット作成 / 復元 / 削除                                                              |
-| **その他**       | チャット詳細ログ(JSONL) / Keepメモ / 相手プロフィール背景表示 / 通話中バッジ / 共通グループ高速表示 / トーク保存(TXT) |
+Unnecessary abstractions, wrappers, services, dependencies, and large rewrites should be avoided unless they clearly improve the project.
 
 ---
 
-## ⚠️ 破壊的変更 (v0.5.0)
+## Status
 
-v0.5.0 は v0.4.x と**互換性がありません**。以下の変更により、既存の設定・キャッシュの一部リセットが必要な場合があります。
+Vyline is currently a **Beta project**.
 
-| 変更                                                   | 影響                                                                        |
-| ------------------------------------------------------ | --------------------------------------------------------------------------- |
-| 受信エンジンを Push 長ポール → fetchOps 方式に刷新     | イベントポーリングの挙動が変わります                                        |
-| 公開 API (`/v1/`) を新設                               | 環境変数 `VYLINE_API_ADMIN_SECRET` を設定するとトークン管理が可能になります |
-| イベント種別の拡張（通話・メンバー変更・アナウンス等） | フロントエンドの旧バージョンとは互換しません                                |
+Current priority areas:
 
-**アップグレード手順**: `git pull && bun install && bun run dev` のみで動作します。既存のログイン状態は維持されます。
+- repository cleanup
+- documentation cleanup
+- frontend / backend separation
+- Swagger / OpenAPI API design
+- plugin system
+- custom client support
+- multi-account storage isolation
+- multi-image sending
+- server mode
+- Docker deployment
+- update / migration flow
+- performance optimization
 
 ---
 
-## Quick Start
+## Features
+
+### Desktop Client
+
+Vyline provides a desktop client experience for LINE-like messaging workflows.
+
+The UI should remain clean, fast, and easy to use.
+
+---
+
+### API-first Architecture
+
+Vyline must be designed as an API-first application.
+
+The backend should expose a stable API that can be used by:
+
+- the official Vyline frontend
+- custom frontends
+- server dashboards
+- plugins
+- automation tools
+- future CLI wrappers
+- external clients
+
+Frontend code must not depend directly on backend private modules.
+
+The frontend should communicate with the backend through the public API or a generated API client.
+
+---
+
+## API / Swagger / OpenAPI
+
+Vyline must provide a documented backend API.
+
+Swagger / OpenAPI support is required.
+
+The API should be available in development and server mode.
+
+Required API documentation routes:
+
+```txt
+GET /docs
+GET /swagger
+GET /openapi.json
+```
+
+The API must be versioned.
+
+Example:
+
+```txt
+/api/v1/...
+```
+
+Public API, internal API, plugin API, and desktop IPC must be separated.
+
+---
+
+### Required API Areas
+
+The backend API must cover at least:
+
+* accounts
+* sessions
+* chats
+* messages
+* media
+* multi-image sending
+* storage
+* cache
+* saved media
+* backup
+* restore
+* settings
+* themes
+* plugins
+* notifications
+* health checks
+* metrics
+
+---
+
+### Example API Endpoints
+
+```txt
+GET    /health
+GET    /metrics
+GET    /api/v1/status
+
+GET    /api/v1/accounts
+POST   /api/v1/accounts/switch
+GET    /api/v1/accounts/:accountId/profile
+
+GET    /api/v1/accounts/:accountId/chats
+GET    /api/v1/accounts/:accountId/chats/:chatId/messages
+POST   /api/v1/accounts/:accountId/chats/:chatId/messages
+
+POST   /api/v1/accounts/:accountId/chats/:chatId/media/batch
+
+GET    /api/v1/accounts/:accountId/storage
+GET    /api/v1/accounts/:accountId/storage/cache
+DELETE /api/v1/accounts/:accountId/storage/cache
+
+GET    /api/v1/accounts/:accountId/plugins
+POST   /api/v1/accounts/:accountId/plugins/:pluginId/enable
+POST   /api/v1/accounts/:accountId/plugins/:pluginId/disable
+
+POST   /api/v1/accounts/:accountId/backup
+POST   /api/v1/accounts/:accountId/restore
+```
+
+Actual endpoint names may change during Beta, but the final API must be documented through OpenAPI / Swagger.
+
+---
+
+## Frontend / Backend Separation
+
+Vyline must separate frontend and backend completely.
+
+The frontend should be replaceable.
+
+The backend should be reusable.
+
+The desktop shell should only bundle or connect frontend and backend. It should not create hidden dependencies between them.
+
+Required direction:
+
+```txt
+apps/
+  web/
+  desktop/
+  server/
+
+packages/
+  api/
+  api-client/
+  core/
+  line/
+  storage/
+  plugin-sdk/
+  plugin-runtime/
+  shared/
+  ui/
+```
+
+Rules:
+
+* frontend must not import backend private modules
+* backend must not import React components
+* shared types must live in shared packages
+* API types should be generated or shared safely
+* desktop IPC must not replace the public API
+* server mode and desktop mode should use the same core logic
+
+---
+
+## Custom Clients
+
+Vyline is not only a themeable client.
+
+Users and developers should be able to build their own clients using Vyline's backend API.
+
+Possible clients:
+
+* official Vyline desktop frontend
+* custom web client
+* minimal chat viewer
+* notification-only client
+* media manager
+* server dashboard
+* future CLI wrapper
+
+Custom clients should use:
+
+* public REST API
+* generated API client
+* shared types
+* documented auth flow
+* documented account scope
+
+The goal is to allow client replacement, not just theme replacement.
+
+---
+
+## Plugin System
+
+Vyline must support a JavaScript / TypeScript plugin system.
+
+TypeScript is recommended.
+
+The design can be inspired by plugin-based clients such as Vencord, but it must be safe for Vyline's architecture.
+
+Plugins should extend Vyline without modifying core code.
+
+---
+
+### Plugin Requirements
+
+Plugins must support:
+
+* install
+* enable
+* disable
+* update
+* remove
+* activate
+* deactivate
+* settings
+* permissions
+* logs
+* error isolation
+* developer mode
+* examples
+* plugin SDK
+
+Disabled plugins should have almost zero runtime cost.
+
+Plugin crashes must not crash Vyline itself.
+
+---
+
+### Example Plugin
+
+```ts
+import { definePlugin } from "@vyline/plugin-sdk";
+
+export default definePlugin({
+  id: "example-plugin",
+  name: "Example Plugin",
+  version: "0.1.0",
+  description: "Example Vyline plugin",
+  permissions: ["messages:read", "notifications:send"],
+
+  async activate(ctx) {
+    ctx.messages.on("message", (message) => {
+      ctx.logger.info("New message", message.id);
+    });
+  },
+
+  async deactivate(ctx) {
+    // cleanup listeners / resources
+  },
+});
+```
+
+---
+
+### Plugin Permissions
+
+Example permissions:
+
+```txt
+messages:read
+messages:send
+chats:read
+media:read
+media:write
+storage:read
+storage:write
+notifications:send
+ui:extend
+network:request
+settings:read
+settings:write
+```
+
+Plugins must not access:
+
+* raw tokens
+* sessions
+* cookies
+* private keys
+* unrestricted filesystem paths
+* backend private APIs
+* another account's data
+* raw MID values unless absolutely required and permissioned
+
+Plugin APIs must be account-scoped.
+
+---
+
+## Multi-account Support
+
+Vyline must support multiple LINE accounts.
+
+Account data must be separated by account scope using the user's LINE `mid` or a safe derived account identifier.
+
+Raw MID values should not be exposed unnecessarily.
+
+Recommended storage direction:
+
+```txt
+data/
+  accounts/
+    <safe-account-id>/
+      profile.json
+      session/
+      storage/
+      cache/
+      media/
+      db/
+      plugins/
+      logs/
+      backup/
+```
+
+The following data must not be mixed between accounts:
+
+* messages
+* chats
+* media
+* cache
+* saved media
+* sessions
+* settings
+* plugin data
+* logs
+* backups
+* pending uploads
+* pending multi-image batches
+
+Account switching must clean up old listeners, stale UI state, old sockets, old plugin contexts, and old media references.
+
+---
+
+## Multi-image Sending
+
+Vyline must support grouped multi-image sending.
+
+For LINE Desktop compatibility, multiple images should not be merged into one message.
+
+Instead, multiple images should be sent as separate `IMAGE` messages and connected using relation fields.
+
+Required relation fields:
+
+* `relatedMessageId`
+* `messageRelationType`
+* `relatedMessageServiceCode`, if required
+
+Expected behavior:
+
+```txt
+image 1 -> IMAGE message
+image 2 -> IMAGE message, relatedMessageId = image 1 message id
+image 3 -> IMAGE message, relatedMessageId = image 2 message id
+```
+
+The UI should group related image messages visually while keeping each image as an individual message internally.
+
+This must work across:
+
+* frontend file picker
+* frontend send action
+* backend media batch API
+* protocol layer
+* E2EE path
+* plain media path
+* storage
+* message list API
+* frontend message model
+* UI grouped rendering
+* app restart
+* multi-account environments
+
+This feature is not complete until:
+
+* relation fields are sent
+* relation fields are saved
+* relation fields are returned by the message API
+* the UI groups related images
+* restart keeps the grouping
+* account switching does not mix media
+* E2EE and plain paths both work
+* partial failures do not cause duplicate sending
+
+---
+
+## Storage Management
+
+Vyline must separate temporary cache from saved user media.
+
+Cache is temporary and can be deleted safely.
+
+Saved media is user-owned persistent data and must be preserved through backup and restore.
+
+Required storage categories:
+
+* cache
+* saved media
+* account data
+* plugin data
+* logs
+* backups
+* temporary uploads
+
+Cache and saved media must not be mixed.
+
+Storage size calculation should be incremental or cached. It must not block the UI with full scans on every startup.
+
+---
+
+## Backup / Restore
+
+Backup and restore must be account-aware.
+
+Backup should preserve:
+
+* saved media
+* message references
+* account settings
+* plugin settings, where safe
+* storage metadata
+
+Restore must not mix data between accounts.
+
+Restore should handle missing media, old schemas, and partial data safely.
+
+---
+
+## Server Mode
+
+Vyline must be able to run on a server, not only as a desktop app.
+
+Server mode should expose:
+
+* REST API
+* Swagger / OpenAPI docs
+* health check endpoint
+* metrics endpoint
+* static frontend serving option
+* configurable storage paths
+* configurable plugin directory
+* configurable logs directory
+* CORS settings
+* auth settings
+* reverse proxy support
+
+Example target command:
+
+```bash
+bun run server
+```
+
+Required server endpoints:
+
+```txt
+GET /health
+GET /metrics
+GET /docs
+GET /swagger
+GET /openapi.json
+```
+
+---
+
+## Docker Support
+
+Vyline should be easy to run in Docker or Docker Compose.
+
+Required files:
+
+```txt
+Dockerfile
+docker-compose.yml
+.dockerignore
+```
+
+Recommended persistent directories:
+
+* data
+* config
+* logs
+* plugins
+* media
+
+Example:
+
+```yaml
+services:
+  vyline:
+    build: .
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./data:/app/data
+      - ./config:/app/config
+      - ./logs:/app/logs
+      - ./plugins:/app/plugins
+    environment:
+      - VYLINE_HOST=0.0.0.0
+      - VYLINE_PORT=3000
+      - VYLINE_DATA_DIR=/app/data
+      - VYLINE_CONFIG_DIR=/app/config
+      - VYLINE_LOG_DIR=/app/logs
+      - VYLINE_PLUGIN_DIR=/app/plugins
+```
+
+---
+
+## Update / Migration
+
+Vyline should be easy to update.
+
+Required documentation:
+
+* source update guide
+* Docker update guide
+* backup before update
+* rollback guide
+* database migration guide
+* config migration guide
+* breaking changes guide
+
+Example source update flow:
+
+```bash
+git pull
+bun install --frozen-lockfile
+bun run build
+bun run migrate
+bun run server
+```
+
+Example Docker update flow:
+
+```bash
+docker compose pull
+docker compose up -d --build
+```
+
+---
+
+## Runtime
+
+Vyline targets **Bun 1.6**.
+
+Common commands:
 
 ```bash
 bun install
-bun run dev          # backend :3001 + frontend :5173
+bun run dev
+bun run build
+bun run test
+bun run typecheck
+bun run server
 ```
 
-ブラウザで `http://localhost:5173` を開きます。
+Actual commands may change while the project is in Beta.
 
-| コマンド               | 内容                           |
-| ---------------------- | ------------------------------ |
-| `bun run dev:backend`  | backend のみ（:3001）          |
-| `bun run dev:frontend` | frontend のみ（:5173）         |
-| `bun run typecheck`    | 型チェック（全ワークスペース） |
-| `bun run lint`         | Biome lint                     |
-| `bun run build`        | frontend 本番ビルド            |
-
-詳細: [docs/onboarding.md](docs/onboarding.md) · [docs/development.md](docs/development.md) · [AGENTS.md](AGENTS.md)
-
-### セルフホスト（Docker）
-
-自宅サーバーに立てて、複数端末の Web ブラウザから同じ LINE セッションを利用できます（履歴・画像はサーバー側に永続化）。
-
-```bash
-docker compose up -d --build   # http://localhost:3001
-```
-
-設定・Cloudflare Access での外部公開手順: [docs/selfhosting.md](docs/selfhosting.md)
-
-### 推奨環境
-
-| 項目               | 推奨値         | 備考                                               |
-| ------------------ | -------------- | -------------------------------------------------- |
-| **LINE アプリ**    | IOSIPAD 26.7.2 | `x-line-application` ヘッダー値。最新版を推奨      |
-| **OS**             | iOS 18.0       | Android / Windows 互換は未検証                     |
-| **デバイスモード** | IOSIPAD        | `VYLINE_DEVICE` 環境変数で指定（省略時は IOSIPAD） |
-
-> 定義元: `packages/protocol/src/desktop/types.ts` の DesktopProfile。実際のヘッダー値は `"x-line-application": "IOSIPAD\t26.7.2\tiOS\t18.0"` のように伝搬されます。
+Documentation should always reflect the actual commands in the repository.
 
 ---
 
-## Architecture
+## Performance Policy
 
-```
-┌─ Frontend (React + Vite) ── apps/desktop ──┐
-│  store / mappers / sync / VyTheme UI       │
-├─ Backend (Hono on Bun) ───── backend ──────┤
-│  BFF routes → lineService → clientManager  │
-├─ Vyline ──────────── packages/protocol ────┤
-│  domain / dictionary / E2EE / Thrift stack │
-└─ LINE Servers ──────────────────────────────┘
-```
+Vyline should be lightweight.
 
-| パス                  | 役割                     |
-| --------------------- | ------------------------ |
-| `apps/desktop`        | React UI                 |
-| `backend`             | Hono BFF                 |
-| `packages/protocol`   | プロトコル本体（Vyline） |
-| `packages/line-types` | Thrift 型（vendored）    |
+A third-party client is not useful if it is heavier than the official desktop client.
 
-### E2EE / Desktop 鍵
+Vyline should avoid:
 
-過去メッセージの復号には、公式 LINE Desktop から抽出した自己鍵一式が必要です。
+* loading all messages into memory
+* loading all media at startup
+* storing large image buffers in UI state
+* converting large media to base64 unnecessarily
+* unnecessary polling
+* duplicate network requests
+* full cache scans on every startup
+* keeping inactive accounts fully loaded
+* keeping disabled plugins active
+* excessive background CPU usage
+* unlimited in-memory logs
+* unnecessary deep clones
+* unnecessary JSON stringify / parse cycles
 
-1. LINE.exe 起動状態で鍵を抽出（[docs/analysis/](docs/analysis/)）
-2. `backend/data/desktop-e2ee-keys.json` に配置（**gitignore・コミット禁止**）
-3. backend 起動時に自動 import
+Vyline should use:
 
-### 公開 API (`/v1/`)
+* lazy loading
+* pagination
+* virtualized message lists
+* virtualized media grids
+* incremental storage scanning
+* bounded memory caches
+* request deduplication
+* retry backoff
+* upload concurrency limits
+* worker threads or web workers for heavy tasks
+* cleanup after account switching
+* cleanup after plugin disable
+* memory and CPU measurement
 
-セルフホスト時に Bearer トークンで Vyline を外部から操作できます。
+Performance improvements must be measured, not guessed.
 
-```bash
-# トークン作成（VYLINE_API_ADMIN_SECRET を設定後）
-curl -X POST http://localhost:3001/v1/tokens \
-  -H "Authorization: Bearer $VYLINE_API_ADMIN_SECRET" \
-  -H "Content-Type: application/json" \
-  -d '{"name": "my-bot"}'
+Important metrics:
 
-# チャット一覧取得
-curl http://localhost:3001/v1/accounts/{accountId}/chats \
-  -H "Authorization: Bearer vyl_xxxx..."
-```
-
-API 仕様（OpenAPI 3.1）: `GET /openapi.json` または [zensical.org](https://zensical.org)
-
-### 解析ツールキット（vyline-search）
-
-Desktop LINE（Themida 保護）の unpack / ネイティブシンボル検索 / 逆コンパイルを行う独立ツールキットです。教育・研究目的で `findNativeSymbol` による文字列 xref 解析と Ghidra decompile をワンコマンドで実行できます。
-
-> [!WARNING]
-> **注意**: LINE デスクトップクライアントが起動中の状態では、解析ツール（unpack 等）が正常に動作しません（単一インスタンス制御により frida の注入が拒否されプロセスが強制終了するため）。必ず LINE アプリを完全に終了させてから実行してください。
-
-**[github.com/nezumi0627/vyline-search](https://github.com/nezumi0627/vyline-search)**
-
-```powershell
-bun run vyline:check                  # インストール版 / 最新版の比較
-bun run vyline:versions               # インストール済みバージョン一覧
-bun run vyline:unpack -- --version <ver>   # インストール済みバージョンを選択して unpack
-bun run vyline:update                 # LINE Desktop を最新版へ更新
-bun run vyline:find-native -- sendMessage  # ネイティブシンボル検索
-```
-
-> **注意**: `vyline:unpack` / `vyline:update` は **LINE を終了してから実行**してください。
-> 稼働中は Frida 注入が拒否され `ProcessNotRespondingError` になります。
+* startup time
+* idle memory usage
+* idle CPU usage
+* message list rendering time
+* media loading memory
+* account switch memory delta
+* server idle memory
+* network request count
+* duplicate request count
 
 ---
 
-## ドキュメント
+## Documentation
 
-| リンク                                                     | 内容                                   |
-| ---------------------------------------------------------- | -------------------------------------- |
-| [docs/README.md](docs/README.md)                           | ドキュメント索引                       |
-| [docs/onboarding.md](docs/onboarding.md)                   | 初日チェックリスト                     |
-| [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md)               | 貢献フロー                             |
-| [docs/architecture.md](docs/architecture.md)               | 層構造                                 |
-| [docs/development.md](docs/development.md)                 | 開発コマンド                           |
-| [docs/selfhosting.md](docs/selfhosting.md)                 | Docker セルフホスト・Cloudflare Access |
-| [docs/protocol/dictionary.md](docs/protocol/dictionary.md) | RPC 辞書                               |
-| [AGENTS.md](AGENTS.md)                                     | エージェント向けガイド                 |
-| [CHANGELOG.md](CHANGELOG.md)                               | 変更履歴                               |
-| [zensical.org](https://zensical.org)                       | 公開ドキュメント・API リファレンス     |
-| [/openapi.json](/openapi.json)                             | OpenAPI 3.1 仕様（ローカル）           |
+README should stay short enough to be an entry point.
 
-公開ドキュメント・チュートリアル: **[zensical.org](https://zensical.org)**
+Detailed documentation should live in `docs/`.
+
+Required documentation structure:
+
+```txt
+docs/
+  user-guide/
+    installation.md
+    update.md
+    account-switching.md
+    sending-media.md
+    storage.md
+    backup-restore.md
+    troubleshooting.md
+
+  developer-guide/
+    architecture.md
+    frontend.md
+    backend.md
+    api.md
+    plugin-system.md
+    plugin-sdk.md
+    custom-client.md
+    multi-account.md
+    account-storage.md
+    multi-image-sending.md
+    message-relations.md
+    performance-budget.md
+    memory-policy.md
+    network-optimization.md
+    testing.md
+
+  api/
+    openapi.md
+    swagger.md
+    media-batch.md
+
+  deployment/
+    local.md
+    docker.md
+    docker-compose.md
+    server.md
+    reverse-proxy.md
+    systemd.md
+
+  agents/
+    overview.md
+    coding-rules.md
+    review-rules.md
+```
+
+Docs must match the actual implementation.
+
+Do not claim features as complete unless they are verified.
 
 ---
 
-## 貢献 / 募集
+## Development Policy
 
-- 🐛 [Bug report](.github/ISSUE_TEMPLATE/bug_report.md)
-- ✨ [Feature request](.github/ISSUE_TEMPLATE/feature_request.md)
-- 📝 [Pull request](.github/pull_request_template.md)
+Vyline development follows these principles:
 
-貢献フローは [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) を参照してください。PR には解析対象ソフトウェアの実体・鍵・トークンなどを含めないでください。
+* keep code simple
+* avoid unnecessary abstractions
+* prefer existing APIs and standard library features
+* avoid unnecessary dependencies
+* keep frontend and backend separated
+* keep APIs stable and documented
+* protect user data
+* isolate account data
+* make plugins permission-based
+* measure performance changes
+* separate confirmed bugs from suspected issues
+* keep README readable
+* move detailed information into docs
 
-現在、以下を募集しています:
+Existing implementation should be questioned, but not blindly replaced.
 
-- **PR**: バグ修正、機能改善、ドキュメントの更新
-- **アイコン**: アプリアイコン・テーマアイコンのデザイン
-- **バナー**: SNS・ブログでのプロモーション用バナー
-- **定期的なメンテナー**: 個人開発のため、継続的に助けていただける方を募集中
+If existing code is correct and has a valid reason to exist, keep it.
 
-興味がある方は [AGENTS.md](AGENTS.md) の手順に従ってプルリクエストをお送りください。
+If the structure blocks future development, it may be rebuilt.
+
+Breaking changes are allowed when necessary, but existing features must not be broken without a migration path.
 
 ---
 
-## Vyline Desktop
+## Branch Rules
 
-> **Coming Soon** 🚀
+Recommended branch names:
 
-Vyline が安定版に到達した後、専用のデスクトップアプリ **Vyline Desktop** をリリース予定です。
+```txt
+feature/<short-name>
+fix/<short-name>
+docs/<short-name>
+refactor/<short-name>
+security/<short-name>
+perf/<short-name>
+chore/<short-name>
+```
 
-- 🖥️ Windows / macOS / Linux ネイティブアプリ
-- 🔔 プッシュ通知
-- 🗂️ トレイアイコン常駐
-- 🔒 ローカルデータ完全管理
+Recommended commit style:
 
-Vyline の安定版リリースをお待ちください。
+```txt
+feat(api): add media batch endpoint
+fix(storage): separate cache from saved media
+docs(readme): simplify project overview
+perf(messages): virtualize message list
+security(plugins): restrict filesystem access
+```
+
+---
+
+## Agent / Skill Policy
+
+Vyline development may use coding-agent skill sets to reduce unnecessary code, avoid over-engineering, and improve review quality.
+
+Before large refactors, audits, API redesigns, plugin work, or documentation cleanup, the agent should check and use the following skill / rule sets when available.
+
+### Required Skill Sets
+
+| Skill | Repository | Purpose |
+|---|---|---|
+| Ponytail | `DietrichGebert/ponytail` | YAGNI, standard library first, reuse existing code, avoid unnecessary abstraction |
+| Caveman | `JuliusBrussee/caveman` | Compress reports and explanations while keeping code blocks intact |
+| agent-skills-standard | `HoangNguyen0403/agent-skills-standard` | Load task-specific skills only when needed |
+| agent-skills | `addyosmani/agent-skills` | Production-grade frontend, performance, API, testing, and documentation guidance |
+| Minimize-Cursor-Cost | `inboxpraveen/Minimize-Cursor-Cost` | Reduce repeated reads, wasted tool calls, unnecessary verification, and token cost |
+
+### How These Skills Should Be Used
+
+Ponytail should be used as the default engineering mindset.
+
+Use it to avoid:
+
+- unnecessary wrappers
+- unnecessary services
+- unnecessary managers
+- unnecessary dependencies
+- unnecessary rewrites
+- future-proofing without actual need
+- code that only passes data through another layer
+
+Caveman should be used only for shortening reports, comments, and summaries.
+
+Do not apply Caveman to:
+
+- source code
+- OpenAPI schemas
+- JSON
+- YAML
+- TOML
+- SQL
+- Dockerfiles
+- migration files
+- security warnings
+- legal disclaimers
+- user-facing documentation
+
+`agent-skills-standard` and `addyosmani/agent-skills` should be loaded only when relevant.
+
+Do not load every skill at once.
+
+Examples:
+
+- API redesign → load API / OpenAPI related skills
+- plugin system → load plugin / sandbox / security related skills
+- Docker / server mode → load deployment / DevOps related skills
+- performance work → load frontend / React / server performance related skills
+- docs cleanup → load documentation related skills
+
+`Minimize-Cursor-Cost` should be used to keep the workflow efficient.
+
+The agent should:
+
+- avoid reading the same file repeatedly
+- avoid re-checking already confirmed facts
+- batch related searches
+- inspect only relevant files first
+- run targeted tests before full test suites
+- report unknowns instead of wasting time pretending everything is verified
+
+### Skill Priority
+
+These skills are helpers, not final authority.
+
+Priority order:
+
+1. User instructions
+2. Security
+3. Privacy
+4. Data safety
+5. Existing feature compatibility
+6. Actual repository behavior
+7. Test results
+8. Ponytail minimalism
+9. Other skill recommendations
+10. Token reduction
+
+Token reduction must never override correctness, security, privacy, or maintainability.
+
+### Required Agent Report
+
+When an AI coding agent starts a large task, it should include a short skill bootstrap report:
+
+```md
+## Skill Bootstrap
+
+| Skill | Status | Used for |
+|---|---|---|
+| Ponytail | Available / Not available | Minimal implementation and YAGNI |
+| Caveman | Available / Not available | Report compression only |
+| agent-skills-standard | Available / Not available | Task-specific skills |
+| addyosmani/agent-skills | Available / Not available | Production-grade review |
+| Minimize-Cursor-Cost | Available / Not available | Efficient repository exploration |
+
+Notes:
+- Missing skills must be listed.
+- If a skill is unavailable, continue with the same principles manually.
+- Do not stop work only because a skill is unavailable.
+```
+
+---
+
+## Support Vyline
+
+Vyline is developed as an independent project.
+
+Small support is appreciated and helps with development, testing, documentation, and maintenance.
+
+Suggested support tiers:
+
+|            Amount | Tier              | Notes                                                             |
+| ----------------: | ----------------- | ----------------------------------------------------------------- |
+|     Under 500 JPY | Thank you support | Helps development and maintenance                                 |
+|   500 JPY or more | Supporter         | May be listed as a supporter if requested                         |
+| 1,000 JPY or more | Special supporter | May receive acknowledgement in docs or release notes if requested |
+| 3,000 JPY or more | Major supporter   | May be listed as a major supporter if requested                   |
+
+Support does not guarantee:
+
+* feature implementation
+* bug fixes
+* private support
+* priority support
+* special permissions
+* account support
+
+Supporter names are only listed with permission.
+
+Payment details such as PayPay links or QR codes should be documented carefully and should not expose private information.
+
+---
+
+## Security and Privacy
+
+Vyline should never expose sensitive data unnecessarily.
+
+Do not log or expose:
+
+* raw MID values
+* tokens
+* sessions
+* cookies
+* private keys
+* local user paths
+* message contents in debug logs
+* account identifiers without need
+* plugin private data
+* backup private data
+
+Plugins must use permission-scoped APIs.
+
+Account data must remain separated.
+
+Multi-account data mixing is a serious bug.
+
+---
+
+## Disclaimer
+
+Vyline is an independent third-party client project.
+
+Vyline is not affiliated with, endorsed by, or sponsored by LY Corporation or LINE.
+
+Use this project at your own risk.
+
+The maintainers are not responsible for account issues, data loss, service restrictions, or damages caused by using this software.
+
+If there is a problem with content in this repository, please contact the maintainer.
 
 ---
 
 ## License
 
-MIT — see [LICENSE](LICENSE)
+MIT License.
 
-**著作権**: [`nezumi0627`](https://github.com/nezumi0627)
-改変・再配布・記事・投稿等では出典表示をお願いします（詳細は [LICENSE](LICENSE) の Attribution requirement を参照）。
+See `LICENSE` for details.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@
   <img alt="PRs" src="https://img.shields.io/badge/PRs-welcome-22c55e?style=flat-square" />
 </p>
 
+
+<p align="center">このさんさんとした太陽の下、Vyline を選んでくださるユーザーに出会えたことに感謝します。</p>
+
 <p align="center">
   <a href="#vyline-とは">概要</a> ・
   <a href="#主な機能">機能</a> ・

--- a/README.md
+++ b/README.md
@@ -2,294 +2,440 @@
 
 <p align="center">
   <strong>Vision Beyond Limits.</strong><br/>
-  自前プロトコルで動く、LINE サードパーティクライアント（Web / React）
+  自前のプロトコルスタックで動作する、拡張可能な LINE サードパーティクライアント
 </p>
 
 <p align="center">
   <img alt="version" src="https://img.shields.io/badge/version-0.5.1--beta-a78bfa?style=flat-square" />
   <img alt="license" src="https://img.shields.io/badge/license-MIT-22c55e?style=flat-square" />
   <img alt="runtime" src="https://img.shields.io/badge/runtime-Bun-f472b6?style=flat-square" />
-  <img alt="stack" src="https://img.shields.io/badge/stack-Hono%20%2B%20React-0ea5e9?style=flat-square" />
-  <img alt="state" src="https://img.shields.io/badge/state-beta-a78bfa?style=flat-square" />
+  <img alt="backend" src="https://img.shields.io/badge/backend-Hono-e879f9?style=flat-square" />
+  <img alt="frontend" src="https://img.shields.io/badge/frontend-React%20%2B%20Vite-38bdf8?style=flat-square" />
   <img alt="PRs" src="https://img.shields.io/badge/PRs-welcome-22c55e?style=flat-square" />
 </p>
 
 <p align="center">
-  このさんさんとした太陽の下、Vyline を選んでくださるユーザーに出会えたことに感謝します。
+  <a href="#vyline-とは">概要</a> ・
+  <a href="#主な機能">機能</a> ・
+  <a href="#インストール更新">インストール・更新</a> ・
+  <a href="#vyline-を支援する">支援・参加</a> ・
+  <a href="#公開-api">API</a> ・
+  <a href="#ドキュメント">ドキュメント</a> ・
+  <a href="#ロードマップ">ロードマップ</a>
 </p>
 
-> **2026/08/20 beta 版 release 開始** — 本リポジトリは Vyline Beta 0.5.0 として公開されました。機能の安定性は保証されておらず、予期しない動作やアカウントリスクが含まれる可能性があります。
+> [!CAUTION]
+> Vyline は **LINE 非公式・未承認**のサードパーティクライアントです。LINE 株式会社および LY Corporation とは関係ありません。利用規約への抵触やアカウント停止を含むリスクを理解したうえで、自己責任で使用してください。
 
----
-
-## ⚠️ ご利用前に必ずお読みください
-
-Vyline は LINE 非公式のサードパーティクライアントであり、LINE 株式会社・LY Corporation とは**無関係・未承認**です。
-
-- **アカウントリスク**: LINE 利用規約に違反する可能性があり、アカウント停止等のリスクを伴います。**利用はすべて自己責任**です。
-- **同意ゲート**: ログイン直後に利用規約・免責事項を表示し、**同意しない限りアプリは一切動作しません**（同期・通信・表示を含む）。同意せず、または画面をスキップする等の手段で利用した場合も、**その時点で本規約に同意したものとみなされ**、開発者・Vyline のメンバーは一切の責任を負いません。
-- **目的の範囲**: 教育・学習・個人利用の範囲でご利用ください。第三者への攻撃・不正アクセス・迷惑行為・権利侵害は禁止です。
-- **データの扱い**: ログイン情報・セッション・暗号鍵・トーク履歴は端末内にのみ保存され、外部へ送信されません。
-- **解析ツール**: `tools/` 以下の解析ツールは [vyline-search](https://github.com/nezumi0627/vyline-search) リポジトリを Git Submodule としてリンクしたものです。Desktop LINE の unpack・逆コンパイルを行います。**教育・実験目的のみ**で使用し、解析結果を再配布しないでください。詳細: [docs/tools/DISCLAIMER.md](docs/tools/DISCLAIMER.md)
-- **開発者の免責**: 本ソフトウェアの利用により生じた一切の問題（アカウント停止、データ破損、法的問題等）について、開発者・Vyline のメンバーは責任を負いません。
-
-### 著作権表示
-
-本ソフトウェアは [nezumi0627](https://github.com/nezumi0627) によって開発されています。改変・再配布・解説記事等では、必ず著作権表示（`nezumi0627`）を保持してください。ライセンス詳細は [LICENSE](LICENSE)（MIT）を参照してください。
+> [!NOTE]
+> 2026年8月20日に Beta 0.5.0 として公開を開始しました。現在のバージョンは **Beta 0.5.1** です。Beta 版のため、仕様変更・不具合・データ損失が発生する可能性があります。
 
 ---
 
 ## Vyline とは
 
-**Vyline** は LINE にログインしてメッセージの送受信・Flex/Rich 表示・テーマカスタマイズを行うサードパーティクライアントです。外部サービスに依存せず、**自前のプロトコルスタック `@vyline/protocol`** で動作します。
+**Vyline** は、メッセージの送受信、Flex / Rich 表示、テーマカスタマイズ、バックアップなどを備えた Web / React ベースの LINE クライアントです。
 
-| 項目       | 内容                                     |
-| ---------- | ---------------------------------------- |
-| 誰向け     | UI を自分好みにしたい人・開発者          |
-| なにが違う | テーマ管理 / メンション / ローカル最適化 |
-| ライセンス | MIT                                      |
-| 状態       | Beta 0.5.0                               |
+外部の中継サービスに依存せず、独自実装のプロトコルパッケージ **`@vyline/protocol`** を介して LINE サーバーと通信します。UI、バックエンド、プロトコルを分離しているため、テーマ、公開 API、将来のプラグインやカスタムクライアントへ拡張できる構成です。
 
-### 主な機能
+| 項目 | 内容 |
+| --- | --- |
+| 対象 | UI を自分好みに調整したいユーザー、開発者、セルフホスト利用者 |
+| 特徴 | 自前プロトコル、VyTheme、公開 API、ローカル優先のデータ管理 |
+| 技術 | React + Vite / Hono on Bun / TypeScript / Thrift |
+| 状態 | Beta 0.5.1 |
+| ライセンス | MIT |
 
-| カテゴリ         | 内容                                                                                                                  |
-| ---------------- | --------------------------------------------------------------------------------------------------------------------- |
-| **ログイン**     | QR / Email ログイン、マルチアカウント、セッション復元                                                                 |
-| **メッセージ**   | 送受信 / 返信 / 取り消し / 既読制御 / 再送                                                                            |
-| **メンション**   | `@ALL` / `@名前`（LINE Desktop 準拠の `MENTION` metadata）                                                            |
-| **メディア**     | 画像・動画・音声（画像は自動圧縮、設定で高画質送信も可） / LINE 絵文字(sticon) / スタンプ全種                         |
-| **Flex / Rich**  | 公式準拠の描画、カルーセルのマウスドラッグ                                                                            |
-| **リアクション** | 1クリック、公式バッジ、既読者一覧                                                                                     |
-| **通話**         | 音声 / ビデオ通話（実験的）                                                                                           |
-| **チャット管理** | ピン / 非表示 / ミュート / ブロック / MID コピー / グループ作成・招待                                                 |
-| **VyTheme**      | フルカスタマイズテーマ、文字サイズ、密度、プロフィール背景                                                            |
-| **E2EE**         | Letter Sealing の復号・送信、Desktop 鍵 import                                                                        |
-| **プライバシー** | ストリーマーモード、PIN ロック                                                                                        |
-| **VylineBackup** | トーク履歴・メディアのスナップショット作成 / 復元 / 削除                                                              |
-| **その他**       | チャット詳細ログ(JSONL) / Keepメモ / 相手プロフィール背景表示 / 通話中バッジ / 共通グループ高速表示 / トーク保存(TXT) |
+## 主な機能
 
----
-
-## ⚠️ 破壊的変更 (v0.5.0)
-
-v0.5.0 は v0.4.x と**互換性がありません**。以下の変更により、既存の設定・キャッシュの一部リセットが必要な場合があります。
-
-| 変更                                                   | 影響                                                                        |
-| ------------------------------------------------------ | --------------------------------------------------------------------------- |
-| 受信エンジンを Push 長ポール → fetchOps 方式に刷新     | イベントポーリングの挙動が変わります                                        |
-| 公開 API (`/v1/`) を新設                               | 環境変数 `VYLINE_API_ADMIN_SECRET` を設定するとトークン管理が可能になります |
-| イベント種別の拡張（通話・メンバー変更・アナウンス等） | フロントエンドの旧バージョンとは互換しません                                |
-
-**アップグレード手順**: `git pull && bun install && bun run dev` のみで動作します。既存のログイン状態は維持されます。
+| カテゴリ | 内容 |
+| --- | --- |
+| **ログイン** | QR / Email ログイン、マルチアカウント、セッション復元 |
+| **メッセージ** | 送受信、返信、送信取り消し、既読制御、再送 |
+| **メンション** | `@ALL` / `@名前`、LINE Desktop 準拠の `MENTION` metadata |
+| **メディア** | 画像、動画、音声、LINE 絵文字（sticon）、スタンプ。画像の自動圧縮と高画質送信に対応 |
+| **Flex / Rich** | 公式形式に準拠した描画、カルーセルのマウスドラッグ |
+| **リアクション** | 1クリックリアクション、公式バッジ、既読者一覧 |
+| **通話** | 音声 / ビデオ通話（実験的） |
+| **チャット管理** | ピン、非表示、ミュート、ブロック、MID コピー、グループ作成・招待 |
+| **VyTheme** | テーマ、文字サイズ、表示密度、プロフィール背景のカスタマイズ |
+| **E2EE** | Letter Sealing の復号・送信、LINE Desktop の鍵のインポート |
+| **プライバシー** | ストリーマーモード、PIN ロック |
+| **VylineBackup** | トーク履歴とメディアのスナップショット作成・復元・削除 |
+| **開発者向け** | Bearer トークン対応の公開 API、OpenAPI 3.1、JSONL 詳細ログ |
+| **その他** | Keepメモ、プロフィール背景、通話中バッジ、共通グループの高速表示、トークの TXT 保存 |
 
 ---
 
-## Quick Start
+## Vyline を支援する
+
+Vyline は個人開発のオープンソースプロジェクトです。支援は、開発環境、テスト、サーバー、ドキュメントの維持に活用します。
+
+### 支援方法
+
+| 方法 | 内容 |
+| --- | --- |
+| **PayPay** | PayPay の「送る・受け取る」による支援 |
+| **Amazon ギフトカード（アマギフ）** | Amazon ギフトカードによる支援 |
+| **その他のギフトカード** | Apple Gift Card、Google Play、Steam など。事前に相談してください |
+| **開発・デザイン** | コード、ドキュメント、UI、アイコン、バナーなどでの貢献 |
+
+送付先や手順は、[nezumi0627 のGitHubプロフィール](https://github.com/nezumi0627) に掲載している連絡先から事前にお問い合わせください。支援方法は状況に応じて案内します。
+
+> [!IMPORTANT]
+> 支援は任意であり、機能実装、バグ修正、個別サポート、将来の提供を保証するものではありません。ギフトカード番号、PayPayの送付情報、セッション、トークン、暗号鍵を Issue、Pull Request、公開チャットへ投稿しないでください。送信後の返金や取り消しには対応できない場合があります。
+
+### メンテナー・コントリビューター募集
+
+Vyline の継続的な開発を支えるメンテナーとコントリビューターを募集しています。
+
+- **メンテナー**: Issue の整理、PRレビュー、リリース、ドキュメントの保守
+- **開発**: バグ修正、API、プロトコル、UI、ストレージ、テスト
+- **デザイン**: VyTheme、アプリアイコン、テーマアイコン、バナー
+- **ドキュメント**: セットアップ、APIリファレンス、翻訳、トラブルシューティング
+
+参加方法は [コントリビューションガイド](docs/CONTRIBUTING.md) を確認し、まず Issue または Pull Request で提案してください。
+
+---
+
+## ご利用前の重要事項
+
+- **アカウントリスク**: LINE の利用規約に抵触し、アカウント停止などの措置を受ける可能性があります。
+- **同意ゲート**: ログイン後に利用規約と免責事項を表示します。同意が完了するまで、同期・通信・メッセージ表示を含むアプリ機能は開始されません。ゲートの回避や改変はサポート対象外です。
+- **利用目的**: 教育、学習、研究、個人利用を想定しています。不正アクセス、攻撃、迷惑行為、権利侵害への利用は禁止します。
+- **データの保存**: ログイン情報、セッション、暗号鍵、トーク履歴は、ユーザーが管理するローカル環境またはセルフホスト先に保存されます。通常動作に必要な通信を除き、Vyline 開発者が運営する外部サーバーへ送信しません。
+- **無保証**: 本ソフトウェアの使用により生じたアカウント停止、データ破損、損失、法的問題などについて、開発者およびコントリビューターは責任を負いません。
+- **解析ツール**: `tools/` 以下は [vyline-search](https://github.com/nezumi0627/vyline-search) を Git Submodule として参照します。教育・研究目的でのみ使用し、解析対象や解析結果を不適切に再配布しないでください。詳細は [docs/tools/DISCLAIMER.md](docs/tools/DISCLAIMER.md) を参照してください。
+
+---
+
+## インストール・更新
+
+### 方法を選ぶ
+
+| 用途 | 推奨方法 | 説明 |
+| --- | --- | --- |
+| 開発・動作確認 | Bun + ソースコード | フロントエンドとバックエンドを個別に確認できます |
+| 自宅サーバー・複数端末 | Docker Compose | データをボリュームに保存して Web ブラウザから利用できます |
+| Windows の単体アプリ | 準備中 | Vyline Desktop のインストーラーは今後提供予定です |
+
+> [!NOTE]
+> 現在、一般ユーザー向けの公式インストーラーはありません。まずは Bun または Docker を使用してください。
+
+### ソースコードからインストール（Bun）
+
+- [Git](https://git-scm.com/)
+- [Bun](https://bun.sh/)
+
+### 開発環境で起動
 
 ```bash
+git clone https://github.com/nezumi0627/Vyline.git
+cd Vyline
+# 必要に応じて環境変数を設定（macOS / Linux / Git Bash）
+cp .env.example .env
 bun install
-bun run dev          # backend :3001 + frontend :5173
+bun run typecheck
+bun run dev
 ```
 
-ブラウザで `http://localhost:5173` を開きます。
+PowerShell の場合:
 
-| コマンド               | 内容                           |
-| ---------------------- | ------------------------------ |
-| `bun run dev:backend`  | backend のみ（:3001）          |
-| `bun run dev:frontend` | frontend のみ（:5173）         |
-| `bun run typecheck`    | 型チェック（全ワークスペース） |
-| `bun run lint`         | Biome lint                     |
-| `bun run build`        | frontend 本番ビルド            |
+```powershell
+Copy-Item .env.example .env
+```
 
-詳細: [docs/onboarding.md](docs/onboarding.md) · [docs/development.md](docs/development.md) · [AGENTS.md](AGENTS.md)
+起動後、ブラウザで `http://localhost:5173` を開きます。バックエンドは `http://localhost:3001` で待ち受けます。
 
-### セルフホスト（Docker）
+`bun install` はワークスペース全体の依存関係をインストールします。`Vyline/backend` や `Vyline/apps/desktop` で個別に install する必要はありません。
 
-自宅サーバーに立てて、複数端末の Web ブラウザから同じ LINE セッションを利用できます（履歴・画像はサーバー側に永続化）。
+| コマンド | 内容 |
+| --- | --- |
+| `bun run dev` | バックエンドとフロントエンドを同時に起動 |
+| `bun run dev:backend` | バックエンドのみ起動（`:3001`） |
+| `bun run dev:frontend` | フロントエンドのみ起動（`:5173`） |
+| `bun run typecheck` | 全ワークスペースの型チェック |
+| `bun run lint` | Biome による lint |
+| `bun run build` | フロントエンドの本番ビルド |
+
+導入の詳細は [オンボーディング](docs/onboarding.md) と [開発ガイド](docs/development.md) を参照してください。
+
+### Bun環境の更新
+
+ローカルで変更したファイルがある場合は、先にコミットまたは退避してください。
 
 ```bash
-docker compose up -d --build   # http://localhost:3001
+git status --short
+git pull --ff-only
+bun install
+bun run typecheck
+bun run dev
 ```
 
-設定・Cloudflare Access での外部公開手順: [docs/selfhosting.md](docs/selfhosting.md)
+`git pull --ff-only` が失敗した場合は、ローカル変更を確認してから手動で merge または rebase してください。`git reset --hard` で変更を消す必要はありません。
 
-### 推奨環境
+### Docker でインストール
 
-| 項目               | 推奨値         | 備考                                               |
-| ------------------ | -------------- | -------------------------------------------------- |
-| **LINE アプリ**    | IOSIPAD 26.7.2 | `x-line-application` ヘッダー値。最新版を推奨      |
-| **OS**             | iOS 18.0       | Android / Windows 互換は未検証                     |
-| **デバイスモード** | IOSIPAD        | `VYLINE_DEVICE` 環境変数で指定（省略時は IOSIPAD） |
+```bash
+git clone https://github.com/nezumi0627/Vyline.git
+cd Vyline
+docker compose up -d --build
+```
 
-> 定義元: `packages/protocol/src/desktop/types.ts` の DesktopProfile。実際のヘッダー値は `"x-line-application": "IOSIPAD\t26.7.2\tiOS\t18.0"` のように伝搬されます。
+起動後は `http://localhost:3001` へアクセスします。Docker版はフロントエンドとバックエンドを同一オリジンで配信します。
+
+### Docker環境の更新
+
+```bash
+git pull --ff-only
+docker compose up -d --build
+```
+
+`docker compose up -d --build` が既存コンテナを再作成し、`vyline_data` ボリュームは維持します。**`docker compose down -v` はデータボリュームを削除するため、通常の更新では使用しないでください。**
+
+トーク履歴、画像、セッションなどは `vyline_data` ボリュームへ永続化され、同じ LINE セッションを複数の Web ブラウザから利用できます。
+
+設定方法と Cloudflare Access を利用した外部公開については、[セルフホストガイド](docs/selfhosting.md) を参照してください。
+
+### 既定のプロトコルプロファイル
+
+| 項目 | 既定値 | 備考 |
+| --- | --- | --- |
+| クライアント | `IOSIPAD 26.7.2` | `x-line-application` に使用 |
+| プロファイルOS | `iOS 18.0` | プロトコル上の識別値 |
+| デバイスモード | `IOSIPAD` | `VYLINE_DEVICE` で変更可能 |
+
+> [!IMPORTANT]
+> 上記は LINE サーバーへ送る**プロトコル識別値**であり、Vyline を実行するホストOSの要件ではありません。定義元は `packages/protocol/src/desktop/types.ts` の `DesktopProfile` です。
 
 ---
 
-## Architecture
+## アーキテクチャ
 
+```mermaid
+flowchart TB
+    FE["Frontend — React + Vite<br/>Vyline/apps/desktop<br/>Store / Mappers / Sync / VyTheme UI"]
+    BE["Backend — Hono on Bun<br/>Vyline/backend<br/>BFF Routes → lineService → clientManager"]
+    VP["Vyline Protocol<br/>Vyline/packages/protocol<br/>Domain / Dictionary / E2EE / Thrift Stack"]
+    LS["LINE Servers"]
+
+    FE -->|HTTP / WebSocket| BE
+    BE -->|Protocol API| VP
+    VP -->|Thrift / E2EE| LS
+
+    classDef frontend fill:#eff6ff,stroke:#3b82f6,color:#172554,stroke-width:2px;
+    classDef backend fill:#f5f3ff,stroke:#8b5cf6,color:#2e1065,stroke-width:2px;
+    classDef protocol fill:#ecfdf5,stroke:#10b981,color:#052e16,stroke-width:2px;
+    classDef external fill:#f8fafc,stroke:#64748b,color:#0f172a,stroke-width:2px;
+
+    class FE frontend;
+    class BE backend;
+    class VP protocol;
+    class LS external;
 ```
-┌─ Frontend (React + Vite) ── apps/desktop ──┐
-│  store / mappers / sync / VyTheme UI       │
-├─ Backend (Hono on Bun) ───── backend ──────┤
-│  BFF routes → lineService → clientManager  │
-├─ Vyline ──────────── packages/protocol ────┤
-│  domain / dictionary / E2EE / Thrift stack │
-└─ LINE Servers ──────────────────────────────┘
-```
 
-| パス                  | 役割                     |
-| --------------------- | ------------------------ |
-| `apps/desktop`        | React UI                 |
-| `backend`             | Hono BFF                 |
-| `packages/protocol`   | プロトコル本体（Vyline） |
-| `packages/line-types` | Thrift 型（vendored）    |
+| パス | 役割 |
+| --- | --- |
+| `Vyline/apps/desktop` | React + Vite によるフロントエンド |
+| `Vyline/backend` | Hono ベースの BFF、認証、同期、API |
+| `Vyline/packages/protocol` | ドメインモデル、辞書、E2EE、Thrift 通信 |
+| `Vyline/packages/line-types` | vendored の Thrift 型定義 |
 
-### E2EE / Desktop 鍵
+詳細は [docs/architecture.md](docs/architecture.md) を参照してください。
 
-過去メッセージの復号には、公式 LINE Desktop から抽出した自己鍵一式が必要です。
+---
 
-1. LINE.exe 起動状態で鍵を抽出（[docs/analysis/](docs/analysis/)）
-2. `backend/data/desktop-e2ee-keys.json` に配置（**gitignore・コミット禁止**）
-3. backend 起動時に自動 import
+## 公開 API
 
-### 公開 API (`/v1/`)
+セルフホストした Vyline は、Bearer トークンを使って外部ツールや独自クライアントから操作できます。API は `/v1/` 配下で提供されます。
 
-セルフホスト時に Bearer トークンで Vyline を外部から操作できます。
+| エンドポイント | 用途 |
+| --- | --- |
+| `/v1/*` | トークン認証された Vyline API |
+| `/openapi.json` | OpenAPI 3.1 の機械可読仕様 |
+| `/docs` | API ドキュメント UI |
+| `/swagger` | Swagger UI |
+
+> [!TIP]
+> 利用可能なエンドポイントはバージョンによって異なる場合があります。実行中のサーバーが返す `/openapi.json` を正として扱ってください。
+
+### トークンの作成
+
+環境変数 `VYLINE_API_ADMIN_SECRET` を設定してから、管理シークレットでトークンを作成します。
 
 ```bash
-# トークン作成（VYLINE_API_ADMIN_SECRET を設定後）
 curl -X POST http://localhost:3001/v1/tokens \
   -H "Authorization: Bearer $VYLINE_API_ADMIN_SECRET" \
   -H "Content-Type: application/json" \
-  -d '{"name": "my-bot"}'
+  -d '{"name":"my-bot"}'
+```
 
-# チャット一覧取得
+### API の利用例
+
+```bash
 curl http://localhost:3001/v1/accounts/{accountId}/chats \
   -H "Authorization: Bearer vyl_xxxx..."
 ```
 
-API 仕様（OpenAPI 3.1）: `GET /openapi.json` または [zensical.org](https://zensical.org)
-
-### 解析ツールキット（vyline-search）
-
-Desktop LINE（Themida 保護）の unpack / ネイティブシンボル検索 / 逆コンパイルを行う独立ツールキットです。教育・研究目的で `findNativeSymbol` による文字列 xref 解析と Ghidra decompile をワンコマンドで実行できます。
-
 > [!WARNING]
-> **注意**: LINE デスクトップクライアントが起動中の状態では、解析ツール（unpack 等）が正常に動作しません（単一インスタンス制御により frida の注入が拒否されプロセスが強制終了するため）。必ず LINE アプリを完全に終了させてから実行してください。
+> `VYLINE_API_ADMIN_SECRET`、発行済みトークン、セッション、暗号鍵をリポジトリやログへ含めないでください。
 
-**[github.com/nezumi0627/vyline-search](https://github.com/nezumi0627/vyline-search)**
+API の設計と利用方法は [docs/api/openapi.md](docs/api/openapi.md) および [公開ドキュメント](https://zensical.org) を参照してください。
 
-```powershell
-bun run vyline:check                  # インストール版 / 最新版の比較
-bun run vyline:versions               # インストール済みバージョン一覧
-bun run vyline:unpack -- --version <ver>   # インストール済みバージョンを選択して unpack
-bun run vyline:update                 # LINE Desktop を最新版へ更新
-bun run vyline:find-native -- sendMessage  # ネイティブシンボル検索
+## テーマ・プラグイン・カスタムクライアント
+
+Vyline は API ファーストの拡張可能なクライアントを目指しています。
+
+### VyTheme
+
+テーマ、文字サイズ、表示密度、プロフィール背景を変更できます。今後は CSS 変数、背景、各 UI 要素を対象としたカスタムセレクターを整備し、コードを直接変更せずに外観を調整できる仕組みを強化します。
+
+### プラグインシステム（計画中）
+
+JavaScript / TypeScript で機能を追加できるプラグインシステムを計画しています。
+
+- Manifest によるプラグイン情報と互換バージョンの宣言
+- API ごとの権限スコープと、インストール時の権限確認
+- 補完可能な型定義と安定した Open API
+- 起動、停止、更新、無効化を管理するライフサイクル
+- 互換性を壊す変更に対するバージョニング方針
+
+### カスタムクライアント
+
+公開 API と OpenAPI 仕様を利用し、Vyline バックエンド上に独自 UI、Bot、連携ツールを構築できる設計を進めています。
+
+---
+
+## E2EE / LINE Desktop の鍵
+
+過去の Letter Sealing メッセージを復号するには、公式 LINE Desktop から抽出した自己鍵一式が必要です。
+
+1. LINE Desktop を起動した状態で鍵を抽出します（[docs/analysis/](docs/analysis/)）。
+2. 鍵を `backend/data/desktop-e2ee-keys.json` に配置します。
+3. バックエンド起動時に鍵が自動でインポートされます。
+
+> [!CAUTION]
+> `desktop-e2ee-keys.json` は機密情報です。必ず `.gitignore` の対象にし、コミット、共有、ログ出力をしないでください。
+
+---
+
+## v0.5.0 の破壊的変更
+
+v0.5.0 は v0.4.x と互換性がありません。アップグレード時に、既存の設定やキャッシュの一部を再作成する必要がある場合があります。
+
+| 変更 | 影響 |
+| --- | --- |
+| 受信エンジンを Push 長ポールから `fetchOps` 方式へ刷新 | イベントポーリングの挙動が変更されます |
+| 公開 API（`/v1/`）を新設 | `VYLINE_API_ADMIN_SECRET` を設定するとトークンを管理できます |
+| 通話、メンバー変更、アナウンスなどのイベントを追加 | 旧フロントエンドとは互換性がありません |
+
+```bash
+git pull
+bun install
+bun run dev
 ```
 
-> **注意**: `vyline:unpack` / `vyline:update` は **LINE を終了してから実行**してください。
-> 稼働中は Frida 注入が拒否され `ProcessNotRespondingError` になります。
+既存のログイン状態は維持されます。詳細な変更内容は [CHANGELOG.md](CHANGELOG.md) を参照してください。
+
+---
+
+## 解析ツールキット
+
+[vyline-search](https://github.com/nezumi0627/vyline-search) は、Desktop LINE の unpack、ネイティブシンボル検索、逆コンパイルを行う独立ツールキットです。文字列 xref を利用した `findNativeSymbol` と Ghidra decompile をワンコマンドで実行できます。
+
+> [!WARNING]
+> unpack やアップデートを実行する前に LINE Desktop を完全に終了してください。起動中は単一インスタンス制御によって Frida の注入が拒否され、`ProcessNotRespondingError` になる場合があります。
+
+```powershell
+bun run vyline:check                       # インストール版と最新版を比較
+bun run vyline:versions                    # インストール済みバージョンを一覧表示
+bun run vyline:unpack -- --version <ver>   # 指定バージョンを unpack
+bun run vyline:update                      # LINE Desktop を更新
+bun run vyline:find-native -- sendMessage  # ネイティブシンボルを検索
+```
+
+解析ツールは教育・研究目的でのみ使用してください。詳細な免責事項は [docs/tools/DISCLAIMER.md](docs/tools/DISCLAIMER.md) を参照してください。
 
 ---
 
 ## ドキュメント
 
-| リンク                                                     | 内容                                   |
-| ---------------------------------------------------------- | -------------------------------------- |
-| [docs/README.md](docs/README.md)                           | ドキュメント索引                       |
-| [docs/onboarding.md](docs/onboarding.md)                   | 初日チェックリスト                     |
-| [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md)               | 貢献フロー                             |
-| [docs/architecture.md](docs/architecture.md)               | 層構造                                 |
-| [docs/development.md](docs/development.md)                 | 開発コマンド                           |
-| [docs/selfhosting.md](docs/selfhosting.md)                 | Docker セルフホスト・Cloudflare Access |
-| [docs/protocol/dictionary.md](docs/protocol/dictionary.md) | RPC 辞書                               |
-| [AGENTS.md](AGENTS.md)                                     | エージェント向けガイド                 |
-| [CHANGELOG.md](CHANGELOG.md)                               | 変更履歴                               |
-| [zensical.org](https://zensical.org)                       | 公開ドキュメント・API リファレンス     |
-| [/openapi.json](/openapi.json)                             | OpenAPI 3.1 仕様（ローカル）           |
+| ドキュメント | 内容 |
+| --- | --- |
+| [docs/README.md](docs/README.md) | ドキュメント索引 |
+| [docs/onboarding.md](docs/onboarding.md) | 初回セットアップ |
+| [docs/development.md](docs/development.md) | 開発環境とコマンド |
+| [docs/architecture.md](docs/architecture.md) | アーキテクチャ |
+| [docs/selfhosting.md](docs/selfhosting.md) | Docker と Cloudflare Access |
+| [docs/protocol/dictionary.md](docs/protocol/dictionary.md) | RPC 辞書 |
+| [docs/api/openapi.md](docs/api/openapi.md) | OpenAPI と公開 API |
+| [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) | コントリビューションガイド |
+| [AGENTS.md](AGENTS.md) | コーディングエージェント向けガイド |
+| [CHANGELOG.md](CHANGELOG.md) | 変更履歴 |
 
-公開ドキュメント・チュートリアル: **[zensical.org](https://zensical.org)**
-
----
-
-## 貢献 / 募集
-
-- 🐛 [Bug report](.github/ISSUE_TEMPLATE/bug_report.md)
-- ✨ [Feature request](.github/ISSUE_TEMPLATE/feature_request.md)
-- 📝 [Pull request](.github/pull_request_template.md)
-
-貢献フローは [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) を参照してください。PR には解析対象ソフトウェアの実体・鍵・トークンなどを含めないでください。
-
-現在、以下を募集しています:
-
-- **PR**: バグ修正、機能改善、ドキュメントの更新
-- **アイコン**: アプリアイコン・テーマアイコンのデザイン
-- **バナー**: SNS・ブログでのプロモーション用バナー
-- **定期的なメンテナー**: 個人開発のため、継続的に助けていただける方を募集中
-
-興味がある方は [AGENTS.md](AGENTS.md) の手順に従ってプルリクエストをお送りください。
-
----
-
-## Vyline Desktop
-
-> **Coming Soon** 🚀
-
-Vyline が安定版に到達した後、専用のデスクトップアプリ **Vyline Desktop** をリリース予定です。
-
-- 🖥️ Windows / macOS / Linux ネイティブアプリ
-- 🔔 プッシュ通知
-- 🗂️ トレイアイコン常駐
-- 🔒 ローカルデータ完全管理
-
-Vyline の安定版リリースをお待ちください。
+公開ドキュメントと API リファレンス: **[zensical.org](https://zensical.org)**
 
 ---
 
 ## ロードマップ
 
-Vyline は API ファーストな拡張可能アーキテクチャを目指します（詳細は [AGENTS.md](AGENTS.md)）。
+- **API / Swagger**: `/v1/`、`/openapi.json`、`/docs`、`/swagger` の整備と安定化
+- **プラグインシステム**: JavaScript / TypeScript、権限スコープ、型付き Open API
+- **カスタムクライアント**: 独自フロントエンド、Bot、外部ツールとの連携
+- **マルチアカウント**: アカウント単位の認証・データ・メディア分離
+- **ストレージ管理**: キャッシュと保存済みメディアの分離、容量表示、バックアップ復元
+- **複数画像送信**: 個別の IMAGE メッセージとグルーピング表示
+- **サーバーモード**: Docker Compose とセルフホスト運用の改善
+- **軽量化**: メモリ、CPU、通信量を計測し、公式クライアント以下を目標に改善
 
-- **API / Swagger**: `GET /docs`・`/swagger`・`/openapi.json` で API 仕様を公開（[docs/api](docs/api/openapi.md)）
-- **プラグインシステム**: JavaScript / TypeScript 補完・権限スコープ付き（計画中）
-- **カスタムクライアント**: バックエンド API を使った独自クライアント開発を想定
-- **マルチアカウント**: アカウント単位のデータ分離
-- **複数画像一括送信**: 個別 IMAGE メッセージ + グルーピング表示（実装済み）
-- **Docker / サーバーモード**: `bun run server`・Docker Compose 配布
-- **軽量性**: メモリ・CPU・通信量は公式クライアント以下を目標に、計測ベースで改善
+### Vyline Desktop — Coming Soon
 
----
+安定版の公開後、専用デスクトップアプリ **Vyline Desktop** をリリース予定です。
 
-## エージェント / Skill 方針
-
-開発には coding-agent 用 skill セット（Ponytail / Caveman / agent-skills-standard /
-addyosmani agent-skills / Minimize-Cursor-Cost）を利用する場合があります。
-不要なコード・過剰設計を避け、レビュー品質を上げるためです。
-
-ただし セキュリティ > プライバシー > データ保護 > 既存機能互換 > トークン削減 の順で、
-正確性と安全性が常に優先されます。詳細は [AGENTS.md](AGENTS.md) を参照してください。
+- Windows / macOS / Linux 対応
+- ネイティブ通知とクイック返信
+- トレイアイコン常駐
+- ローカルデータの完全管理
 
 ---
 
-## Support Vyline
+## コントリビューション
 
-Vyline は個人開発の独立プロジェクトです。小さな支援が開発・テスト・ドキュメント整備に役立ちます。
+バグ修正、機能改善、ドキュメント、デザインへの貢献を歓迎します。
 
-| 金額 | Tier | 内容 |
-| ---: | --- | --- |
-| ~500円 | 応援 | 開発・保守費に |
-| 500円~ | サポーター | 希望者はサポート一覧に掲載 |
-| 1,000円~ | スペシャルサポーター | docs / リリースノートに感謝掲載（希望者） |
-| 3,000円~ | メジャーサポーター | メジャーサポーターとして掲載（希望者） |
+- [バグを報告する](.github/ISSUE_TEMPLATE/bug_report.md)
+- [機能を提案する](.github/ISSUE_TEMPLATE/feature_request.md)
+- [Pull Request を作成する](.github/pull_request_template.md)
 
-※ 支援は機能実装・バグ修正・個別対応等を保証するものではありません。
-掲載は許可いただいた場合のみ。支払い方法の詳細は今後このセクションに追記します。
+参加前に [コントリビューションガイド](docs/CONTRIBUTING.md) を確認してください。Pull Request に解析対象ソフトウェア、セッション、鍵、トークンなどの機密情報を含めないでください。
+
+### エージェント / Skill 方針
+
+開発では必要に応じて Ponytail、Caveman、agent-skills-standard、addyosmani agent-skills、Minimize-Cursor-Cost などの coding-agent 用 Skill を利用します。不要なコードと過剰設計を避け、レビュー品質を保つことが目的です。
+
+優先順位は次のとおりです。
+
+1. セキュリティ
+2. プライバシー
+3. データ保護
+4. 既存機能との互換性
+5. 実装量・トークン・コストの削減
+
+効率化よりも正確性と安全性を優先します。詳細は [AGENTS.md](AGENTS.md) を参照してください。
 
 ---
 
-## License
+## ライセンスと著作権
 
-MIT — see [LICENSE](LICENSE)
+Vyline は [MIT License](LICENSE) のもとで公開されています。
 
-**著作権**: [`nezumi0627`](https://github.com/nezumi0627)
-改変・再配布・記事・投稿等では出典表示をお願いします（詳細は [LICENSE](LICENSE) の Attribution requirement を参照）。
+Copyright © [nezumi0627](https://github.com/nezumi0627)
+
+改変や再配布を行う場合は、`LICENSE` に記載された著作権表示とライセンス表示を保持してください。
+
+---
+
+<p align="center">
+  <strong>Vision Beyond Limits.</strong><br/>
+  Built with care by <a href="https://github.com/nezumi0627">nezumi0627</a> and contributors.
+</p>

--- a/README.md
+++ b/README.md
@@ -2,991 +2,294 @@
 
 <p align="center">
   <strong>Vision Beyond Limits.</strong><br/>
-  API-first, extensible third-party LINE client architecture for desktop, server, plugins, and custom clients.
+  自前プロトコルで動く、LINE サードパーティクライアント（Web / React）
 </p>
 
 <p align="center">
-  <img alt="status" src="https://img.shields.io/badge/status-beta-a78bfa?style=flat-square" />
-  <img alt="runtime" src="https://img.shields.io/badge/runtime-Bun%201.6-f472b6?style=flat-square" />
+  <img alt="version" src="https://img.shields.io/badge/version-0.5.1--beta-a78bfa?style=flat-square" />
   <img alt="license" src="https://img.shields.io/badge/license-MIT-22c55e?style=flat-square" />
+  <img alt="runtime" src="https://img.shields.io/badge/runtime-Bun-f472b6?style=flat-square" />
+  <img alt="stack" src="https://img.shields.io/badge/stack-Hono%20%2B%20React-0ea5e9?style=flat-square" />
+  <img alt="state" src="https://img.shields.io/badge/state-beta-a78bfa?style=flat-square" />
+  <img alt="PRs" src="https://img.shields.io/badge/PRs-welcome-22c55e?style=flat-square" />
 </p>
 
----
+<p align="center">
+  このさんさんとした太陽の下、Vyline を選んでくださるユーザーに出会えたことに感謝します。
+</p>
 
-## About
-
-Vyline is an independent third-party LINE client project.
-
-Vyline aims to become a clean, fast, extensible LINE client architecture with:
-
-- desktop client support
-- server mode support
-- separated frontend / backend
-- OpenAPI / Swagger based API
-- JavaScript / TypeScript plugin system
-- custom client support
-- multi-account support
-- grouped multi-image sending
-- storage management
-- backup / restore
-- Docker-friendly deployment
-- lightweight CPU / memory / network usage
-
-Vyline is currently in **Beta**.
-
-The project is still changing quickly. Some features are implemented, some are experimental, and some are planned.
+> **2026/08/20 beta 版 release 開始** — 本リポジトリは Vyline Beta 0.5.0 として公開されました。機能の安定性は保証されておらず、予期しない動作やアカウントリスクが含まれる可能性があります。
 
 ---
 
-## Project Goals
+## ⚠️ ご利用前に必ずお読みください
 
-Vyline is built around these goals:
+Vyline は LINE 非公式のサードパーティクライアントであり、LINE 株式会社・LY Corporation とは**無関係・未承認**です。
 
-- provide a clean desktop client experience
-- separate frontend and backend completely
-- expose a stable backend API
-- provide Swagger / OpenAPI documentation
-- allow users to build custom clients
-- allow plugins written in JavaScript / TypeScript
-- isolate data per account
-- separate cache and saved media
-- make backup / restore reliable
-- run locally or on a server
-- support Docker / Docker Compose deployment
-- keep memory, CPU, and network usage low
-- keep documentation accurate and readable
+- **アカウントリスク**: LINE 利用規約に違反する可能性があり、アカウント停止等のリスクを伴います。**利用はすべて自己責任**です。
+- **同意ゲート**: ログイン直後に利用規約・免責事項を表示し、**同意しない限りアプリは一切動作しません**（同期・通信・表示を含む）。同意せず、または画面をスキップする等の手段で利用した場合も、**その時点で本規約に同意したものとみなされ**、開発者・Vyline のメンバーは一切の責任を負いません。
+- **目的の範囲**: 教育・学習・個人利用の範囲でご利用ください。第三者への攻撃・不正アクセス・迷惑行為・権利侵害は禁止です。
+- **データの扱い**: ログイン情報・セッション・暗号鍵・トーク履歴は端末内にのみ保存され、外部へ送信されません。
+- **解析ツール**: `tools/` 以下の解析ツールは [vyline-search](https://github.com/nezumi0627/vyline-search) リポジトリを Git Submodule としてリンクしたものです。Desktop LINE の unpack・逆コンパイルを行います。**教育・実験目的のみ**で使用し、解析結果を再配布しないでください。詳細: [docs/tools/DISCLAIMER.md](docs/tools/DISCLAIMER.md)
+- **開発者の免責**: 本ソフトウェアの利用により生じた一切の問題（アカウント停止、データ破損、法的問題等）について、開発者・Vyline のメンバーは責任を負いません。
 
-Vyline should not become heavy or over-engineered.
+### 著作権表示
 
-Unnecessary abstractions, wrappers, services, dependencies, and large rewrites should be avoided unless they clearly improve the project.
+本ソフトウェアは [nezumi0627](https://github.com/nezumi0627) によって開発されています。改変・再配布・解説記事等では、必ず著作権表示（`nezumi0627`）を保持してください。ライセンス詳細は [LICENSE](LICENSE)（MIT）を参照してください。
 
 ---
 
-## Status
+## Vyline とは
 
-Vyline is currently a **Beta project**.
+**Vyline** は LINE にログインしてメッセージの送受信・Flex/Rich 表示・テーマカスタマイズを行うサードパーティクライアントです。外部サービスに依存せず、**自前のプロトコルスタック `@vyline/protocol`** で動作します。
 
-Current priority areas:
+| 項目       | 内容                                     |
+| ---------- | ---------------------------------------- |
+| 誰向け     | UI を自分好みにしたい人・開発者          |
+| なにが違う | テーマ管理 / メンション / ローカル最適化 |
+| ライセンス | MIT                                      |
+| 状態       | Beta 0.5.0                               |
 
-- repository cleanup
-- documentation cleanup
-- frontend / backend separation
-- Swagger / OpenAPI API design
-- plugin system
-- custom client support
-- multi-account storage isolation
-- multi-image sending
-- server mode
-- Docker deployment
-- update / migration flow
-- performance optimization
+### 主な機能
 
----
-
-## Features
-
-### Desktop Client
-
-Vyline provides a desktop client experience for LINE-like messaging workflows.
-
-The UI should remain clean, fast, and easy to use.
-
----
-
-### API-first Architecture
-
-Vyline must be designed as an API-first application.
-
-The backend should expose a stable API that can be used by:
-
-- the official Vyline frontend
-- custom frontends
-- server dashboards
-- plugins
-- automation tools
-- future CLI wrappers
-- external clients
-
-Frontend code must not depend directly on backend private modules.
-
-The frontend should communicate with the backend through the public API or a generated API client.
+| カテゴリ         | 内容                                                                                                                  |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------- |
+| **ログイン**     | QR / Email ログイン、マルチアカウント、セッション復元                                                                 |
+| **メッセージ**   | 送受信 / 返信 / 取り消し / 既読制御 / 再送                                                                            |
+| **メンション**   | `@ALL` / `@名前`（LINE Desktop 準拠の `MENTION` metadata）                                                            |
+| **メディア**     | 画像・動画・音声（画像は自動圧縮、設定で高画質送信も可） / LINE 絵文字(sticon) / スタンプ全種                         |
+| **Flex / Rich**  | 公式準拠の描画、カルーセルのマウスドラッグ                                                                            |
+| **リアクション** | 1クリック、公式バッジ、既読者一覧                                                                                     |
+| **通話**         | 音声 / ビデオ通話（実験的）                                                                                           |
+| **チャット管理** | ピン / 非表示 / ミュート / ブロック / MID コピー / グループ作成・招待                                                 |
+| **VyTheme**      | フルカスタマイズテーマ、文字サイズ、密度、プロフィール背景                                                            |
+| **E2EE**         | Letter Sealing の復号・送信、Desktop 鍵 import                                                                        |
+| **プライバシー** | ストリーマーモード、PIN ロック                                                                                        |
+| **VylineBackup** | トーク履歴・メディアのスナップショット作成 / 復元 / 削除                                                              |
+| **その他**       | チャット詳細ログ(JSONL) / Keepメモ / 相手プロフィール背景表示 / 通話中バッジ / 共通グループ高速表示 / トーク保存(TXT) |
 
 ---
 
-## API / Swagger / OpenAPI
+## ⚠️ 破壊的変更 (v0.5.0)
 
-Vyline must provide a documented backend API.
+v0.5.0 は v0.4.x と**互換性がありません**。以下の変更により、既存の設定・キャッシュの一部リセットが必要な場合があります。
 
-Swagger / OpenAPI support is required.
+| 変更                                                   | 影響                                                                        |
+| ------------------------------------------------------ | --------------------------------------------------------------------------- |
+| 受信エンジンを Push 長ポール → fetchOps 方式に刷新     | イベントポーリングの挙動が変わります                                        |
+| 公開 API (`/v1/`) を新設                               | 環境変数 `VYLINE_API_ADMIN_SECRET` を設定するとトークン管理が可能になります |
+| イベント種別の拡張（通話・メンバー変更・アナウンス等） | フロントエンドの旧バージョンとは互換しません                                |
 
-The API should be available in development and server mode.
-
-Required API documentation routes:
-
-```txt
-GET /docs
-GET /swagger
-GET /openapi.json
-```
-
-The API must be versioned.
-
-Example:
-
-```txt
-/api/v1/...
-```
-
-Public API, internal API, plugin API, and desktop IPC must be separated.
+**アップグレード手順**: `git pull && bun install && bun run dev` のみで動作します。既存のログイン状態は維持されます。
 
 ---
 
-### Required API Areas
-
-The backend API must cover at least:
-
-* accounts
-* sessions
-* chats
-* messages
-* media
-* multi-image sending
-* storage
-* cache
-* saved media
-* backup
-* restore
-* settings
-* themes
-* plugins
-* notifications
-* health checks
-* metrics
-
----
-
-### Example API Endpoints
-
-```txt
-GET    /health
-GET    /metrics
-GET    /api/v1/status
-
-GET    /api/v1/accounts
-POST   /api/v1/accounts/switch
-GET    /api/v1/accounts/:accountId/profile
-
-GET    /api/v1/accounts/:accountId/chats
-GET    /api/v1/accounts/:accountId/chats/:chatId/messages
-POST   /api/v1/accounts/:accountId/chats/:chatId/messages
-
-POST   /api/v1/accounts/:accountId/chats/:chatId/media/batch
-
-GET    /api/v1/accounts/:accountId/storage
-GET    /api/v1/accounts/:accountId/storage/cache
-DELETE /api/v1/accounts/:accountId/storage/cache
-
-GET    /api/v1/accounts/:accountId/plugins
-POST   /api/v1/accounts/:accountId/plugins/:pluginId/enable
-POST   /api/v1/accounts/:accountId/plugins/:pluginId/disable
-
-POST   /api/v1/accounts/:accountId/backup
-POST   /api/v1/accounts/:accountId/restore
-```
-
-Actual endpoint names may change during Beta, but the final API must be documented through OpenAPI / Swagger.
-
----
-
-## Frontend / Backend Separation
-
-Vyline must separate frontend and backend completely.
-
-The frontend should be replaceable.
-
-The backend should be reusable.
-
-The desktop shell should only bundle or connect frontend and backend. It should not create hidden dependencies between them.
-
-Required direction:
-
-```txt
-apps/
-  web/
-  desktop/
-  server/
-
-packages/
-  api/
-  api-client/
-  core/
-  line/
-  storage/
-  plugin-sdk/
-  plugin-runtime/
-  shared/
-  ui/
-```
-
-Rules:
-
-* frontend must not import backend private modules
-* backend must not import React components
-* shared types must live in shared packages
-* API types should be generated or shared safely
-* desktop IPC must not replace the public API
-* server mode and desktop mode should use the same core logic
-
----
-
-## Custom Clients
-
-Vyline is not only a themeable client.
-
-Users and developers should be able to build their own clients using Vyline's backend API.
-
-Possible clients:
-
-* official Vyline desktop frontend
-* custom web client
-* minimal chat viewer
-* notification-only client
-* media manager
-* server dashboard
-* future CLI wrapper
-
-Custom clients should use:
-
-* public REST API
-* generated API client
-* shared types
-* documented auth flow
-* documented account scope
-
-The goal is to allow client replacement, not just theme replacement.
-
----
-
-## Plugin System
-
-Vyline must support a JavaScript / TypeScript plugin system.
-
-TypeScript is recommended.
-
-The design can be inspired by plugin-based clients such as Vencord, but it must be safe for Vyline's architecture.
-
-Plugins should extend Vyline without modifying core code.
-
----
-
-### Plugin Requirements
-
-Plugins must support:
-
-* install
-* enable
-* disable
-* update
-* remove
-* activate
-* deactivate
-* settings
-* permissions
-* logs
-* error isolation
-* developer mode
-* examples
-* plugin SDK
-
-Disabled plugins should have almost zero runtime cost.
-
-Plugin crashes must not crash Vyline itself.
-
----
-
-### Example Plugin
-
-```ts
-import { definePlugin } from "@vyline/plugin-sdk";
-
-export default definePlugin({
-  id: "example-plugin",
-  name: "Example Plugin",
-  version: "0.1.0",
-  description: "Example Vyline plugin",
-  permissions: ["messages:read", "notifications:send"],
-
-  async activate(ctx) {
-    ctx.messages.on("message", (message) => {
-      ctx.logger.info("New message", message.id);
-    });
-  },
-
-  async deactivate(ctx) {
-    // cleanup listeners / resources
-  },
-});
-```
-
----
-
-### Plugin Permissions
-
-Example permissions:
-
-```txt
-messages:read
-messages:send
-chats:read
-media:read
-media:write
-storage:read
-storage:write
-notifications:send
-ui:extend
-network:request
-settings:read
-settings:write
-```
-
-Plugins must not access:
-
-* raw tokens
-* sessions
-* cookies
-* private keys
-* unrestricted filesystem paths
-* backend private APIs
-* another account's data
-* raw MID values unless absolutely required and permissioned
-
-Plugin APIs must be account-scoped.
-
----
-
-## Multi-account Support
-
-Vyline must support multiple LINE accounts.
-
-Account data must be separated by account scope using the user's LINE `mid` or a safe derived account identifier.
-
-Raw MID values should not be exposed unnecessarily.
-
-Recommended storage direction:
-
-```txt
-data/
-  accounts/
-    <safe-account-id>/
-      profile.json
-      session/
-      storage/
-      cache/
-      media/
-      db/
-      plugins/
-      logs/
-      backup/
-```
-
-The following data must not be mixed between accounts:
-
-* messages
-* chats
-* media
-* cache
-* saved media
-* sessions
-* settings
-* plugin data
-* logs
-* backups
-* pending uploads
-* pending multi-image batches
-
-Account switching must clean up old listeners, stale UI state, old sockets, old plugin contexts, and old media references.
-
----
-
-## Multi-image Sending
-
-Vyline must support grouped multi-image sending.
-
-For LINE Desktop compatibility, multiple images should not be merged into one message.
-
-Instead, multiple images should be sent as separate `IMAGE` messages and connected using relation fields.
-
-Required relation fields:
-
-* `relatedMessageId`
-* `messageRelationType`
-* `relatedMessageServiceCode`, if required
-
-Expected behavior:
-
-```txt
-image 1 -> IMAGE message
-image 2 -> IMAGE message, relatedMessageId = image 1 message id
-image 3 -> IMAGE message, relatedMessageId = image 2 message id
-```
-
-The UI should group related image messages visually while keeping each image as an individual message internally.
-
-This must work across:
-
-* frontend file picker
-* frontend send action
-* backend media batch API
-* protocol layer
-* E2EE path
-* plain media path
-* storage
-* message list API
-* frontend message model
-* UI grouped rendering
-* app restart
-* multi-account environments
-
-This feature is not complete until:
-
-* relation fields are sent
-* relation fields are saved
-* relation fields are returned by the message API
-* the UI groups related images
-* restart keeps the grouping
-* account switching does not mix media
-* E2EE and plain paths both work
-* partial failures do not cause duplicate sending
-
----
-
-## Storage Management
-
-Vyline must separate temporary cache from saved user media.
-
-Cache is temporary and can be deleted safely.
-
-Saved media is user-owned persistent data and must be preserved through backup and restore.
-
-Required storage categories:
-
-* cache
-* saved media
-* account data
-* plugin data
-* logs
-* backups
-* temporary uploads
-
-Cache and saved media must not be mixed.
-
-Storage size calculation should be incremental or cached. It must not block the UI with full scans on every startup.
-
----
-
-## Backup / Restore
-
-Backup and restore must be account-aware.
-
-Backup should preserve:
-
-* saved media
-* message references
-* account settings
-* plugin settings, where safe
-* storage metadata
-
-Restore must not mix data between accounts.
-
-Restore should handle missing media, old schemas, and partial data safely.
-
----
-
-## Server Mode
-
-Vyline must be able to run on a server, not only as a desktop app.
-
-Server mode should expose:
-
-* REST API
-* Swagger / OpenAPI docs
-* health check endpoint
-* metrics endpoint
-* static frontend serving option
-* configurable storage paths
-* configurable plugin directory
-* configurable logs directory
-* CORS settings
-* auth settings
-* reverse proxy support
-
-Example target command:
-
-```bash
-bun run server
-```
-
-Required server endpoints:
-
-```txt
-GET /health
-GET /metrics
-GET /docs
-GET /swagger
-GET /openapi.json
-```
-
----
-
-## Docker Support
-
-Vyline should be easy to run in Docker or Docker Compose.
-
-Required files:
-
-```txt
-Dockerfile
-docker-compose.yml
-.dockerignore
-```
-
-Recommended persistent directories:
-
-* data
-* config
-* logs
-* plugins
-* media
-
-Example:
-
-```yaml
-services:
-  vyline:
-    build: .
-    ports:
-      - "3000:3000"
-    volumes:
-      - ./data:/app/data
-      - ./config:/app/config
-      - ./logs:/app/logs
-      - ./plugins:/app/plugins
-    environment:
-      - VYLINE_HOST=0.0.0.0
-      - VYLINE_PORT=3000
-      - VYLINE_DATA_DIR=/app/data
-      - VYLINE_CONFIG_DIR=/app/config
-      - VYLINE_LOG_DIR=/app/logs
-      - VYLINE_PLUGIN_DIR=/app/plugins
-```
-
----
-
-## Update / Migration
-
-Vyline should be easy to update.
-
-Required documentation:
-
-* source update guide
-* Docker update guide
-* backup before update
-* rollback guide
-* database migration guide
-* config migration guide
-* breaking changes guide
-
-Example source update flow:
-
-```bash
-git pull
-bun install --frozen-lockfile
-bun run build
-bun run migrate
-bun run server
-```
-
-Example Docker update flow:
-
-```bash
-docker compose pull
-docker compose up -d --build
-```
-
----
-
-## Runtime
-
-Vyline targets **Bun 1.6**.
-
-Common commands:
+## Quick Start
 
 ```bash
 bun install
-bun run dev
-bun run build
-bun run test
-bun run typecheck
-bun run server
+bun run dev          # backend :3001 + frontend :5173
 ```
 
-Actual commands may change while the project is in Beta.
+ブラウザで `http://localhost:5173` を開きます。
 
-Documentation should always reflect the actual commands in the repository.
+| コマンド               | 内容                           |
+| ---------------------- | ------------------------------ |
+| `bun run dev:backend`  | backend のみ（:3001）          |
+| `bun run dev:frontend` | frontend のみ（:5173）         |
+| `bun run typecheck`    | 型チェック（全ワークスペース） |
+| `bun run lint`         | Biome lint                     |
+| `bun run build`        | frontend 本番ビルド            |
+
+詳細: [docs/onboarding.md](docs/onboarding.md) · [docs/development.md](docs/development.md) · [AGENTS.md](AGENTS.md)
+
+### セルフホスト（Docker）
+
+自宅サーバーに立てて、複数端末の Web ブラウザから同じ LINE セッションを利用できます（履歴・画像はサーバー側に永続化）。
+
+```bash
+docker compose up -d --build   # http://localhost:3001
+```
+
+設定・Cloudflare Access での外部公開手順: [docs/selfhosting.md](docs/selfhosting.md)
+
+### 推奨環境
+
+| 項目               | 推奨値         | 備考                                               |
+| ------------------ | -------------- | -------------------------------------------------- |
+| **LINE アプリ**    | IOSIPAD 26.7.2 | `x-line-application` ヘッダー値。最新版を推奨      |
+| **OS**             | iOS 18.0       | Android / Windows 互換は未検証                     |
+| **デバイスモード** | IOSIPAD        | `VYLINE_DEVICE` 環境変数で指定（省略時は IOSIPAD） |
+
+> 定義元: `packages/protocol/src/desktop/types.ts` の DesktopProfile。実際のヘッダー値は `"x-line-application": "IOSIPAD\t26.7.2\tiOS\t18.0"` のように伝搬されます。
 
 ---
 
-## Performance Policy
+## Architecture
 
-Vyline should be lightweight.
+```
+┌─ Frontend (React + Vite) ── apps/desktop ──┐
+│  store / mappers / sync / VyTheme UI       │
+├─ Backend (Hono on Bun) ───── backend ──────┤
+│  BFF routes → lineService → clientManager  │
+├─ Vyline ──────────── packages/protocol ────┤
+│  domain / dictionary / E2EE / Thrift stack │
+└─ LINE Servers ──────────────────────────────┘
+```
 
-A third-party client is not useful if it is heavier than the official desktop client.
+| パス                  | 役割                     |
+| --------------------- | ------------------------ |
+| `apps/desktop`        | React UI                 |
+| `backend`             | Hono BFF                 |
+| `packages/protocol`   | プロトコル本体（Vyline） |
+| `packages/line-types` | Thrift 型（vendored）    |
 
-Vyline should avoid:
+### E2EE / Desktop 鍵
 
-* loading all messages into memory
-* loading all media at startup
-* storing large image buffers in UI state
-* converting large media to base64 unnecessarily
-* unnecessary polling
-* duplicate network requests
-* full cache scans on every startup
-* keeping inactive accounts fully loaded
-* keeping disabled plugins active
-* excessive background CPU usage
-* unlimited in-memory logs
-* unnecessary deep clones
-* unnecessary JSON stringify / parse cycles
+過去メッセージの復号には、公式 LINE Desktop から抽出した自己鍵一式が必要です。
 
-Vyline should use:
+1. LINE.exe 起動状態で鍵を抽出（[docs/analysis/](docs/analysis/)）
+2. `backend/data/desktop-e2ee-keys.json` に配置（**gitignore・コミット禁止**）
+3. backend 起動時に自動 import
 
-* lazy loading
-* pagination
-* virtualized message lists
-* virtualized media grids
-* incremental storage scanning
-* bounded memory caches
-* request deduplication
-* retry backoff
-* upload concurrency limits
-* worker threads or web workers for heavy tasks
-* cleanup after account switching
-* cleanup after plugin disable
-* memory and CPU measurement
+### 公開 API (`/v1/`)
 
-Performance improvements must be measured, not guessed.
+セルフホスト時に Bearer トークンで Vyline を外部から操作できます。
 
-Important metrics:
+```bash
+# トークン作成（VYLINE_API_ADMIN_SECRET を設定後）
+curl -X POST http://localhost:3001/v1/tokens \
+  -H "Authorization: Bearer $VYLINE_API_ADMIN_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "my-bot"}'
 
-* startup time
-* idle memory usage
-* idle CPU usage
-* message list rendering time
-* media loading memory
-* account switch memory delta
-* server idle memory
-* network request count
-* duplicate request count
+# チャット一覧取得
+curl http://localhost:3001/v1/accounts/{accountId}/chats \
+  -H "Authorization: Bearer vyl_xxxx..."
+```
+
+API 仕様（OpenAPI 3.1）: `GET /openapi.json` または [zensical.org](https://zensical.org)
+
+### 解析ツールキット（vyline-search）
+
+Desktop LINE（Themida 保護）の unpack / ネイティブシンボル検索 / 逆コンパイルを行う独立ツールキットです。教育・研究目的で `findNativeSymbol` による文字列 xref 解析と Ghidra decompile をワンコマンドで実行できます。
+
+> [!WARNING]
+> **注意**: LINE デスクトップクライアントが起動中の状態では、解析ツール（unpack 等）が正常に動作しません（単一インスタンス制御により frida の注入が拒否されプロセスが強制終了するため）。必ず LINE アプリを完全に終了させてから実行してください。
+
+**[github.com/nezumi0627/vyline-search](https://github.com/nezumi0627/vyline-search)**
+
+```powershell
+bun run vyline:check                  # インストール版 / 最新版の比較
+bun run vyline:versions               # インストール済みバージョン一覧
+bun run vyline:unpack -- --version <ver>   # インストール済みバージョンを選択して unpack
+bun run vyline:update                 # LINE Desktop を最新版へ更新
+bun run vyline:find-native -- sendMessage  # ネイティブシンボル検索
+```
+
+> **注意**: `vyline:unpack` / `vyline:update` は **LINE を終了してから実行**してください。
+> 稼働中は Frida 注入が拒否され `ProcessNotRespondingError` になります。
 
 ---
 
-## Documentation
+## ドキュメント
 
-README should stay short enough to be an entry point.
+| リンク                                                     | 内容                                   |
+| ---------------------------------------------------------- | -------------------------------------- |
+| [docs/README.md](docs/README.md)                           | ドキュメント索引                       |
+| [docs/onboarding.md](docs/onboarding.md)                   | 初日チェックリスト                     |
+| [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md)               | 貢献フロー                             |
+| [docs/architecture.md](docs/architecture.md)               | 層構造                                 |
+| [docs/development.md](docs/development.md)                 | 開発コマンド                           |
+| [docs/selfhosting.md](docs/selfhosting.md)                 | Docker セルフホスト・Cloudflare Access |
+| [docs/protocol/dictionary.md](docs/protocol/dictionary.md) | RPC 辞書                               |
+| [AGENTS.md](AGENTS.md)                                     | エージェント向けガイド                 |
+| [CHANGELOG.md](CHANGELOG.md)                               | 変更履歴                               |
+| [zensical.org](https://zensical.org)                       | 公開ドキュメント・API リファレンス     |
+| [/openapi.json](/openapi.json)                             | OpenAPI 3.1 仕様（ローカル）           |
 
-Detailed documentation should live in `docs/`.
-
-Required documentation structure:
-
-```txt
-docs/
-  user-guide/
-    installation.md
-    update.md
-    account-switching.md
-    sending-media.md
-    storage.md
-    backup-restore.md
-    troubleshooting.md
-
-  developer-guide/
-    architecture.md
-    frontend.md
-    backend.md
-    api.md
-    plugin-system.md
-    plugin-sdk.md
-    custom-client.md
-    multi-account.md
-    account-storage.md
-    multi-image-sending.md
-    message-relations.md
-    performance-budget.md
-    memory-policy.md
-    network-optimization.md
-    testing.md
-
-  api/
-    openapi.md
-    swagger.md
-    media-batch.md
-
-  deployment/
-    local.md
-    docker.md
-    docker-compose.md
-    server.md
-    reverse-proxy.md
-    systemd.md
-
-  agents/
-    overview.md
-    coding-rules.md
-    review-rules.md
-```
-
-Docs must match the actual implementation.
-
-Do not claim features as complete unless they are verified.
+公開ドキュメント・チュートリアル: **[zensical.org](https://zensical.org)**
 
 ---
 
-## Development Policy
+## 貢献 / 募集
 
-Vyline development follows these principles:
+- 🐛 [Bug report](.github/ISSUE_TEMPLATE/bug_report.md)
+- ✨ [Feature request](.github/ISSUE_TEMPLATE/feature_request.md)
+- 📝 [Pull request](.github/pull_request_template.md)
 
-* keep code simple
-* avoid unnecessary abstractions
-* prefer existing APIs and standard library features
-* avoid unnecessary dependencies
-* keep frontend and backend separated
-* keep APIs stable and documented
-* protect user data
-* isolate account data
-* make plugins permission-based
-* measure performance changes
-* separate confirmed bugs from suspected issues
-* keep README readable
-* move detailed information into docs
+貢献フローは [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) を参照してください。PR には解析対象ソフトウェアの実体・鍵・トークンなどを含めないでください。
 
-Existing implementation should be questioned, but not blindly replaced.
+現在、以下を募集しています:
 
-If existing code is correct and has a valid reason to exist, keep it.
+- **PR**: バグ修正、機能改善、ドキュメントの更新
+- **アイコン**: アプリアイコン・テーマアイコンのデザイン
+- **バナー**: SNS・ブログでのプロモーション用バナー
+- **定期的なメンテナー**: 個人開発のため、継続的に助けていただける方を募集中
 
-If the structure blocks future development, it may be rebuilt.
-
-Breaking changes are allowed when necessary, but existing features must not be broken without a migration path.
+興味がある方は [AGENTS.md](AGENTS.md) の手順に従ってプルリクエストをお送りください。
 
 ---
 
-## Branch Rules
+## Vyline Desktop
 
-Recommended branch names:
+> **Coming Soon** 🚀
 
-```txt
-feature/<short-name>
-fix/<short-name>
-docs/<short-name>
-refactor/<short-name>
-security/<short-name>
-perf/<short-name>
-chore/<short-name>
-```
+Vyline が安定版に到達した後、専用のデスクトップアプリ **Vyline Desktop** をリリース予定です。
 
-Recommended commit style:
+- 🖥️ Windows / macOS / Linux ネイティブアプリ
+- 🔔 プッシュ通知
+- 🗂️ トレイアイコン常駐
+- 🔒 ローカルデータ完全管理
 
-```txt
-feat(api): add media batch endpoint
-fix(storage): separate cache from saved media
-docs(readme): simplify project overview
-perf(messages): virtualize message list
-security(plugins): restrict filesystem access
-```
+Vyline の安定版リリースをお待ちください。
 
 ---
 
-## Agent / Skill Policy
+## ロードマップ
 
-Vyline development may use coding-agent skill sets to reduce unnecessary code, avoid over-engineering, and improve review quality.
+Vyline は API ファーストな拡張可能アーキテクチャを目指します（詳細は [AGENTS.md](AGENTS.md)）。
 
-Before large refactors, audits, API redesigns, plugin work, or documentation cleanup, the agent should check and use the following skill / rule sets when available.
+- **API / Swagger**: `GET /docs`・`/swagger`・`/openapi.json` で API 仕様を公開（[docs/api](docs/api/openapi.md)）
+- **プラグインシステム**: JavaScript / TypeScript 補完・権限スコープ付き（計画中）
+- **カスタムクライアント**: バックエンド API を使った独自クライアント開発を想定
+- **マルチアカウント**: アカウント単位のデータ分離
+- **複数画像一括送信**: 個別 IMAGE メッセージ + グルーピング表示（実装済み）
+- **Docker / サーバーモード**: `bun run server`・Docker Compose 配布
+- **軽量性**: メモリ・CPU・通信量は公式クライアント以下を目標に、計測ベースで改善
 
-### Required Skill Sets
+---
 
-| Skill | Repository | Purpose |
-|---|---|---|
-| Ponytail | `DietrichGebert/ponytail` | YAGNI, standard library first, reuse existing code, avoid unnecessary abstraction |
-| Caveman | `JuliusBrussee/caveman` | Compress reports and explanations while keeping code blocks intact |
-| agent-skills-standard | `HoangNguyen0403/agent-skills-standard` | Load task-specific skills only when needed |
-| agent-skills | `addyosmani/agent-skills` | Production-grade frontend, performance, API, testing, and documentation guidance |
-| Minimize-Cursor-Cost | `inboxpraveen/Minimize-Cursor-Cost` | Reduce repeated reads, wasted tool calls, unnecessary verification, and token cost |
+## エージェント / Skill 方針
 
-### How These Skills Should Be Used
+開発には coding-agent 用 skill セット（Ponytail / Caveman / agent-skills-standard /
+addyosmani agent-skills / Minimize-Cursor-Cost）を利用する場合があります。
+不要なコード・過剰設計を避け、レビュー品質を上げるためです。
 
-Ponytail should be used as the default engineering mindset.
-
-Use it to avoid:
-
-- unnecessary wrappers
-- unnecessary services
-- unnecessary managers
-- unnecessary dependencies
-- unnecessary rewrites
-- future-proofing without actual need
-- code that only passes data through another layer
-
-Caveman should be used only for shortening reports, comments, and summaries.
-
-Do not apply Caveman to:
-
-- source code
-- OpenAPI schemas
-- JSON
-- YAML
-- TOML
-- SQL
-- Dockerfiles
-- migration files
-- security warnings
-- legal disclaimers
-- user-facing documentation
-
-`agent-skills-standard` and `addyosmani/agent-skills` should be loaded only when relevant.
-
-Do not load every skill at once.
-
-Examples:
-
-- API redesign → load API / OpenAPI related skills
-- plugin system → load plugin / sandbox / security related skills
-- Docker / server mode → load deployment / DevOps related skills
-- performance work → load frontend / React / server performance related skills
-- docs cleanup → load documentation related skills
-
-`Minimize-Cursor-Cost` should be used to keep the workflow efficient.
-
-The agent should:
-
-- avoid reading the same file repeatedly
-- avoid re-checking already confirmed facts
-- batch related searches
-- inspect only relevant files first
-- run targeted tests before full test suites
-- report unknowns instead of wasting time pretending everything is verified
-
-### Skill Priority
-
-These skills are helpers, not final authority.
-
-Priority order:
-
-1. User instructions
-2. Security
-3. Privacy
-4. Data safety
-5. Existing feature compatibility
-6. Actual repository behavior
-7. Test results
-8. Ponytail minimalism
-9. Other skill recommendations
-10. Token reduction
-
-Token reduction must never override correctness, security, privacy, or maintainability.
-
-### Required Agent Report
-
-When an AI coding agent starts a large task, it should include a short skill bootstrap report:
-
-```md
-## Skill Bootstrap
-
-| Skill | Status | Used for |
-|---|---|---|
-| Ponytail | Available / Not available | Minimal implementation and YAGNI |
-| Caveman | Available / Not available | Report compression only |
-| agent-skills-standard | Available / Not available | Task-specific skills |
-| addyosmani/agent-skills | Available / Not available | Production-grade review |
-| Minimize-Cursor-Cost | Available / Not available | Efficient repository exploration |
-
-Notes:
-- Missing skills must be listed.
-- If a skill is unavailable, continue with the same principles manually.
-- Do not stop work only because a skill is unavailable.
-```
+ただし セキュリティ > プライバシー > データ保護 > 既存機能互換 > トークン削減 の順で、
+正確性と安全性が常に優先されます。詳細は [AGENTS.md](AGENTS.md) を参照してください。
 
 ---
 
 ## Support Vyline
 
-Vyline is developed as an independent project.
+Vyline は個人開発の独立プロジェクトです。小さな支援が開発・テスト・ドキュメント整備に役立ちます。
 
-Small support is appreciated and helps with development, testing, documentation, and maintenance.
+| 金額 | Tier | 内容 |
+| ---: | --- | --- |
+| ~500円 | 応援 | 開発・保守費に |
+| 500円~ | サポーター | 希望者はサポート一覧に掲載 |
+| 1,000円~ | スペシャルサポーター | docs / リリースノートに感謝掲載（希望者） |
+| 3,000円~ | メジャーサポーター | メジャーサポーターとして掲載（希望者） |
 
-Suggested support tiers:
-
-|            Amount | Tier              | Notes                                                             |
-| ----------------: | ----------------- | ----------------------------------------------------------------- |
-|     Under 500 JPY | Thank you support | Helps development and maintenance                                 |
-|   500 JPY or more | Supporter         | May be listed as a supporter if requested                         |
-| 1,000 JPY or more | Special supporter | May receive acknowledgement in docs or release notes if requested |
-| 3,000 JPY or more | Major supporter   | May be listed as a major supporter if requested                   |
-
-Support does not guarantee:
-
-* feature implementation
-* bug fixes
-* private support
-* priority support
-* special permissions
-* account support
-
-Supporter names are only listed with permission.
-
-Payment details such as PayPay links or QR codes should be documented carefully and should not expose private information.
-
----
-
-## Security and Privacy
-
-Vyline should never expose sensitive data unnecessarily.
-
-Do not log or expose:
-
-* raw MID values
-* tokens
-* sessions
-* cookies
-* private keys
-* local user paths
-* message contents in debug logs
-* account identifiers without need
-* plugin private data
-* backup private data
-
-Plugins must use permission-scoped APIs.
-
-Account data must remain separated.
-
-Multi-account data mixing is a serious bug.
-
----
-
-## Disclaimer
-
-Vyline is an independent third-party client project.
-
-Vyline is not affiliated with, endorsed by, or sponsored by LY Corporation or LINE.
-
-Use this project at your own risk.
-
-The maintainers are not responsible for account issues, data loss, service restrictions, or damages caused by using this software.
-
-If there is a problem with content in this repository, please contact the maintainer.
+※ 支援は機能実装・バグ修正・個別対応等を保証するものではありません。
+掲載は許可いただいた場合のみ。支払い方法の詳細は今後このセクションに追記します。
 
 ---
 
 ## License
 
-MIT License.
+MIT — see [LICENSE](LICENSE)
 
-See `LICENSE` for details.
+**著作権**: [`nezumi0627`](https://github.com/nezumi0627)
+改変・再配布・記事・投稿等では出典表示をお願いします（詳細は [LICENSE](LICENSE) の Attribution requirement を参照）。


### PR DESCRIPTION
## Summary
- ユーザー提供の完成版READMEに全面差し替え（API-first / Swagger必須ルート / plugin / Docker / multi-account / perf方針 / Support / Skill Policy）
- AGENTS.md に skill 使用指示を追加（大型タスク前に5種を確認・使用、優先順位付き）

## Test
- markdown のみ。typecheck 等はコード変更なしのため省略（pre-push hook が全体チェックを実行）