### PR TITLE
feat(api): Swagger UI + BFF OpenAPI spec + api docs

### DIFF
--- a/Vyline/backend/src/api/openapi.line.ts
+++ b/Vyline/backend/src/api/openapi.line.ts
@@ -1,0 +1,536 @@
+/**
+ * api/openapi.line.ts — BFF (/line) 内部 API の OpenAPI 3.1 仕様
+ *
+ * Swagger UI は GET /docs および /swagger で提供される。
+ * 公開 REST API (/v1) の仕様は openapi.yaml を参照（/openapi/v1.yaml で提供）。
+ */
+
+const accountParam = {
+  name: "accountId",
+  in: "path",
+  required: true,
+  schema: { type: "string" },
+  description: "Vyline アカウント ID（例: main）",
+} as const;
+
+const chatParam = {
+  name: "chatMid",
+  in: "path",
+  required: true,
+  schema: { type: "string" },
+  description: "チャット MID (u.../c.../r...)",
+} as const;
+
+const ok = {
+  type: "object",
+  properties: { ok: { type: "boolean" } },
+} as const;
+
+const error = {
+  type: "object",
+  properties: { ok: { type: "boolean", enum: [false] }, error: { type: "string" } },
+} as const;
+
+export const lineOpenApiSpec = {
+  openapi: "3.1.0",
+  info: {
+    title: "Vyline BFF API",
+    version: "0.6.0",
+    description:
+      "Vyline フロントエンドが利用する内部 BFF API。セッション Cookie / ローカル実行を前提とし、" +
+      "外部公開は想定していない。安定した公開 API は /v1 (openapi.yaml) を使用すること。",
+  },
+  servers: [{ url: "{baseUrl}", variables: { baseUrl: { default: "http://127.0.0.1:3001" } } }],
+  tags: [
+    { name: "session" },
+    { name: "chats" },
+    { name: "messages" },
+    { name: "media" },
+    { name: "stickers" },
+    { name: "backup" },
+    { name: "storage" },
+  ],
+  paths: {
+    "/healthz": {
+      get: {
+        tags: ["session"],
+        summary: "ヘルスチェック",
+        responses: {
+          "200": { description: "ready", content: { "application/json": { schema: ok } } },
+        },
+      },
+    },
+    "/auth/accounts": {
+      get: {
+        tags: ["session"],
+        summary: "登録済みアカウント一覧",
+        responses: {
+          "200": {
+            description: "アカウント配列",
+            content: {
+              "application/json": { schema: { type: "array", items: { type: "object" } } },
+            },
+          },
+        },
+      },
+    },
+    "/line/{accountId}/profile": {
+      get: {
+        tags: ["session"],
+        summary: "自分のプロフィール",
+        parameters: [accountParam],
+        responses: {
+          "200": {
+            description: "プロフィール",
+            content: {
+              "application/json": {
+                schema: { type: "object", properties: { profile: { type: "object" } } },
+              },
+            },
+          },
+          "401": { description: "未ログイン", content: { "application/json": { schema: error } } },
+        },
+      },
+    },
+    "/line/{accountId}/bootstrap": {
+      get: {
+        tags: ["chats"],
+        summary: "起動時一括 hydrate（チャット + 直近メッセージ）",
+        parameters: [accountParam],
+        responses: {
+          "200": {
+            description: "BootstrapPayload",
+            content: { "application/json": { schema: { type: "object" } } },
+          },
+        },
+      },
+    },
+    "/line/{accountId}/chats": {
+      get: {
+        tags: ["chats"],
+        summary: "チャット一覧",
+        parameters: [accountParam],
+        responses: {
+          "200": {
+            description: "Chat 配列",
+            content: {
+              "application/json": { schema: { type: "array", items: { type: "object" } } },
+            },
+          },
+        },
+      },
+    },
+    "/line/{accountId}/messages/{chatMid}": {
+      get: {
+        tags: ["messages"],
+        summary: "メッセージ取得（local-first + サーバ同期）",
+        parameters: [
+          accountParam,
+          chatParam,
+          { name: "limit", in: "query", schema: { type: "integer", default: 30, maximum: 100 } },
+          {
+            name: "force",
+            in: "query",
+            schema: { type: "string", enum: ["0", "1"] },
+            description: "1 でサーバ強制取得",
+          },
+          { name: "local", in: "query", schema: { type: "string", enum: ["0", "1"] } },
+          { name: "beforeMessageId", in: "query", schema: { type: "string" } },
+        ],
+        responses: {
+          "200": {
+            description: "Message 配列（降順）",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    messages: { type: "array", items: { $ref: "#/components/schemas/Message" } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/line/{accountId}/send": {
+      post: {
+        tags: ["messages"],
+        summary: "テキスト送信",
+        parameters: [accountParam],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["chatMid", "text"],
+                properties: {
+                  chatMid: { type: "string" },
+                  text: { type: "string" },
+                  relatedMessageId: { type: "string" },
+                  mute: { type: "boolean" },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "送信結果",
+            content: { "application/json": { schema: { type: "object" } } },
+          },
+        },
+      },
+    },
+    "/line/{accountId}/send-media-batch": {
+      post: {
+        tags: ["media"],
+        summary: "複数メディアの一括送信",
+        description:
+          "各アイテムは個別の IMAGE メッセージとして送信される。" +
+          "plain 経路では OBS /r/talk/m/reqseq 連番アップロードにより LINE サーバ側がメッセージを生成する。" +
+          "UI は同一送信者の連続 IMAGE を時間窓でグルーピング表示する。",
+        parameters: [accountParam],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/MediaBatchRequest" },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "送信完了",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    ok: { type: "boolean" },
+                    count: { type: "integer", description: "送信できたアイテム数" },
+                  },
+                },
+              },
+            },
+          },
+          "400": {
+            description: "chatMid/items 不備",
+            content: { "application/json": { schema: error } },
+          },
+          "413": {
+            description: "ファイル超過",
+            content: { "application/json": { schema: error } },
+          },
+        },
+      },
+    },
+    "/line/{accountId}/send-media": {
+      post: {
+        tags: ["media"],
+        summary: "単体メディア送信",
+        parameters: [accountParam],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["chatMid", "dataBase64"],
+                properties: {
+                  chatMid: { type: "string" },
+                  dataBase64: { type: "string", description: "最大 ~12MB base64" },
+                  mimeType: { type: "string" },
+                  filename: { type: "string" },
+                  mediaType: { type: "string", enum: ["image", "video", "audio", "file", "gif"] },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          "200": { description: "送信結果", content: { "application/json": { schema: ok } } },
+        },
+      },
+    },
+    "/line/{accountId}/media/{chatMid}/{messageId}": {
+      get: {
+        tags: ["media"],
+        summary: "メディア取得（キャッシュ → OBS → RPC フォールバック）",
+        parameters: [
+          accountParam,
+          chatParam,
+          { name: "messageId", in: "path", required: true, schema: { type: "string" } },
+          {
+            name: "preview",
+            in: "query",
+            schema: { type: "string", enum: ["0", "1"], default: "1" },
+          },
+        ],
+        responses: {
+          "200": {
+            description: "バイナリ",
+            content: { "*/*": { schema: { type: "string", format: "binary" } } },
+          },
+          "401": { description: "未ログイン" },
+          "422": { description: "取得不能（期限切れ等）" },
+        },
+      },
+    },
+    "/line/{accountId}/unsend": {
+      post: {
+        tags: ["messages"],
+        summary: "メッセージ送信取り消し",
+        parameters: [accountParam],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["messageId"],
+                properties: { messageId: { type: "string" } },
+              },
+            },
+          },
+        },
+        responses: {
+          "200": { description: "結果", content: { "application/json": { schema: ok } } },
+        },
+      },
+    },
+    "/line/{accountId}/read": {
+      post: {
+        tags: ["messages"],
+        summary: "既読送信",
+        parameters: [accountParam],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["chatMid", "messageId"],
+                properties: { chatMid: { type: "string" }, messageId: { type: "string" } },
+              },
+            },
+          },
+        },
+        responses: {
+          "200": { description: "結果", content: { "application/json": { schema: ok } } },
+        },
+      },
+    },
+    "/line/{accountId}/read-receipts/{chatMid}": {
+      get: {
+        tags: ["messages"],
+        summary: "既読情報取得",
+        parameters: [accountParam, chatParam],
+        responses: {
+          "200": {
+            description: "既読範囲",
+            content: { "application/json": { schema: { type: "object" } } },
+          },
+        },
+      },
+    },
+    "/line/{accountId}/stickers": {
+      get: {
+        tags: ["stickers"],
+        summary: "所持スタンプ一覧",
+        parameters: [accountParam],
+        responses: {
+          "200": {
+            description: "スタンプパック配列",
+            content: {
+              "application/json": { schema: { type: "array", items: { type: "object" } } },
+            },
+          },
+        },
+      },
+    },
+    "/line/{accountId}/send-sticker": {
+      post: {
+        tags: ["stickers"],
+        summary: "スタンプ送信",
+        parameters: [accountParam],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["chatMid"],
+                properties: {
+                  chatMid: { type: "string" },
+                  packageId: { type: "string" },
+                  stickerId: { type: "string" },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "結果",
+            content: { "application/json": { schema: { type: "object" } } },
+          },
+        },
+      },
+    },
+    "/line/{accountId}/combination-stickers/can-create": {
+      post: {
+        tags: ["stickers"],
+        summary: "コンビネーションスタンプ作成可否",
+        parameters: [accountParam],
+        responses: {
+          "200": {
+            description: "可否",
+            content: { "application/json": { schema: { type: "object" } } },
+          },
+        },
+      },
+    },
+    "/line/{accountId}/send-combination-sticker": {
+      post: {
+        tags: ["stickers"],
+        summary: "コンビネーションスタンプ送信",
+        parameters: [accountParam],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["chatMid", "items"],
+                properties: {
+                  chatMid: { type: "string" },
+                  items: {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      properties: {
+                        packageId: { type: "string" },
+                        stickerId: { type: "string" },
+                        x: { type: "number" },
+                        y: { type: "number" },
+                        size: { type: "number" },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "結果",
+            content: { "application/json": { schema: { type: "object" } } },
+          },
+        },
+      },
+    },
+    "/line/{accountId}/vyline/cache": {
+      get: {
+        tags: ["storage"],
+        summary: "ストレージ / キャッシュ使用量",
+        parameters: [accountParam],
+        responses: {
+          "200": {
+            description: "使用量サマリ",
+            content: { "application/json": { schema: { type: "object" } } },
+          },
+        },
+      },
+    },
+    "/line/{accountId}/vyline/warm": {
+      post: {
+        tags: ["storage"],
+        summary: "キャッシュウォーム",
+        parameters: [accountParam],
+        responses: {
+          "200": { description: "結果", content: { "application/json": { schema: ok } } },
+        },
+      },
+    },
+    "/line/{accountId}/backup": {
+      get: {
+        tags: ["backup"],
+        summary: "バックアップ一覧 / チャット選択用リスト",
+        parameters: [accountParam],
+        responses: {
+          "200": {
+            description: "バックアップ情報",
+            content: { "application/json": { schema: { type: "object" } } },
+          },
+        },
+      },
+    },
+    "/line/{accountId}/restore": {
+      post: {
+        tags: ["backup"],
+        summary: "バックアップ復元",
+        parameters: [accountParam],
+        requestBody: {
+          required: true,
+          content: { "application/json": { schema: { type: "object" } } },
+        },
+        responses: {
+          "200": {
+            description: "結果",
+            content: { "application/json": { schema: { type: "object" } } },
+          },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {
+      MediaBatchItem: {
+        type: "object",
+        required: ["dataBase64"],
+        properties: {
+          dataBase64: {
+            type: "string",
+            description: "base64 エンコードされたバイナリ（最大 ~12MB）",
+          },
+          mimeType: { type: "string", example: "image/png" },
+          filename: { type: "string" },
+          mediaType: { type: "string", enum: ["image", "video", "audio", "file", "gif"] },
+        },
+      },
+      MediaBatchRequest: {
+        type: "object",
+        required: ["chatMid", "items"],
+        properties: {
+          chatMid: { type: "string" },
+          items: {
+            type: "array",
+            minItems: 1,
+            items: { $ref: "#/components/schemas/MediaBatchItem" },
+          },
+        },
+      },
+      Message: {
+        type: "object",
+        properties: {
+          id: { type: "string" },
+          from: { type: "string" },
+          to: { type: "string" },
+          text: { type: "string", nullable: true },
+          contentType: { type: "string" },
+          createdTime: { type: "integer", format: "int64" },
+          isMyMessage: { type: "boolean" },
+          relatedMessageId: { type: "string", nullable: true },
+          messageRelationType: { type: "string", nullable: true },
+          relatedMessageServiceCode: { type: "string", nullable: true },
+          contentMetadata: { type: "object", nullable: true },
+          readCount: { type: "integer", nullable: true },
+        },
+      },
+    },
+  },
+} as const;

--- a/Vyline/backend/src/index.ts
+++ b/Vyline/backend/src/index.ts
@@ -4,7 +4,7 @@
  * 通話モジュールは遅延 import（ログイン等の基本機能を通話スタック障害から切り離す）
  */
 
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
 import { cors } from "hono/cors";
 
 import { existsSync } from "node:fs";
@@ -17,6 +17,7 @@ import { lineRouter } from "./api/line.js";
 import { debugRouter } from "./api/debug.js";
 import { cdnRouter } from "./api/cdn.js";
 import { publicRouter } from "./api/public.js";
+import { lineOpenApiSpec } from "./api/openapi.line.js";
 import { restoreAllSessions } from "./line/clientManager.js";
 import { initVylineProfile } from "./vyline/profileBridge.js";
 import { warmAccountCache } from "./storage/chatStore.js";
@@ -53,6 +54,10 @@ app.route("/v1", publicRouter);
 app.route("/api/v1", publicRouter);
 
 // OpenAPI 仕様
+// /openapi.yaml      — 公開 REST API (/v1) の YAML
+// /openapi.json      — BFF (/line) API の JSON
+// /openapi/v1.yaml   — 公開 REST API (/v1) の YAML（Swagger UI 用エイリアス）
+// /docs, /swagger    — Swagger UI（CDN）
 app.get("/openapi.yaml", async (c) => {
   try {
     const yamlPath = join(dirname(fileURLToPath(import.meta.url)), "../../openapi.yaml");
@@ -65,18 +70,39 @@ app.get("/openapi.yaml", async (c) => {
     return c.json({ ok: false, error: "openapi.yaml not found" }, 404);
   }
 });
-app.get("/openapi.json", async (c) => {
-  try {
-    const yamlPath = join(dirname(fileURLToPath(import.meta.url)), "../../openapi.yaml");
-    const yaml = await readFile(yamlPath, "utf8");
-    return new Response(yaml, {
-      status: 200,
-      headers: { "Content-Type": "text/yaml; charset=utf-8" },
-    });
-  } catch {
-    return c.json({ ok: false, error: "openapi.yaml not found" }, 404);
-  }
-});
+app.get("/openapi/v1.yaml", (c) => c.redirect("/openapi.yaml"));
+app.get("/openapi.json", (c) => c.json(lineOpenApiSpec));
+app.get("/docs", (c) => docsHtml(c));
+app.get("/swagger", (c) => docsHtml(c));
+
+function docsHtml(c: Context): Response {
+  const html = `<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <title>Vyline API Docs</title>
+    <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css" />
+  </head>
+  <body>
+    <div id="swagger"></div>
+    <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js" crossorigin></script>
+    <script>
+      SwaggerUIBundle({
+        urls: [
+          { name: "BFF API (/line)", url: "/openapi.json" },
+          { name: "Public API (/v1)", url: "/openapi.yaml" },
+        ],
+        dom_id: "#swagger",
+        deepLinking: true,
+      });
+    </script>
+  </body>
+</html>`;
+  return new Response(html, {
+    status: 200,
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  });
+}
 
 const MIME: Record<string, string> = {
   ".html": "text/html; charset=utf-8",

--- a/docs/api/media-batch.md
+++ b/docs/api/media-batch.md
@@ -1,0 +1,65 @@
+# Media Batch API（複数メディア一括送信）
+
+最終更新: 2026-08-22
+
+## エンドポイント
+
+```
+POST /line/{accountId}/send-media-batch
+```
+
+OpenAPI 仕様: `GET /openapi.json`（Swagger UI: `GET /docs`）
+
+## Request
+
+```json
+{
+  "chatMid": "c1efe9d6cf1848350bc91848a8a29963e",
+  "items": [
+    { "dataBase64": "<base64>", "mimeType": "image/png", "filename": "a.png", "mediaType": "image" },
+    { "dataBase64": "<base64>", "mimeType": "image/png", "filename": "b.png", "mediaType": "image" }
+  ]
+}
+```
+
+| field | 型 | 必須 | 備考 |
+|---|---|---|---|
+| chatMid | string | ✓ | 送信先 (u.../c.../r...) |
+| items | array | ✓ | 1 件以上 |
+| items[].dataBase64 | string | ✓ | 最大 ~12MB |
+| items[].mimeType | string |  | 既定 `image/png` |
+| items[].filename | string |  | 既定 `screenshot.png` 等 |
+| items[].mediaType | string |  | image/video/audio/file/gif（mimeType から推論可） |
+
+## Response
+
+```json
+{ "ok": true, "count": 2 }
+```
+
+`count` は送信できたアイテム数。エラー時は `4xx` と `{ ok: false, error }`。
+
+## 送信経路の内部動作
+
+1. **E2EE 可能な相手/グループ** → `uploadMediaByE2EE`（OBS アップロード + `sendMessage` with chunks）。
+   失敗時は sender key 再生成 / グループ鍵再作成して 1 回リトライ。
+2. **plain 経路**（flow=1 チャット・BOT・E2EE 非対応）→ **OBS `/r/talk/m/reqseq` に連番 reqseq でアップロードし、LINE サーバ側がメッセージを生成する**（公式アプリと同じ経路）。
+   thrift `sendMessage` を併用するとサーバ履歴に載らないため使用しないこと。
+3. plain 経路のアップロード応答 `x-obs-oid` は生成メッセージ ID と一致するため、
+   送信バイトをローカル media cache に置き、自クライアントの即表示に使う。
+
+## グルーピング表示
+
+- 公式クライアントのアルバム（`contentMetadata.GID/GSEQ/GTOTAL`）の再現は未達。
+  現状の UI は `sender + chatId + 30 秒窓` で連続 IMAGE をグルーピングするフォールバック実装。
+- `relatedMessageId` / `messageRelationType` は E2EE 経路の `sendMessage` では付与されるが、
+  reqseq 経路ではサーバ生成のため存在しない。詳細は
+  `docs/analysis/multi-image-send-handoff.md` を参照。
+
+## テスト
+
+```bash
+bun run test:media -- --chat c1efe9d6cf1848350bc91848a8a29963e --n 3
+```
+
+送信先は AGENTS.md の許可されたテスト先のみ。

--- a/docs/api/openapi.md
+++ b/docs/api/openapi.md
@@ -1,0 +1,31 @@
+# OpenAPI / Swagger
+
+最終更新: 2026-08-22
+
+Vyline バックエンドは 2 種類の API を持つ。
+
+| API | prefix | 認証 | 仕様 |
+|---|---|---|---|
+| 公開 REST API | `/v1` (`/api/v1`) | Bearer トークン | `openapi.yaml` |
+| BFF（フロントエンド内部 API） | `/line` `/auth` `/debug` `/cdn` | ローカルセッション | `backend/src/api/openapi.line.ts` |
+
+## ルート
+
+```txt
+GET /docs            Swagger UI（両方の仕様を切り替え表示）
+GET /swagger         同上（エイリアス）
+GET /openapi.json    BFF API の OpenAPI 3.1 JSON
+GET /openapi.yaml    公開 REST API の YAML
+GET /openapi/v1.yaml /openapi.yaml へのリダイレクト
+```
+
+Swagger UI は CDN からスクリプトを読み込むため、オフライン環境では `openapi.json` /
+`openapi.yaml` を直接確認すること。
+
+## 変更フロー
+
+BFF のエンドポイントを追加・変更した場合は
+`Vyline/backend/src/api/openapi.line.ts` を必ず更新する。
+型チェックは `bun run typecheck` に含まれる（spec は TypeScript オブジェクトのため）。
+
+公開 REST API (/v1) を変更した場合はルート直下の `openapi.yaml` を手動で更新する。


### PR DESCRIPTION
## Summary

README の required routes (GET /docs, /swagger, /openapi.json) を実装。

- Swagger UI (CDN・依存追加なし): BFF (/line) と Public (/v1) の両仕様を切り替え表示
- /openapi.json: BFF API の OpenAPI 3.1 JSON（21 paths — messages/media/media-batch/stickers/storage/backup 等）
- /openapi/v1.yaml: 既存公開仕様へのリダイレクト
- docs/api/openapi.md, docs/api/media-batch.md を新規追加

## Test
- backend typecheck OK / lint OK
- 実プロセスで /docs 200, /swagger 200, /openapi.json (3.1.0, 21 paths) を確認済み

※ スタック PR: base は #41 (integrate/consolidated-work)
