### PR TITLE
feat(server): server mode script + /metrics + /api/v1/status

### DIFF
--- a/Vyline/backend/src/index.ts
+++ b/Vyline/backend/src/index.ts
@@ -36,6 +36,42 @@ const app = new Hono();
 app.use("*", cors({ origin: CORS_ORIGIN }));
 
 app.get("/healthz", (c) => c.json({ ok: true, status: "ready" }));
+app.get("/api/v1/status", (c) =>
+  c.json({
+    ok: true,
+    status: "ready",
+    uptimeSec: Math.floor(performance.now() / 1000),
+    version: process.env.npm_package_version ?? "dev",
+  }),
+);
+
+// 軽量メトリクス: リクエストカウンタ + プロセス統計のみ（重い集計は行わない）
+const metricsState = { requests: 0, errors: 0 };
+app.use("*", async (c, next) => {
+  await next();
+  if (c.req.path === "/metrics") return;
+  metricsState.requests++;
+  if (c.res.status >= 500) metricsState.errors++;
+});
+app.get("/metrics", (c) => {
+  const mem = process.memoryUsage();
+  const body = [
+    "# TYPE vyline_requests_total counter",
+    `vyline_requests_total ${metricsState.requests}`,
+    "# TYPE vyline_errors_total counter",
+    `vyline_errors_total ${metricsState.errors}`,
+    "# TYPE vyline_process_uptime_seconds gauge",
+    `vyline_process_uptime_seconds ${Math.floor(performance.now() / 1000)}`,
+    "# TYPE vyline_memory_rss_bytes gauge",
+    `vyline_memory_rss_bytes ${mem.rss}`,
+    "# TYPE vyline_memory_heap_used_bytes gauge",
+    `vyline_memory_heap_used_bytes ${mem.heapUsed}`,
+  ].join("\n");
+  return new Response(body, {
+    status: 200,
+    headers: { "Content-Type": "text/plain; version=0.0.4; charset=utf-8" },
+  });
+});
 app.route("/auth", authRouter);
 app.route("/line", lineRouter);
 app.route("/debug", debugRouter);

--- a/package.json
+++ b/package.json
@@ -5,14 +5,11 @@
   "engines": {
     "bun": ">=1.4.0"
   },
-  "workspaces": [
-    "Vyline/packages/*",
-    "Vyline/apps/*",
-    "Vyline/backend"
-  ],
+  "workspaces": ["Vyline/packages/*", "Vyline/apps/*", "Vyline/backend"],
   "scripts": {
     "dev": "concurrently -n backend,frontend -c cyan,magenta \"bun run dev:backend\" \"bun run dev:frontend\"",
     "dev:backend": "bun --watch Vyline/backend/src/index.ts",
+    "server": "bun Vyline/backend/src/index.ts",
     "dev:frontend": "bun run --cwd Vyline/apps/desktop dev",
     "build": "bun run --cwd Vyline/apps/desktop build",
     "typecheck": "bun run --cwd Vyline/packages/protocol typecheck && bun run --cwd Vyline/backend typecheck && bun run --cwd Vyline/apps/desktop typecheck",


### PR DESCRIPTION
## Summary

README Server Mode 要件の最初の一部を実装。

- `bun run server` スクリプト追加（watch なし起動）
- `GET /metrics`: Prometheus テキスト形式（リクエスト/エラーカウンタ・uptime・メモリ。重い集計なし）
- `GET /api/v1/status`: JSON ステータス

## Test
- backend typecheck OK / biome OK
- 実プロセスで /metrics 200 (counter出力確認)・/api/v1/status 200 を確認

※ スタック PR: base は #41
