### PR TITLE
feat(plugins): plugin system foundation (SDK + registry + API)

### DIFF
--- a/Vyline/backend/src/api/line.ts
+++ b/Vyline/backend/src/api/line.ts
@@ -27,6 +27,7 @@ import { childLogger } from "../logger.js";
 import { readMediaCache, writeMediaCache } from "../storage/mediaCache.js";
 import { getProxyConfig, setProxyConfig } from "../proxyConfig.js";
 import { getFeatureLocks, unbanCreateGroup } from "../storage/featureLocks.js";
+import { getPluginStates, listPlugins, setPluginState } from "../line/pluginManager.js";
 import {
   fetchProfile,
   fetchContactProfile,
@@ -115,6 +116,31 @@ import {
 
 const log = childLogger("bff:line");
 export const lineRouter = new Hono();
+
+// ─── plugins（基盤: マニフェスト一覧と有効/無効の永続化。コード実行は未対応） ───
+lineRouter.get("/:accountId/plugins", (c) => {
+  const accountId = c.req.param("accountId");
+  const states = getPluginStates(accountId);
+  return c.json({
+    plugins: listPlugins().map((p) => ({ ...p, enabled: states[p.id] === true })),
+    runtimePending: true,
+  });
+});
+
+lineRouter.post("/:accountId/plugins/:pluginId/:action", (c) => {
+  const accountId = c.req.param("accountId");
+  const pluginId = c.req.param("pluginId");
+  const action = c.req.param("action");
+  if (action !== "enable" && action !== "disable") {
+    return c.json({ ok: false, error: "action must be enable or disable" }, 400);
+  }
+  try {
+    setPluginState(accountId, pluginId, action === "enable");
+    return c.json({ ok: true, pluginId, enabled: action === "enable" });
+  } catch (err) {
+    return c.json({ ok: false, error: err instanceof Error ? err.message : String(err) }, 404);
+  }
+});
 
 // ─── helpers ─────────────────────────────
 

--- a/Vyline/backend/src/line/pluginManager.ts
+++ b/Vyline/backend/src/line/pluginManager.ts
@@ -1,0 +1,84 @@
+/**
+ * line/pluginManager.ts — プラグインレジストリ（基盤）
+ *
+ * 現状はマニフェストの検出と有効/無効状態の管理のみを行う。
+ * プラグインコードの実行（activate/deactivate）は権限サンドボックス設計後に有効化する。
+ * 詳細: README「Plugin System」/ docs/developer-guide/plugin-system.md
+ */
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { PluginManifest } from "@vyline/plugin-sdk";
+import { childLogger } from "../logger.js";
+
+const log = childLogger("plugins");
+
+const _dir = dirname(fileURLToPath(import.meta.url));
+const DATA_DIR = process.env.VYLINE_DATA_DIR ?? join(_dir, "../../data");
+const PLUGIN_DIR = process.env.VYLINE_PLUGIN_DIR ?? join(DATA_DIR, "plugins");
+const STATES_PATH = join(DATA_DIR, "plugin-states.json");
+
+export interface PluginEntry extends PluginManifest {
+  /** プラグインコードの実行は未対応（サンドボックス設計待ち）。常に true */
+  runtimePending: true;
+}
+
+type PluginStates = Record<string, Record<string, boolean>>;
+
+function loadStates(): PluginStates {
+  try {
+    return JSON.parse(readFileSync(STATES_PATH, "utf8")) as PluginStates;
+  } catch {
+    return {};
+  }
+}
+
+function saveStates(states: PluginStates): void {
+  try {
+    require("node:fs").writeFileSync(STATES_PATH, JSON.stringify(states, null, 2), "utf8");
+  } catch (err) {
+    log.warn({ err }, "failed to save plugin states");
+  }
+}
+
+/** プラグインディレクトリを走査し manifest.json を読む（コードは実行しない） */
+export function listPlugins(): PluginEntry[] {
+  if (!existsSync(PLUGIN_DIR)) return [];
+  const out: PluginEntry[] = [];
+  for (const entry of readdirSync(PLUGIN_DIR, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const manifestPath = join(PLUGIN_DIR, entry.name, "manifest.json");
+    if (!existsSync(manifestPath)) continue;
+    try {
+      const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as Partial<PluginManifest>;
+      if (!manifest.id || !manifest.name) continue;
+      out.push({
+        id: manifest.id,
+        name: manifest.name,
+        version: manifest.version ?? "0.0.0",
+        ...(manifest.description ? { description: manifest.description } : {}),
+        permissions: Array.isArray(manifest.permissions) ? manifest.permissions : [],
+        runtimePending: true,
+      });
+    } catch (err) {
+      log.warn({ plugin: entry.name, err }, "invalid plugin manifest");
+    }
+  }
+  return out;
+}
+
+export function getPluginStates(accountId: string): Record<string, boolean> {
+  return loadStates()[accountId] ?? {};
+}
+
+export function setPluginState(accountId: string, pluginId: string, enabled: boolean): void {
+  const states = loadStates();
+  const known = new Set(listPlugins().map((p) => p.id));
+  if (!known.has(pluginId)) {
+    throw new Error(`unknown plugin: ${pluginId}`);
+  }
+  states[accountId] = states[accountId] ?? {};
+  states[accountId]![pluginId] = enabled;
+  saveStates(states);
+}

--- a/Vyline/backend/tsconfig.json
+++ b/Vyline/backend/tsconfig.json
@@ -12,7 +12,8 @@
     "types": ["bun"],
     "paths": {
       "@vyline/types": ["../../packages/types/src/index.ts"],
-      "@vyline/protocol": ["../../packages/protocol/src/index.ts"]
+      "@vyline/protocol": ["../../packages/protocol/src/index.ts"],
+      "@vyline/plugin-sdk": ["../../packages/plugin-sdk/src/index.ts"]
     }
   },
   "include": ["src/**/*"]

--- a/Vyline/packages/plugin-sdk/package.json
+++ b/Vyline/packages/plugin-sdk/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@vyline/plugin-sdk",
+  "version": "0.1.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  }
+}

--- a/Vyline/packages/plugin-sdk/src/index.ts
+++ b/Vyline/packages/plugin-sdk/src/index.ts
@@ -1,0 +1,77 @@
+/**
+ * @vyline/plugin-sdk — Vyline プラグインの型定義と definePlugin
+ *
+ * 設計方針（README「Plugin System」参照）:
+ * - プラグインはコアコードを変更せず拡張だけを行う
+ * - 権限は明示宣言し、アカウントスコープで実行される
+ * - 無効化されたプラグインのランタイムコストはほぼゼロ
+ * - クラッシュしたプラグインが Vyline 本体を落とさない
+ *
+ * この SDK は型のみを提供する。実行基盤は backend 側の plugin manager。
+ */
+
+/** プラグインが要求できる権限。raw token / session / filesystem 等は意図的に含まない */
+export type PluginPermission =
+  | "messages:read"
+  | "messages:send"
+  | "chats:read"
+  | "media:read"
+  | "media:write"
+  | "storage:read"
+  | "storage:write"
+  | "notifications:send"
+  | "ui:extend"
+  | "network:request"
+  | "settings:read"
+  | "settings:write";
+
+export interface PluginLogger {
+  debug(msg: string, ...args: unknown[]): void;
+  info(msg: string, ...args: unknown[]): void;
+  warn(msg: string, ...args: unknown[]): void;
+  error(msg: string, ...args: unknown[]): void;
+}
+
+export interface PluginMessageSnapshot {
+  id: string;
+  chatId: string;
+  /** 送信者 MID。permissions の messages:read が必要 */
+  authorId?: string;
+  text?: string | null;
+  contentType: string;
+  createdAt: number;
+}
+
+export interface PluginContext {
+  /** このプラグインが動作するアカウントスコープ */
+  accountId: string;
+  logger: PluginLogger;
+
+  messages: {
+    on(event: "message", handler: (message: PluginMessageSnapshot) => void): () => void;
+  };
+
+  settings: {
+    get<T>(key: string, fallback: T): Promise<T>;
+    set<T>(key: string, value: T): Promise<void>;
+  };
+}
+
+export interface PluginManifest {
+  id: string;
+  name: string;
+  version: string;
+  description?: string;
+  permissions?: PluginPermission[];
+}
+
+export interface VylinePlugin {
+  manifest: PluginManifest;
+  activate(ctx: PluginContext): void | Promise<void>;
+  deactivate(ctx: PluginContext): void | Promise<void>;
+}
+
+/** プラグイン作者向けのヘルパー。型補完のためだけに存在する */
+export function definePlugin(plugin: VylinePlugin): VylinePlugin {
+  return plugin;
+}

--- a/docs/developer-guide/plugin-system.md
+++ b/docs/developer-guide/plugin-system.md
@@ -1,0 +1,55 @@
+# Plugin System（基盤）
+
+最終更新: 2026-08-22
+
+## 現状
+
+**基盤のみ実装**。プラグインコードの実行は未対応（`runtimePending: true`）。
+
+実装済み:
+
+- `@vyline/plugin-sdk`: `definePlugin` / `VylinePlugin` / 権限・コンテキストの型定義
+- backend plugin manager: マニフェスト検出 + アカウント単位の有効/無効状態の永続化
+- BFF API:
+  - `GET /line/{accountId}/plugins`
+  - `POST /line/{accountId}/plugins/{pluginId}/enable`
+  - `POST /line/{accountId}/plugins/{pluginId}/disable`
+
+未対応（ロードマップ）:
+
+1. プラグインコードの実行ランタイム（activate / deactivate / イベント配信）
+2. 権限の強制（permissions 宣言の検証とアクセス制御）
+3. エラー分離（クラッシュしたプラグインが本体に影響しない機構）
+4. install / update / remove のライフサイクル管理
+5. UI 拡張ポイント（ui:extend）
+
+## ディレクトリ構成
+
+```txt
+<VYLINE_PLUGIN_DIR>/            既定: Vyline/backend/data/plugins/
+  my-plugin/
+    manifest.json               必須: id / name / version / permissions
+    index.ts                    実行ランタイム対応後に読み込まれる
+```
+
+manifest.json 例:
+
+```json
+{
+  "id": "example-plugin",
+  "name": "Example Plugin",
+  "version": "0.1.0",
+  "description": "Example Vyline plugin",
+  "permissions": ["messages:read", "notifications:send"]
+}
+```
+
+有効/無効の状態は `<VYLINE_DATA_DIR>/plugin-states.json` に
+`{ accountId: { pluginId: enabled } }` 形式で保存される（アカウントスコープ分離）。
+
+## セキュリティ原則
+
+- プラグインは raw token / session / cookie / 秘密鍵 / 無制限な filesystem へ
+  アクセスできない（SDK の型にその面を露出させない）
+- プラグイン API は必ずアカウントスコープで呼ばれる
+- 無効化されたプラグインのコードは読み込まれない（ランタイムコストほぼゼロ）


### PR DESCRIPTION
## Summary

README Plugin System 要件の基盤を実装。

- @vyline/plugin-sdk（型のみ・依存ゼロ）: definePlugin / 権限 / PluginContext
- backend plugin manager: マニフェスト検出（コード実行なし）+ アカウント別 有効/無効の永続化 (plugin-states.json)
- BFF API: GET /line/:accountId/plugins, POST .../plugins/:pluginId/{enable,disable}
- docs/developer-guide/plugin-system.md（未実装部分とセキュリティ原則を明記）

意図的に未実装: プラグインコード実行ランタイム・権限強制・エラー分離（サンドボックス設計が必要）

## Test
- 全体 typecheck / lint / test 190 通過
- 実プロセスで plugins 一覧(空)・unknown plugin enable 404 を確認

※ スタック PR: base は #41
