### PR TITLE
docs: multi-account design doc + docs index update

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+echo "Running pre-push checks..."
+bun run typecheck
+bun run lint
+bun run build

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,7 @@ tools/data/
 .cursor/
 .claude/
 .agents/skills/handoff/
+
+# ── Backend runtime caches (never commit) ────────────────────────
+Vyline/backend/storage/cache/
+Vyline/backend/storage/saved-media/

--- a/.kilo/pr-body.md
+++ b/.kilo/pr-body.md
@@ -1,0 +1,11 @@
+## Summary
+- Add message history tracking with `messageState` and `history` fields
+- Support revoke-by-self and revoke-by-other with distinct handling
+- Add restore flow for revoked-by-self messages from local history
+- Add backend endpoints for message history and restore
+
+## Files Changed
+- Backend: `chatStore.ts`, `lineService.ts`, `api/line.ts`
+- Frontend: `store.ts`, `store-types.ts`, `mappers.ts`, `message-bubble.tsx`, `message-input.tsx`, `sidebar.tsx`, `useVylineSync.ts`, `client.ts`
+- Types: `packages/types/src/index.ts`
+- Other: `cdnAssetCache.ts`, `mediaCache.ts`, `icons.tsx`, `settings-sections.tsx`

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
-<h1 align="center">Vyline <sup>Beta</sup></h1>
+<div align="center">
 
-<p align="center">
-  <strong>Vision Beyond Limits.</strong><br/>
-  自前プロトコルで動く、LINE サードパーティクライアント（Web / React）
-</p>
+# Vyline <sup>Beta</sup>
 
-<p align="center">
+### Vision Beyond Limits.
+
+**独自プロトコルスタックで動作する、モダンでセルフホスト可能な LINE サードパーティクライアント。**
+
+Web / React · Bun · Hono · `@vyline/protocol`
+
+<p>
   <img alt="version" src="https://img.shields.io/badge/version-0.5.1--beta-a78bfa?style=flat-square" />
   <img alt="license" src="https://img.shields.io/badge/license-MIT-22c55e?style=flat-square" />
   <img alt="runtime" src="https://img.shields.io/badge/runtime-Bun-f472b6?style=flat-square" />
@@ -14,120 +17,115 @@
   <img alt="PRs" src="https://img.shields.io/badge/PRs-welcome-22c55e?style=flat-square" />
 </p>
 
-<p align="center">
-  このさんさんとした太陽の下、Vyline を選んでくださるユーザーに出会えたことに感謝します。
-</p>
+[クイックスタート](#クイックスタート) · [機能](#機能) · [アーキテクチャ](#アーキテクチャ) · [ドキュメント](#ドキュメント) · [コントリビューション](#コントリビューション)
 
-> **2026/08/20 beta 版 release 開始** — 本リポジトリは Vyline Beta 0.5.0 として公開されました。機能の安定性は保証されておらず、予期しない動作やアカウントリスクが含まれる可能性があります。
+</div>
 
----
-
-## ⚠️ ご利用前に必ずお読みください
-
-Vyline は LINE 非公式のサードパーティクライアントであり、LINE 株式会社・LY Corporation とは**無関係・未承認**です。
-
-- **アカウントリスク**: LINE 利用規約に違反する可能性があり、アカウント停止等のリスクを伴います。**利用はすべて自己責任**です。
-- **同意ゲート**: ログイン直後に利用規約・免責事項を表示し、**同意しない限りアプリは一切動作しません**（同期・通信・表示を含む）。同意せず、または画面をスキップする等の手段で利用した場合も、**その時点で本規約に同意したものとみなされ**、開発者・Vyline のメンバーは一切の責任を負いません。
-- **目的の範囲**: 教育・学習・個人利用の範囲でご利用ください。第三者への攻撃・不正アクセス・迷惑行為・権利侵害は禁止です。
-- **データの扱い**: ログイン情報・セッション・暗号鍵・トーク履歴は端末内にのみ保存され、外部へ送信されません。
-- **解析ツール**: `tools/` 以下の解析ツールは [vyline-search](https://github.com/nezumi0627/vyline-search) リポジトリを Git Submodule としてリンクしたものです。Desktop LINE の unpack・逆コンパイルを行います。**教育・実験目的のみ**で使用し、解析結果を再配布しないでください。詳細: [docs/tools/DISCLAIMER.md](docs/tools/DISCLAIMER.md)
-- **開発者の免責**: 本ソフトウェアの利用により生じた一切の問題（アカウント停止、データ破損、法的問題等）について、開発者・Vyline のメンバーは責任を負いません。
-
-### 著作権表示
-
-本ソフトウェアは [nezumi0627](https://github.com/nezumi0627) によって開発されています。改変・再配布・解説記事等では、必ず著作権表示（`nezumi0627`）を保持してください。ライセンス詳細は [LICENSE](LICENSE)（MIT）を参照してください。
+> [!WARNING]
+> **現在 Beta 版です。** Vyline は LINE 非公式のサードパーティクライアントであり、LY Corporation とは無関係・未承認です。アカウント、互換性、データ損失などのリスクが含まれる可能性があります。利用は自己責任で行ってください。
 
 ---
 
-## Vyline とは
+## Why Vyline?
 
-**Vyline** は LINE にログインしてメッセージの送受信・Flex/Rich 表示・テーマカスタマイズを行うサードパーティクライアントです。外部サービスに依存せず、**自前のプロトコルスタック `@vyline/protocol`** で動作します。
+Vyline は、LINE をより自由に、自分の環境に合わせて使いたい人のために開発されています。
 
-| 項目       | 内容                                     |
-| ---------- | ---------------------------------------- |
-| 誰向け     | UI を自分好みにしたい人・開発者          |
-| なにが違う | テーマ管理 / メンション / ローカル最適化 |
-| ライセンス | MIT                                      |
-| 状態       | Beta 0.5.0                               |
+外部の中継サービスやゲートウェイに依存するのではなく、独自のプロトコルスタック `@vyline/protocol` を使用して LINE と通信します。
 
-### 主な機能
+メッセージング、メディア、テーマ、E2EE、バックアップ、セルフホスト、外部連携 API までをひとつのプロジェクトに統合しています。
 
-| カテゴリ         | 内容                                                                                                                  |
-| ---------------- | --------------------------------------------------------------------------------------------------------------------- |
-| **ログイン**     | QR / Email ログイン、マルチアカウント、セッション復元                                                                 |
-| **メッセージ**   | 送受信 / 返信 / 取り消し / 既読制御 / 再送                                                                            |
-| **メンション**   | `@ALL` / `@名前`（LINE Desktop 準拠の `MENTION` metadata）                                                            |
-| **メディア**     | 画像・動画・音声（画像は自動圧縮、設定で高画質送信も可） / LINE 絵文字(sticon) / スタンプ全種                         |
-| **Flex / Rich**  | 公式準拠の描画、カルーセルのマウスドラッグ                                                                            |
-| **リアクション** | 1クリック、公式バッジ、既読者一覧                                                                                     |
-| **通話**         | 音声 / ビデオ通話（実験的）                                                                                           |
-| **チャット管理** | ピン / 非表示 / ミュート / ブロック / MID コピー / グループ作成・招待                                                 |
-| **VyTheme**      | フルカスタマイズテーマ、文字サイズ、密度、プロフィール背景                                                            |
-| **E2EE**         | Letter Sealing の復号・送信、Desktop 鍵 import                                                                        |
-| **プライバシー** | ストリーマーモード、PIN ロック                                                                                        |
-| **VylineBackup** | トーク履歴・メディアのスナップショット作成 / 復元 / 削除                                                              |
-| **その他**       | チャット詳細ログ(JSONL) / Keepメモ / 相手プロフィール背景表示 / 通話中バッジ / 共通グループ高速表示 / トーク保存(TXT) |
+* **独自プロトコルスタック** — 外部のサードパーティゲートウェイに依存しません
+* **高度なUIカスタマイズ** — VyTheme、文字サイズ、表示密度、プロフィール背景
+* **強力なメッセージ機能** — メンション、リアクション、既読制御、再送、チャット管理
+* **豊富なメディア対応** — 画像、動画、音声、絵文字、スタンプ、Flex / Rich 表示
+* **ローカル中心のデータ管理** — セッション、鍵、履歴、バックアップを自分の環境で管理
+* **セルフホスト対応** — 複数ブラウザから同じ Vyline セッションを利用可能
+* **拡張可能** — `/v1/` API、OpenAPI 3.1、Protocol Package、解析ツール
 
 ---
 
-## ⚠️ 破壊的変更 (v0.5.0)
+## 機能
 
-v0.5.0 は v0.4.x と**互換性がありません**。以下の変更により、既存の設定・キャッシュの一部リセットが必要な場合があります。
-
-| 変更                                                   | 影響                                                                        |
-| ------------------------------------------------------ | --------------------------------------------------------------------------- |
-| 受信エンジンを Push 長ポール → fetchOps 方式に刷新     | イベントポーリングの挙動が変わります                                        |
-| 公開 API (`/v1/`) を新設                               | 環境変数 `VYLINE_API_ADMIN_SECRET` を設定するとトークン管理が可能になります |
-| イベント種別の拡張（通話・メンバー変更・アナウンス等） | フロントエンドの旧バージョンとは互換しません                                |
-
-**アップグレード手順**: `git pull && bun install && bun run dev` のみで動作します。既存のログイン状態は維持されます。
+| カテゴリ             | 主な機能                                               |
+| ---------------- | -------------------------------------------------- |
+| **ログイン**         | QR / Email ログイン、マルチアカウント、セッション復元                   |
+| **メッセージ**        | 送受信 / 返信 / 送信取消 / 既読制御 / 再送                        |
+| **メンション**        | `@ALL` / `@名前`、LINE Desktop 互換の `MENTION` metadata |
+| **メディア**         | 画像 / 動画 / 音声 / LINE 絵文字 / スタンプ / 高画質画像送信           |
+| **Flex / Rich**  | Rich Message 表示、ドラッグ操作対応カルーセル                      |
+| **リアクション**       | ワンクリックリアクション、公式風バッジ、既読者一覧                          |
+| **通話**           | 音声 / ビデオ通話（実験的）                                    |
+| **チャット管理**       | ピン / 非表示 / ミュート / ブロック / MID コピー / グループ作成・招待       |
+| **VyTheme**      | テーマ、文字サイズ、表示密度、プロフィール背景のカスタマイズ                     |
+| **E2EE**         | Letter Sealing の復号 / 送信、Desktop 鍵 import           |
+| **プライバシー**       | ストリーマーモード、PIN ロック                                  |
+| **VylineBackup** | トーク履歴・メディアのスナップショット作成 / 復元 / 削除                    |
+| **Power Tools**  | JSONL ログ / Keepメモ / TXT エクスポート / 共通グループ高速表示        |
 
 ---
 
-## Quick Start
+## クイックスタート
+
+### 必要環境
+
+* [Bun](https://bun.sh/)
+* モダンブラウザ
+
+### ローカルで起動
 
 ```bash
 bun install
-bun run dev          # backend :3001 + frontend :5173
+bun run dev
 ```
 
-ブラウザで `http://localhost:5173` を開きます。
+起動後、以下をブラウザで開きます。
 
-| コマンド               | 内容                           |
-| ---------------------- | ------------------------------ |
-| `bun run dev:backend`  | backend のみ（:3001）          |
-| `bun run dev:frontend` | frontend のみ（:5173）         |
-| `bun run typecheck`    | 型チェック（全ワークスペース） |
-| `bun run lint`         | Biome lint                     |
-| `bun run build`        | frontend 本番ビルド            |
+```text
+http://localhost:5173
+```
 
-詳細: [docs/onboarding.md](docs/onboarding.md) · [docs/development.md](docs/development.md) · [AGENTS.md](AGENTS.md)
+Backend は `:3001`、Frontend は `:5173` で起動します。
 
-### セルフホスト（Docker）
-
-自宅サーバーに立てて、複数端末の Web ブラウザから同じ LINE セッションを利用できます（履歴・画像はサーバー側に永続化）。
+<details>
+<summary><strong>その他のコマンド</strong></summary>
 
 ```bash
-docker compose up -d --build   # http://localhost:3001
+bun run dev:backend
+bun run dev:frontend
+bun run typecheck
+bun run lint
+bun run build
 ```
 
-設定・Cloudflare Access での外部公開手順: [docs/selfhosting.md](docs/selfhosting.md)
+</details>
 
-### 推奨環境
-
-| 項目               | 推奨値         | 備考                                               |
-| ------------------ | -------------- | -------------------------------------------------- |
-| **LINE アプリ**    | IOSIPAD 26.7.2 | `x-line-application` ヘッダー値。最新版を推奨      |
-| **OS**             | iOS 18.0       | Android / Windows 互換は未検証                     |
-| **デバイスモード** | IOSIPAD        | `VYLINE_DEVICE` 環境変数で指定（省略時は IOSIPAD） |
-
-> 定義元: `packages/protocol/src/desktop/types.ts` の DesktopProfile。実際のヘッダー値は `"x-line-application": "IOSIPAD\t26.7.2\tiOS\t18.0"` のように伝搬されます。
+詳しいセットアップ方法は [docs/onboarding.md](docs/onboarding.md) と [docs/development.md](docs/development.md) を参照してください。
 
 ---
 
-## Architecture
+## セルフホスト
 
+Vyline は自分のサーバー上にデプロイできます。
+
+複数端末のブラウザから同じ LINE セッションを利用しながら、トーク履歴やメディアを自分の管理するサーバーへ永続化できます。
+
+```bash
+docker compose up -d --build
 ```
+
+起動後:
+
+```text
+http://localhost:3001
+```
+
+Docker、Cloudflare Access、外部公開については [docs/selfhosting.md](docs/selfhosting.md) を参照してください。
+
+---
+
+## アーキテクチャ
+
+```text
 ┌─ Frontend (React + Vite) ── apps/desktop ──┐
 │  store / mappers / sync / VyTheme UI       │
 ├─ Backend (Hono on Bun) ───── backend ──────┤
@@ -137,97 +135,142 @@ docker compose up -d --build   # http://localhost:3001
 └─ LINE Servers ──────────────────────────────┘
 ```
 
-| パス                  | 役割                     |
-| --------------------- | ------------------------ |
-| `apps/desktop`        | React UI                 |
-| `backend`             | Hono BFF                 |
-| `packages/protocol`   | プロトコル本体（Vyline） |
-| `packages/line-types` | Thrift 型（vendored）    |
+| パス                    | 役割                  |
+| --------------------- | ------------------- |
+| `apps/desktop`        | React UI            |
+| `backend`             | Hono BFF            |
+| `packages/protocol`   | Vyline 独自プロトコル実装    |
+| `packages/line-types` | Vendored Thrift 型定義 |
 
-### E2EE / Desktop 鍵
+Frontend / Backend / Protocol を分離した構成になっており、それぞれを独立して開発・拡張できる設計です。
 
-過去メッセージの復号には、公式 LINE Desktop から抽出した自己鍵一式が必要です。
+---
 
-1. LINE.exe 起動状態で鍵を抽出（[docs/analysis/](docs/analysis/)）
-2. `backend/data/desktop-e2ee-keys.json` に配置（**gitignore・コミット禁止**）
-3. backend 起動時に自動 import
+## E2EE / Desktop 鍵
 
-### 公開 API (`/v1/`)
+過去のメッセージを復号する場合、公式 LINE Desktop から取得した自分自身の鍵情報が必要になる場合があります。
 
-セルフホスト時に Bearer トークンで Vyline を外部から操作できます。
+1. [docs/analysis/](docs/analysis/) のツールを使用して必要な鍵を取得
+2. `backend/data/desktop-e2ee-keys.json` に配置
+3. Backend 起動時に自動的に import
 
-```bash
-# トークン作成（VYLINE_API_ADMIN_SECRET を設定後）
-curl -X POST http://localhost:3001/v1/tokens \
-  -H "Authorization: Bearer $VYLINE_API_ADMIN_SECRET" \
-  -H "Content-Type: application/json" \
-  -d '{"name": "my-bot"}'
+> [!IMPORTANT]
+> 鍵、セッション、トークン、ログイン情報、個人情報などを Git にコミットしないでください。
 
-# チャット一覧取得
-curl http://localhost:3001/v1/accounts/{accountId}/chats \
-  -H "Authorization: Bearer vyl_xxxx..."
+---
+
+## API
+
+Vyline はセルフホスト環境や外部アプリケーションとの連携に利用できる `/v1/` API を提供しています。
+
+OpenAPI 3.1 仕様は以下から取得できます。
+
+```text
+GET /openapi.json
 ```
 
-API 仕様（OpenAPI 3.1）: `GET /openapi.json` または [zensical.org](https://zensical.org)
+公開ドキュメント:
 
-### 解析ツールキット（vyline-search）
+[zensical.org](https://zensical.org)
 
-Desktop LINE（Themida 保護）の unpack / ネイティブシンボル検索 / 逆コンパイルを行う独立ツールキットです。教育・研究目的で `findNativeSymbol` による文字列 xref 解析と Ghidra decompile をワンコマンドで実行できます。
+---
 
-> [!WARNING]
-> **注意**: LINE デスクトップクライアントが起動中の状態では、解析ツール（unpack 等）が正常に動作しません（単一インスタンス制御により frida の注入が拒否されプロセスが強制終了するため）。必ず LINE アプリを完全に終了させてから実行してください。
+## 解析ツールキット
 
-**[github.com/nezumi0627/vyline-search](https://github.com/nezumi0627/vyline-search)**
+オプションの [`vyline-search`](https://github.com/nezumi0627/vyline-search) Submodule には、Desktop LINE の研究・解析を補助するツールが含まれています。
+
+主な用途:
+
+* unpack
+* native symbol 検索
+* string xref
+* Ghidra decompile 補助
+* インストール済み LINE バージョン確認
 
 ```powershell
-bun run vyline:check                  # インストール版 / 最新版の比較
-bun run vyline:versions               # インストール済みバージョン一覧
-bun run vyline:unpack -- --version <ver>   # インストール済みバージョンを選択して unpack
-bun run vyline:update                 # LINE Desktop を最新版へ更新
-bun run vyline:find-native -- sendMessage  # ネイティブシンボル検索
+bun run vyline:check
+bun run vyline:versions
+bun run vyline:unpack -- --version <ver>
+bun run vyline:update
+bun run vyline:find-native -- sendMessage
 ```
 
-> **注意**: `vyline:unpack` / `vyline:update` は **LINE を終了してから実行**してください。
-> 稼働中は Frida 注入が拒否され `ProcessNotRespondingError` になります。
+> [!CAUTION]
+> 解析ツールは、法的に許可された範囲・教育・研究目的で使用してください。
+>
+> プロプライエタリなバイナリ、抽出した認証情報、秘密鍵、トークン、個人データなどを再配布しないでください。
+
+`vyline:unpack` / `vyline:update` を実行する場合は、LINE Desktop を完全に終了してください。
+
+詳細は [docs/tools/DISCLAIMER.md](docs/tools/DISCLAIMER.md) を参照してください。
 
 ---
 
 ## ドキュメント
 
-| リンク                                                     | 内容                                   |
-| ---------------------------------------------------------- | -------------------------------------- |
-| [docs/README.md](docs/README.md)                           | ドキュメント索引                       |
-| [docs/onboarding.md](docs/onboarding.md)                   | 初日チェックリスト                     |
-| [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md)               | 貢献フロー                             |
-| [docs/architecture.md](docs/architecture.md)               | 層構造                                 |
-| [docs/development.md](docs/development.md)                 | 開発コマンド                           |
-| [docs/selfhosting.md](docs/selfhosting.md)                 | Docker セルフホスト・Cloudflare Access |
-| [docs/protocol/dictionary.md](docs/protocol/dictionary.md) | RPC 辞書                               |
-| [AGENTS.md](AGENTS.md)                                     | エージェント向けガイド                 |
-| [CHANGELOG.md](CHANGELOG.md)                               | 変更履歴                               |
-| [zensical.org](https://zensical.org)                       | 公開ドキュメント・API リファレンス     |
-| [/openapi.json](/openapi.json)                             | OpenAPI 3.1 仕様（ローカル）           |
+README は Vyline の**表紙・概要**として簡潔に保ち、詳細な技術情報は `docs/` に分離しています。
 
-公開ドキュメント・チュートリアル: **[zensical.org](https://zensical.org)**
+* [ドキュメント一覧](docs/README.md)
+* [オンボーディング](docs/onboarding.md)
+* [開発ガイド](docs/development.md)
+* [アーキテクチャ](docs/architecture.md)
+* [セルフホスト](docs/selfhosting.md)
+* [RPC Dictionary](docs/protocol/dictionary.md)
+* [コントリビューションガイド](docs/CONTRIBUTING.md)
+* [Agent Guide](AGENTS.md)
+* [Changelog](CHANGELOG.md)
 
 ---
 
-## 貢献 / 募集
+## メンテナー
 
-- 🐛 [Bug report](.github/ISSUE_TEMPLATE/bug_report.md)
-- ✨ [Feature request](.github/ISSUE_TEMPLATE/feature_request.md)
-- 📝 [Pull request](.github/pull_request_template.md)
+Vyline は現在、以下のメンバーによって開発・メンテナンスされています。
 
-貢献フローは [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) を参照してください。PR には解析対象ソフトウェアの実体・鍵・トークンなどを含めないでください。
+### [nezumi0627](https://github.com/nezumi0627)
 
-現在、以下を募集しています:
+**Creator / Lead Maintainer**
 
-- **PR**: バグ修正、機能改善、ドキュメントの更新
-- **アイコン**: アプリアイコン・テーマアイコンのデザイン
-- **バナー**: SNS・ブログでのプロモーション用バナー
-- **定期的なメンテナー**: 個人開発のため、継続的に助けていただける方を募集中
+Vyline の設計・開発およびプロジェクト全体のメンテナンスを担当。
 
-興味がある方は [AGENTS.md](AGENTS.md) の手順に従ってプルリクエストをお送りください。
+### [YoseiUshida](https://github.com/youseiushida)
+
+**Maintainer**
+
+バグ修正、定期メンテナンス、品質改善など、Vyline の継続的なメンテナンスを担当。
+
+コミュニティからのコントリビューションも歓迎しています。
+
+特に以下の協力を募集しています。
+
+* バグ修正
+* 機能改善
+* ドキュメント改善
+* UI / UX 改善
+* アプリアイコン
+* プロモーション用バナー
+* 継続的なメンテナンス
+
+---
+
+## コントリビューション
+
+Vyline への Issue / Pull Request を歓迎しています。
+
+* [Bug Report](.github/ISSUE_TEMPLATE/bug_report.md)
+* [Feature Request](.github/ISSUE_TEMPLATE/feature_request.md)
+* [Pull Request Template](.github/pull_request_template.md)
+
+Pull Request を送る前に [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) を確認してください。
+
+Issue / PR には以下を含めないでください。
+
+* セッション情報
+* アカウント情報
+* 秘密鍵
+* API Token
+* 認証情報
+* 個人情報
+* プロプライエタリなソフトウェア本体
 
 ---
 
@@ -235,20 +278,57 @@ bun run vyline:find-native -- sendMessage  # ネイティブシンボル検索
 
 > **Coming Soon** 🚀
 
-Vyline が安定版に到達した後、専用のデスクトップアプリ **Vyline Desktop** をリリース予定です。
+Vyline が安定版に到達した後、専用デスクトップアプリ **Vyline Desktop** のリリースを予定しています。
 
-- 🖥️ Windows / macOS / Linux ネイティブアプリ
-- 🔔 プッシュ通知
-- 🗂️ トレイアイコン常駐
-- 🔒 ローカルデータ完全管理
+予定しているプラットフォーム:
 
-Vyline の安定版リリースをお待ちください。
+**Windows · macOS · Linux**
+
+予定機能:
+
+* ネイティブ通知
+* トレイアイコン
+* バックグラウンド常駐
+* ローカルデータ管理
+* Vyline Web / Protocol との統合
+
+---
+
+## ⚠️ 重要事項
+
+Vyline は LINE 非公式のサードパーティクライアントです。
+
+LINE 株式会社および LY Corporation とは**無関係・未承認**です。
+
+Vyline の使用によって、LINE の仕様変更による互換性問題やアカウントに関するリスクが発生する可能性があります。
+
+利用者はこれらのリスクを理解したうえで、自身の責任で Vyline を利用してください。
+
+また、以下の機密情報は利用者自身の管理下に置き、GitHub 等へ公開しないでください。
+
+* ログイン情報
+* セッション
+* 暗号鍵
+* トーク履歴
+* Token
+* その他の個人情報
+
+解析ツールを含む詳細な免責事項については、各ドキュメントおよびライセンスを参照してください。
 
 ---
 
 ## License
 
-MIT — see [LICENSE](LICENSE)
+MIT — [LICENSE](LICENSE)
 
-**著作権**: [`nezumi0627`](https://github.com/nezumi0627)
-改変・再配布・記事・投稿等では出典表示をお願いします（詳細は [LICENSE](LICENSE) の Attribution requirement を参照）。
+Copyright © [nezumi0627](https://github.com/nezumi0627)
+
+---
+
+<div align="center">
+
+**Vision Beyond Limits.**
+
+Made with care by the Vyline contributors.
+
+</div>

--- a/Vyline/apps/desktop/src/api/client.ts
+++ b/Vyline/apps/desktop/src/api/client.ts
@@ -321,8 +321,6 @@ export const api = {
         disk?: { totalBytes: number; freeBytes: number; usedBytes: number };
         vylineTotal: number;
         cacheSize: number;
-        cdnSize: number;
-        iconCacheSize: number;
         savedMediaSize: number;
         error?: string;
       }>("GET", `/line/${accountId}/vyline/storage`),
@@ -337,12 +335,6 @@ export const api = {
       request<{ ok: boolean; removed?: number; error?: string }>(
         "DELETE",
         `/line/${accountId}/vyline/saved-media`,
-      ),
-
-    clearVylineIcons: (accountId: string) =>
-      request<{ ok: boolean; removed?: number; error?: string }>(
-        "DELETE",
-        `/line/${accountId}/vyline/icons`,
       ),
 
     vylineWarm: (accountId: string, mids: string[]) =>

--- a/Vyline/apps/desktop/src/api/client.ts
+++ b/Vyline/apps/desktop/src/api/client.ts
@@ -299,8 +299,7 @@ export const api = {
         items,
         ...(opts?.idOfPreviousVersionOfCombinationSticker
           ? {
-              idOfPreviousVersionOfCombinationSticker:
-                opts.idOfPreviousVersionOfCombinationSticker,
+              idOfPreviousVersionOfCombinationSticker: opts.idOfPreviousVersionOfCombinationSticker,
             }
           : {}),
       }),

--- a/Vyline/apps/desktop/src/api/client.ts
+++ b/Vyline/apps/desktop/src/api/client.ts
@@ -322,6 +322,16 @@ export const api = {
         vylineTotal: number;
         cacheSize: number;
         savedMediaSize: number;
+        cache: {
+          cdn: number;
+          icons: number;
+        };
+        savedMedia: {
+          image: number;
+          video: number;
+          audio: number;
+          file: number;
+        };
         error?: string;
       }>("GET", `/line/${accountId}/vyline/storage`),
 
@@ -331,10 +341,28 @@ export const api = {
         `/line/${accountId}/vyline/cache`,
       ),
 
+    clearVylineCdnCache: (accountId: string) =>
+      request<{ ok: boolean; removed?: number; error?: string }>(
+        "DELETE",
+        `/line/${accountId}/vyline/cache/cdn`,
+      ),
+
+    clearVylineIconCache: (accountId: string) =>
+      request<{ ok: boolean; removed?: number; error?: string }>(
+        "DELETE",
+        `/line/${accountId}/vyline/cache/icons`,
+      ),
+
     clearVylineSavedMedia: (accountId: string) =>
       request<{ ok: boolean; removed?: number; error?: string }>(
         "DELETE",
         `/line/${accountId}/vyline/saved-media`,
+      ),
+
+    clearVylineSavedMediaType: (accountId: string, type: string) =>
+      request<{ ok: boolean; removed?: number; type?: string; error?: string }>(
+        "DELETE",
+        `/line/${accountId}/vyline/saved-media/${type}`,
       ),
 
     vylineWarm: (accountId: string, mids: string[]) =>

--- a/Vyline/apps/desktop/src/api/client.ts
+++ b/Vyline/apps/desktop/src/api/client.ts
@@ -28,6 +28,7 @@ import type {
   CallStatusResponse,
   CallActiveResponse,
   CallType,
+  Message,
 } from "@vyline/types";
 
 // re-export for convenience
@@ -269,11 +270,24 @@ export const api = {
     unsend: (accountId: string, messageId: string) =>
       request<UnsendResponse>("POST", `/line/${accountId}/unsend`, { messageId }),
 
+    restoreRevokedMessage: (accountId: string, chatMid: string, messageId: string) =>
+      request<{ ok: true; text?: string | null; contentType?: string }>(
+        "POST",
+        `/line/${accountId}/restore?chatMid=${encodeURIComponent(chatMid)}`,
+        { messageId },
+      ),
+
     editMessage: (accountId: string, chatMid: string, messageId: string, text: string) =>
       request<EditResponse>("POST", `/line/${accountId}/edit`, { chatMid, messageId, text }),
 
     editNotice: (accountId: string, chatMid: string) =>
       request<EditNoticeResponse>("GET", `/line/${accountId}/edit-notice/${chatMid}`),
+
+    messageHistory: (accountId: string, chatMid: string, messageId: string) =>
+      request<{ ok: true; history: Message["history"] }>(
+        "GET",
+        `/line/${accountId}/messages/${encodeURIComponent(chatMid)}/${encodeURIComponent(messageId)}/history`,
+      ),
 
     /** 相手ユーザーのプロフィール取得 (アイコン URL 用) */
     contactProfile: (accountId: string, targetMid: string) =>
@@ -299,6 +313,37 @@ export const api = {
         groups?: Record<string, unknown>;
         error?: string;
       }>("GET", `/line/${accountId}/vyline/cache`),
+
+    vylineStorage: (accountId: string) =>
+      request<{
+        ok: boolean;
+        driveLetter?: string;
+        disk?: { totalBytes: number; freeBytes: number; usedBytes: number };
+        vylineTotal: number;
+        cacheSize: number;
+        cdnSize: number;
+        iconCacheSize: number;
+        savedMediaSize: number;
+        error?: string;
+      }>("GET", `/line/${accountId}/vyline/storage`),
+
+    clearVylineCache: (accountId: string) =>
+      request<{ ok: boolean; removed?: number; error?: string }>(
+        "DELETE",
+        `/line/${accountId}/vyline/cache`,
+      ),
+
+    clearVylineSavedMedia: (accountId: string) =>
+      request<{ ok: boolean; removed?: number; error?: string }>(
+        "DELETE",
+        `/line/${accountId}/vyline/saved-media`,
+      ),
+
+    clearVylineIcons: (accountId: string) =>
+      request<{ ok: boolean; removed?: number; error?: string }>(
+        "DELETE",
+        `/line/${accountId}/vyline/icons`,
+      ),
 
     vylineWarm: (accountId: string, mids: string[]) =>
       request<{ ok: boolean; profiles?: Record<string, unknown>; count?: number; error?: string }>(

--- a/Vyline/apps/desktop/src/api/client.ts
+++ b/Vyline/apps/desktop/src/api/client.ts
@@ -220,6 +220,25 @@ export const api = {
         ...opts,
       }),
 
+    sendMediaBatch: (
+      accountId: string,
+      chatMid: string,
+      items: Array<{
+        dataBase64: string;
+        mimeType?: string;
+        filename?: string;
+        mediaType?: string;
+      }>,
+    ) =>
+      request<{ ok: boolean; count?: number; error?: string }>(
+        "POST",
+        `/line/${accountId}/send-media-batch`,
+        {
+          chatMid,
+          items,
+        },
+      ),
+
     sendSticker: (
       accountId: string,
       chatMid: string,
@@ -228,6 +247,62 @@ export const api = {
       request<SendResponse>("POST", `/line/${accountId}/send-sticker`, {
         chatMid,
         ...opts,
+      }),
+
+    canCreateCombinationSticker: (accountId: string, packageIds: string[]) =>
+      request<{ ok: boolean; canCreate: boolean; usablePackageIds: string[]; error?: string }>(
+        "POST",
+        `/line/${accountId}/combination-stickers/can-create`,
+        { packageIds },
+      ),
+
+    isStickerAvailableForCombinationSticker: (accountId: string, packageId: string) =>
+      request<{ ok: boolean; availableForCombinationSticker: boolean; error?: string }>(
+        "POST",
+        `/line/${accountId}/combination-stickers/available`,
+        { packageId },
+      ),
+
+    createCombinationSticker: (
+      accountId: string,
+      items: Array<{
+        packageId: string;
+        stickerId: string;
+      }>,
+      opts?: { idOfPreviousVersionOfCombinationSticker?: string },
+    ) =>
+      request<{ ok: boolean; id: string; error?: string }>(
+        "POST",
+        `/line/${accountId}/combination-stickers`,
+        opts?.idOfPreviousVersionOfCombinationSticker
+          ? {
+              items,
+              idOfPreviousVersionOfCombinationSticker: opts.idOfPreviousVersionOfCombinationSticker,
+            }
+          : { items },
+      ),
+
+    sendCombinationSticker: (
+      accountId: string,
+      chatMid: string,
+      items: Array<{
+        packageId: string;
+        stickerId: string;
+        x?: number;
+        y?: number;
+        size?: number;
+      }>,
+      opts?: { idOfPreviousVersionOfCombinationSticker?: string },
+    ) =>
+      request<SendResponse>("POST", `/line/${accountId}/send-combination-sticker`, {
+        chatMid,
+        items,
+        ...(opts?.idOfPreviousVersionOfCombinationSticker
+          ? {
+              idOfPreviousVersionOfCombinationSticker:
+                opts.idOfPreviousVersionOfCombinationSticker,
+            }
+          : {}),
       }),
 
     sendEmoji: (
@@ -412,7 +487,6 @@ export const api = {
         statusMessage?: string;
         phoneticName?: string;
         musicProfile?: string;
-        birthday?: { year?: string; day: string; yearEnabled?: boolean; dayEnabled?: boolean };
       },
     ) => request<ProfileResponse>("PATCH", `/line/${accountId}/profile`, body),
 

--- a/Vyline/apps/desktop/src/components/chat-area.tsx
+++ b/Vyline/apps/desktop/src/components/chat-area.tsx
@@ -46,6 +46,7 @@ type MsgRow =
       key: string;
       kind: "msg";
       message: Message;
+      mediaGroup?: Message[];
       index: number;
       sameAuthorAsPrev: boolean;
       sameAuthorAsNext: boolean;
@@ -56,6 +57,21 @@ type MsgRow =
       highlight?: string;
     };
 
+function canGroupImageMessage(message: Message): boolean {
+  return message.kind === "image" && Boolean(message.imageSrc) && !message.replyToId;
+}
+
+function shouldGroupAdjacentImages(left: Message, right: Message): boolean {
+  return (
+    canGroupImageMessage(left) &&
+    canGroupImageMessage(right) &&
+    left.authorId === right.authorId &&
+    left.chatId === right.chatId &&
+    dayLabel(left.createdAt) === dayLabel(right.createdAt) &&
+    Math.abs(right.createdAt - left.createdAt) <= 30_000
+  );
+}
+
 export function ChatArea() {
   const activeChatId = useStore((s) => s.activeChatId);
   const chats = useStore((s) => s.chats);
@@ -65,7 +81,6 @@ export function ChatArea() {
   const profileOpen = useStore((s) => s.profileDrawerOpen);
   const setProfileDrawer = useStore((s) => s.setProfileDrawer);
   const streamerMode = useStore((s) => s.settings.streamerMode);
-  const showBackground = useStore((s) => s.settings.showBackground);
   const theme = useStore((s) => s.theme);
   const toggleMute = useStore((s) => s.toggleMute);
   const memberProfile = useStore((s) => s.memberProfile);
@@ -160,40 +175,57 @@ export function ChatArea() {
     let lastDay = "";
     const searching = search.open && search.q.trim().length > 0;
     const q = search.q.trim();
-    chatMessages.forEach((m, i) => {
+    for (let i = 0; i < chatMessages.length; i++) {
+      const m = chatMessages[i]!;
       const dl = dayLabel(m.createdAt);
       if (dl !== lastDay) {
         lastDay = dl;
         out.push({ key: `day-${m.id}`, item: { key: `day-${m.id}`, kind: "day", label: dl } });
       }
       const prev = chatMessages[i - 1];
+      const mediaGroup = canGroupImageMessage(m) ? [m] : undefined;
+      if (mediaGroup) {
+        while (
+          i + 1 < chatMessages.length &&
+          shouldGroupAdjacentImages(mediaGroup[mediaGroup.length - 1]!, chatMessages[i + 1]!)
+        ) {
+          mediaGroup.push(chatMessages[i + 1]!);
+          i++;
+        }
+      }
+      const lastInRow = mediaGroup?.[mediaGroup.length - 1] ?? m;
       const next = chatMessages[i + 1];
       const sameAuthorAsNext =
-        next && next.authorId === m.authorId && dayLabel(next.createdAt) === dl;
+        next && next.authorId === lastInRow.authorId && dayLabel(next.createdAt) === dl;
       const sameAuthorAsPrev =
         prev && prev.authorId === m.authorId && dayLabel(prev.createdAt) === lastDay;
+      const groupIds = mediaGroup?.map((item) => item.id) ?? [m.id];
       out.push({
         key: `msg-${m.id}`,
         item: {
           key: `msg-${m.id}`,
           kind: "msg",
           message: m,
+          mediaGroup: mediaGroup && mediaGroup.length > 1 ? mediaGroup : undefined,
           index: i,
           sameAuthorAsPrev: Boolean(sameAuthorAsPrev),
           sameAuthorAsNext: Boolean(sameAuthorAsNext),
-          isMatch: matches.includes(m.id),
-          isActive: m.id === activeMatchId,
-          flash: m.id === highlightMessageId,
+          isMatch: groupIds.some((id) => matches.includes(id)),
+          isActive: groupIds.includes(activeMatchId ?? ""),
+          flash: groupIds.includes(highlightMessageId ?? ""),
           searching,
           highlight: searching ? q : undefined,
         },
       });
-    });
+    }
     return out;
   }, [chatMessages, matches, search.open, search.q, activeMatchId, highlightMessageId]);
 
   const estimateMsgHeight = useCallback((row: MsgRow): number => {
     if (row.kind === "day") return 40;
+    if (row.mediaGroup && row.mediaGroup.length > 1) {
+      return row.mediaGroup.length <= 2 ? 210 : 300;
+    }
     const m = row.message!;
     if (m.kind === "sticker") return 160;
     if (m.kind === "image" || m.kind === "video") return 320;
@@ -494,78 +526,60 @@ export function ChatArea() {
         })()}
 
         {/* messages */}
-        {(() => {
-          const friendBg =
-            showBackground && chat && chat.type === "friend" && !chat.isSelf && chat.backgroundUrl
-              ? chat.backgroundUrl
-              : undefined;
-          return (
-            <div
-              ref={containerRef}
-              onScroll={onScroll}
-              onContextMenu={(e) => {
-                e.preventDefault();
-                setPanel({ x: e.clientX, y: e.clientY });
-              }}
-              className="vy-scroll vy-chat-surface vy-chat-messages flex-1 overflow-y-auto px-3 py-4 md:px-6"
-              data-pattern={theme.pattern}
-              data-image={friendBg || theme.chatImage ? "" : undefined}
-              style={
-                friendBg
-                  ? {
-                      backgroundImage: `linear-gradient(color-mix(in oklab, ${theme.chatBg} 62%, transparent), color-mix(in oklab, ${theme.chatBg} 62%, transparent)), url(${friendBg})`,
-                    }
-                  : undefined
-              }
-            >
-              <div className="mx-auto flex w-full max-w-3xl flex-col">
-                <div className="mb-4 flex justify-center">
-                  <span className="rounded-xl bg-[color-mix(in_oklab,var(--vy-text)_10%,transparent)] px-4 py-2 text-center text-xs leading-relaxed text-[var(--vy-text-dim)]">
-                    {chat.type === "group"
-                      ? "▲ ここがトークの一番上です"
-                      : "▲ ここから会話が始まります"}
+        <div
+          ref={containerRef}
+          onScroll={onScroll}
+          onContextMenu={(e) => {
+            e.preventDefault();
+            setPanel({ x: e.clientX, y: e.clientY });
+          }}
+          className="vy-scroll vy-chat-surface vy-chat-messages flex-1 overflow-y-auto px-3 py-4 md:px-6"
+          data-pattern={theme.pattern}
+          data-image={theme.chatImage ? "" : undefined}
+        >
+          <div className="mx-auto flex w-full max-w-3xl flex-col">
+            <div className="mb-4 flex justify-center">
+              <span className="rounded-xl bg-[color-mix(in_oklab,var(--vy-text)_10%,transparent)] px-4 py-2 text-center text-xs leading-relaxed text-[var(--vy-text-dim)]">
+                {chat.type === "group"
+                  ? "▲ ここがトークの一番上です"
+                  : "▲ ここから会話が始まります"}
+              </span>
+            </div>
+            {topSpacer > 0 && <div style={{ height: topSpacer }} aria-hidden />}
+            {visibleRows.map(({ key, item }) =>
+              item.kind === "day" ? (
+                <div key={key} ref={(el) => measure(key, el)} className="my-3 flex justify-center">
+                  <span className="rounded-full bg-[color-mix(in_oklab,var(--vy-text)_12%,transparent)] px-3 py-1 text-[0.7rem] font-medium text-[var(--vy-text)] backdrop-blur">
+                    {item.label}
                   </span>
                 </div>
-                {topSpacer > 0 && <div style={{ height: topSpacer }} aria-hidden />}
-                {visibleRows.map(({ key, item }) =>
-                  item.kind === "day" ? (
-                    <div
-                      key={key}
-                      ref={(el) => measure(key, el)}
-                      className="my-3 flex justify-center"
-                    >
-                      <span className="rounded-full bg-[color-mix(in_oklab,var(--vy-text)_12%,transparent)] px-3 py-1 text-[0.7rem] font-medium text-[var(--vy-text)] backdrop-blur">
-                        {item.label}
-                      </span>
-                    </div>
-                  ) : (
-                    <div
-                      key={key}
-                      id={key}
-                      ref={(el) => measure(key, el)}
-                      className={cnRow(
-                        item.searching,
-                        item.isMatch,
-                        item.isActive,
-                        item.sameAuthorAsPrev,
-                        item.flash,
-                      )}
-                    >
-                      <MessageBubble
-                        message={item.message}
-                        chat={chat}
-                        showAvatar={!item.sameAuthorAsNext}
-                        showName={!item.sameAuthorAsPrev}
-                        highlight={item.searching ? (item.highlight as string) : undefined}
-                      />
-                    </div>
-                  ),
-                )}
-                {bottomSpacer > 0 && <div style={{ height: bottomSpacer }} aria-hidden />}
-              </div>
-            </div>
-          );
-        })()}
+              ) : (
+                <div
+                  key={key}
+                  id={key}
+                  ref={(el) => measure(key, el)}
+                  className={cnRow(
+                    item.searching,
+                    item.isMatch,
+                    item.isActive,
+                    item.sameAuthorAsPrev,
+                    item.flash,
+                  )}
+                >
+                  <MessageBubble
+                    message={item.message}
+                    mediaGroup={item.mediaGroup}
+                    chat={chat}
+                    showAvatar={!item.sameAuthorAsNext}
+                    showName={!item.sameAuthorAsPrev}
+                    highlight={item.searching ? (item.highlight as string) : undefined}
+                  />
+                </div>
+              ),
+            )}
+            {bottomSpacer > 0 && <div style={{ height: bottomSpacer }} aria-hidden />}
+          </div>
+        </div>
 
         {/* input */}
         {callHint && (

--- a/Vyline/apps/desktop/src/components/icons.tsx
+++ b/Vyline/apps/desktop/src/components/icons.tsx
@@ -350,3 +350,11 @@ export const IconHeart = (p: IconProps) => (
     />
   </svg>
 );
+
+export const IconHardDrive = (p: IconProps) => (
+  <svg {...base(p)}>
+    <rect x="2" y="6" width="20" height="12" rx="2" />
+    <path d="M6 10h.01M6 14h.01" />
+    <path d="M2 10h20" />
+  </svg>
+);

--- a/Vyline/apps/desktop/src/components/member-profile.tsx
+++ b/Vyline/apps/desktop/src/components/member-profile.tsx
@@ -12,6 +12,12 @@ import { looksLikeMid } from "@/lib/mappers";
 import { Avatar } from "@/components/vy-ui";
 import { IconClose, IconChat, IconPhone, IconVideo, IconUsers } from "@/components/icons";
 
+type RichInfo = {
+  statusMessage?: string;
+  backgroundUrl?: string;
+  userType?: number;
+};
+
 export function MemberProfilePopover({ chat }: { chat: Chat }) {
   const memberProfile = useStore((s) => s.memberProfile);
   const close = useStore((s) => s.closeMemberProfile);
@@ -23,6 +29,7 @@ export function MemberProfilePopover({ chat }: { chat: Chat }) {
   const [busy, setBusy] = useState(false);
   const [msg, setMsg] = useState<string | null>(null);
   const [apiCommonGroups, setApiCommonGroups] = useState<Chat[] | null>(null);
+  const [rich, setRich] = useState<RichInfo>({});
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
@@ -38,10 +45,46 @@ export function MemberProfilePopover({ chat }: { chat: Chat }) {
     [apiCommonGroups, chats, member, chat.id],
   );
 
+  const backgroundUrl = rich.backgroundUrl;
+  const showBackground = Boolean(!streamerMode && backgroundUrl);
+
   useEffect(() => {
     setApiCommonGroups(null);
+    setRich({});
     if (!accountId || !member || streamerMode) return;
     let cancelled = false;
+    void api.line
+      .contactProfile(accountId, member.id)
+      .then((res) => {
+        if (cancelled || !res.ok || !res.profile) return;
+        setRich({
+          statusMessage: res.profile.statusMessage,
+          backgroundUrl: res.profile.backgroundUrl,
+          userType: res.profile.userType,
+        });
+        useStore.setState((st) => ({
+          chats: st.chats.map((c) =>
+            c.id === chat.id
+              ? {
+                  ...c,
+                  members: c.members?.map((m) =>
+                    m.id === member.id
+                      ? {
+                          ...m,
+                          avatarUrl: res.profile?.thumbnailUrl || m.avatarUrl,
+                          name:
+                            res.profile?.displayName && !looksLikeMid(res.profile.displayName)
+                              ? res.profile.displayName
+                              : m.name,
+                        }
+                      : m,
+                  ),
+                }
+              : c,
+          ),
+        }));
+      })
+      .catch(() => undefined);
     void api.line
       .commonGroups(accountId, member.id, chat.id)
       .then((res) => {
@@ -120,7 +163,15 @@ export function MemberProfilePopover({ chat }: { chat: Chat }) {
       >
         <div
           className="relative flex flex-col items-center px-6 pb-5 pt-8"
-          style={{ background: `color-mix(in oklab, ${member.color} 18%, var(--vy-surface))` }}
+          style={
+            showBackground
+              ? {
+                  backgroundImage: `linear-gradient(180deg, color-mix(in oklab, black 10%, transparent), color-mix(in oklab, black 24%, transparent)), url(${backgroundUrl})`,
+                  backgroundSize: "cover",
+                  backgroundPosition: "center",
+                }
+              : { background: `color-mix(in oklab, ${member.color} 18%, var(--vy-surface))` }
+          }
         >
           <button
             type="button"
@@ -145,6 +196,16 @@ export function MemberProfilePopover({ chat }: { chat: Chat }) {
           <p className="mt-0.5 text-xs text-[var(--vy-text-dim)]">
             {streamerMode ? "配信者モードで非表示" : `${chat.name} のメンバー`}
           </p>
+          {!streamerMode && rich.statusMessage && (
+              <div className="mt-4 w-full space-y-2 rounded-2xl border border-white/10 bg-black/10 p-3 text-left text-white backdrop-blur-sm">
+                {rich.statusMessage && <TinyInfo label="ステメ" value={rich.statusMessage} />}
+                {(chat.isOfficial || rich.userType === 2) && (
+                  <span className="inline-flex rounded-full bg-white/15 px-2.5 py-1 text-[0.65rem] font-medium text-white">
+                    公式アカウント
+                  </span>
+                )}
+              </div>
+            )}
         </div>
 
         <div className="grid grid-cols-3 gap-2 p-4">
@@ -213,6 +274,15 @@ export function MemberProfilePopover({ chat }: { chat: Chat }) {
         )}
       </div>
     </div>
+  );
+}
+
+function TinyInfo({ label, value }: { label: string; value: string }) {
+  return (
+    <p className="text-xs leading-relaxed">
+      <span className="text-white/70">{label} · </span>
+      <span>{value}</span>
+    </p>
   );
 }
 

--- a/Vyline/apps/desktop/src/components/member-profile.tsx
+++ b/Vyline/apps/desktop/src/components/member-profile.tsx
@@ -197,15 +197,15 @@ export function MemberProfilePopover({ chat }: { chat: Chat }) {
             {streamerMode ? "配信者モードで非表示" : `${chat.name} のメンバー`}
           </p>
           {!streamerMode && rich.statusMessage && (
-              <div className="mt-4 w-full space-y-2 rounded-2xl border border-white/10 bg-black/10 p-3 text-left text-white backdrop-blur-sm">
-                {rich.statusMessage && <TinyInfo label="ステメ" value={rich.statusMessage} />}
-                {(chat.isOfficial || rich.userType === 2) && (
-                  <span className="inline-flex rounded-full bg-white/15 px-2.5 py-1 text-[0.65rem] font-medium text-white">
-                    公式アカウント
-                  </span>
-                )}
-              </div>
-            )}
+            <div className="mt-4 w-full space-y-2 rounded-2xl border border-white/10 bg-black/10 p-3 text-left text-white backdrop-blur-sm">
+              {rich.statusMessage && <TinyInfo label="ステメ" value={rich.statusMessage} />}
+              {(chat.isOfficial || rich.userType === 2) && (
+                <span className="inline-flex rounded-full bg-white/15 px-2.5 py-1 text-[0.65rem] font-medium text-white">
+                  公式アカウント
+                </span>
+              )}
+            </div>
+          )}
         </div>
 
         <div className="grid grid-cols-3 gap-2 p-4">

--- a/Vyline/apps/desktop/src/components/message-bubble.tsx
+++ b/Vyline/apps/desktop/src/components/message-bubble.tsx
@@ -453,12 +453,14 @@ export const MessageBubble = memo(
     showAvatar,
     showName,
     highlight,
+    mediaGroup,
   }: {
     message: Message;
     chat: Chat;
     showAvatar: boolean;
     showName: boolean;
     highlight?: string;
+    mediaGroup?: Message[];
   }) {
     const isMe = message.authorId === "me";
     const settings = useStore((s) => s.settings);
@@ -485,10 +487,12 @@ export const MessageBubble = memo(
     const [history, setHistory] = useState<NonNullable<Message["history"]>>([]);
     const [historyLoading, setHistoryLoading] = useState(false);
     const [lightbox, setLightbox] = useState(false);
+    const [lightboxMedia, setLightboxMedia] = useState<Message | null>(null);
     const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
     const longPressFired = useRef(false);
 
     const author = chat.members?.find((m) => m.id === message.authorId);
+    const mediaItems = mediaGroup?.filter((item) => item.kind === "image" && item.imageSrc) ?? [];
     const repliedAuthor =
       replied?.authorId === "me"
         ? self.name
@@ -1160,7 +1164,49 @@ export const MessageBubble = memo(
               }}
             >
               {replyQuote}
-              {(message.kind === "image" || message.kind === "video") &&
+              {mediaItems.length > 1 && !streamerMode && (
+                <div
+                  className={cn(
+                    "grid overflow-hidden rounded-xl",
+                    mediaItems.length === 2 ? "grid-cols-2" : "grid-cols-3",
+                  )}
+                >
+                  {mediaItems.map((item) => (
+                    <button
+                      key={item.id}
+                      type="button"
+                      className="group relative aspect-square overflow-hidden bg-black/5"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setLightboxMedia(item);
+                        setLightbox(true);
+                      }}
+                      aria-label="画像を拡大"
+                    >
+                      <img
+                        src={item.imageSrc}
+                        alt="送信された画像"
+                        onError={hideBrokenMedia}
+                        className="h-full w-full object-cover transition-opacity group-hover:opacity-95"
+                      />
+                    </button>
+                  ))}
+                </div>
+              )}
+              {mediaItems.length > 1 && streamerMode && (
+                <div
+                  className={cn(
+                    "grid gap-1",
+                    mediaItems.length === 2 ? "grid-cols-2" : "grid-cols-3",
+                  )}
+                >
+                  {mediaItems.map((item) => (
+                    <SpoilerMedia key={item.id} src={item.imageSrc!} alt="送信された画像" />
+                  ))}
+                </div>
+              )}
+              {mediaItems.length <= 1 &&
+                (message.kind === "image" || message.kind === "video") &&
                 message.imageSrc &&
                 (streamerMode ? (
                   <SpoilerMedia
@@ -1174,6 +1220,7 @@ export const MessageBubble = memo(
                     className="group relative block overflow-hidden rounded-xl text-left"
                     onClick={(e) => {
                       e.stopPropagation();
+                      setLightboxMedia(message);
                       setLightbox(true);
                     }}
                     aria-label={message.kind === "video" ? "動画を拡大" : "画像を拡大"}
@@ -1202,10 +1249,10 @@ export const MessageBubble = memo(
                     )}
                   </button>
                 ))}
-              {message.kind === "audio" && message.audioSrc && (
+              {mediaItems.length <= 1 && message.kind === "audio" && message.audioSrc && (
                 <AudioBubble src={message.audioSrc} seconds={message.audioSeconds} />
               )}
-              {message.kind === "text" && (
+              {mediaItems.length <= 1 && message.kind === "text" && (
                 <div>
                   {showOriginal && message.originalText && (
                     <div className="mb-1 flex items-center justify-between border-b border-current/15 pb-1 text-[0.65rem] opacity-70">
@@ -1273,10 +1320,10 @@ export const MessageBubble = memo(
             onClose={() => setEditing(false)}
           />
         )}
-        {lightbox && message.imageSrc && (
+        {lightbox && (lightboxMedia?.imageSrc ?? message.imageSrc) && (
           <MediaLightbox
-            src={message.imageSrc}
-            kind={message.kind === "video" ? "video" : "image"}
+            src={(lightboxMedia?.imageSrc ?? message.imageSrc)!}
+            kind={(lightboxMedia?.kind ?? message.kind) === "video" ? "video" : "image"}
             onClose={() => setLightbox(false)}
           />
         )}

--- a/Vyline/apps/desktop/src/components/message-bubble.tsx
+++ b/Vyline/apps/desktop/src/components/message-bubble.tsx
@@ -313,7 +313,10 @@ function Highlighted({
 }
 
 function replySnippet(m: Message): string {
-  if (m.messageState.startsWith("revoked")) return "取り消されたメッセージ";
+  if (m.messageState.startsWith("revoked")) {
+    if (m.revokedSnapshot) return `取り消し済み: ${replySnippet(m.revokedSnapshot)}`;
+    return "取り消し済みのメッセージ";
+  }
   if (m.kind === "image") return "写真";
   if (m.kind === "video") return "動画";
   if (m.kind === "audio") return "音声";
@@ -327,11 +330,18 @@ function replySnippet(m: Message): string {
 }
 
 /** スタンプ URL（/api/cdn/line?u=...android/sticker.png）→ アニメ版 URL */
-function stickerAnimationUrl(url: string): string {
+function stickerAnimationUrl(url?: string): string {
+  if (!url) return "";
   let u = decodeURIComponent(url);
   u = u.replace(/\/sticker\.png$/, "/sticker_animation.png").replace(/\/android\//, "/ANDROID/");
   if (u.startsWith("http")) u = `/api/cdn/line?u=${encodeURIComponent(u)}`;
   return u;
+}
+
+function isStickerImageSrc(src?: string): boolean {
+  return Boolean(
+    src && (src.startsWith("http") || src.startsWith("/api/") || src.startsWith("data:")),
+  );
 }
 
 // MessageReactionType → 表示絵文字（LINE 公式: NICE=2 LOVE=3 FUN=4 AMAZING=5 SAD=6 OMG=7）
@@ -459,6 +469,7 @@ export const MessageBubble = memo(
     const streamerMode = settings.streamerMode;
     const revokeMessage = useStore((s) => s.revokeMessage);
     const restoreRevokedMessage = useStore((s) => s.restoreRevokedMessage);
+    const fetchMessageHistory = useStore((s) => s.fetchMessageHistory);
     const editMessage = useStore((s) => s.editMessage);
     const retryMessage = useStore((s) => s.retryMessage);
     const markRead = useStore((s) => s.markRead);
@@ -479,8 +490,75 @@ export const MessageBubble = memo(
     const [history, setHistory] = useState<NonNullable<Message["history"]>>([]);
     const [historyLoading, setHistoryLoading] = useState(false);
     const [lightbox, setLightbox] = useState(false);
+    const [revokedFallbackText, setRevokedFallbackText] = useState<string | null>(null);
     const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
     const longPressFired = useRef(false);
+    const isRevoked =
+      message.messageState.startsWith("revoked") ||
+      Boolean(message.revokedSnapshot) ||
+      Boolean(
+        message.history?.length &&
+          message.history.some(
+            (h) => h.state === "normal" || h.state === "edited" || h.contentType === "UNSENT",
+          ),
+      );
+    const displayMessage = isRevoked && message.revokedSnapshot ? message.revokedSnapshot : message;
+    const revokedHistoryText =
+      message.history && message.history.length > 0
+        ? ([...message.history]
+            .reverse()
+            .find((h) => h.state === "normal" || h.state === "edited")
+            ?.text?.trim() ?? null)
+        : null;
+    const revokedBodyText =
+      revokedFallbackText ?? revokedHistoryText ?? displayMessage.text?.trim() ?? null;
+    const revokedDisplayMessage =
+      displayMessage.kind === "text" ||
+      displayMessage.kind === "emoji" ||
+      displayMessage.kind === "system"
+        ? {
+            ...displayMessage,
+            text: revokedBodyText || "（内容なし）",
+          }
+        : displayMessage;
+
+    useEffect(() => {
+      let cancelled = false;
+      if (!isRevoked) {
+        setRevokedFallbackText(null);
+        return () => {
+          cancelled = true;
+        };
+      }
+      const snapshotText = message.revokedSnapshot?.text?.trim();
+      if (snapshotText) {
+        setRevokedFallbackText(null);
+        return () => {
+          cancelled = true;
+        };
+      }
+      void (async () => {
+        try {
+          const history = await fetchMessageHistory(message.chatId, message.id);
+          const last = [...(history ?? [])]
+            .reverse()
+            .find((h) => h.state === "normal" || h.state === "edited");
+          if (!cancelled) setRevokedFallbackText(last?.text ?? null);
+        } catch {
+          if (!cancelled) setRevokedFallbackText(null);
+        }
+      })();
+      return () => {
+        cancelled = true;
+      };
+    }, [
+      fetchMessageHistory,
+      message.chatId,
+      message.id,
+      message.messageState,
+      isRevoked,
+      message.revokedSnapshot?.text,
+    ]);
 
     const author = chat.members?.find((m) => m.id === message.authorId);
     const repliedAuthor =
@@ -498,7 +576,7 @@ export const MessageBubble = memo(
     }
 
     function onTouchStart(e: React.TouchEvent) {
-      if (message.messageState.startsWith("revoked")) return;
+      if (isRevoked) return;
       const t = e.touches[0];
       longPressFired.current = false;
       longPressTimer.current = setTimeout(() => {
@@ -642,7 +720,7 @@ export const MessageBubble = memo(
             },
           ]
         : []),
-      ...(message.kind === "sticker" && message.sticker?.startsWith("/api/")
+      ...(message.kind === "sticker" && isStickerImageSrc(message.sticker)
         ? [
             {
               label: "ダウンロード",
@@ -695,7 +773,7 @@ export const MessageBubble = memo(
           ]
         : []),
       ...(isMe &&
-      !message.messageState.startsWith("revoked") &&
+      !isRevoked &&
       message.kind === "text" &&
       message.status !== "sending" &&
       !message.id.startsWith("pending_")
@@ -732,9 +810,9 @@ export const MessageBubble = memo(
           ]
         : []),
       ...(isMe &&
-      message.messageState === "revoked-by-self" &&
-      message.history &&
-      message.history.length > 0
+      isRevoked &&
+      message.authorId === "me" &&
+      (message.revokedSnapshot || (message.history && message.history.length > 0))
         ? [
             {
               label: "復元",
@@ -743,10 +821,7 @@ export const MessageBubble = memo(
             },
           ]
         : []),
-      ...(isMe &&
-      !message.messageState.startsWith("revoked") &&
-      message.status !== "sending" &&
-      !message.id.startsWith("pending_")
+      ...(isMe && !isRevoked && message.status !== "sending" && !message.id.startsWith("pending_")
         ? [
             {
               label: "送信を取り消し",
@@ -756,7 +831,7 @@ export const MessageBubble = memo(
             },
           ]
         : []),
-      ...(chat.type === "group" && (message.text || message.altText)
+      ...(chat.type === "group" && !isRevoked && (message.text || message.altText)
         ? [
             {
               label: "アナウンスを追加",
@@ -770,7 +845,7 @@ export const MessageBubble = memo(
     const isMessageEdited = message.edited || Boolean(message.originalText);
 
     const readReceipt = (() => {
-      if (!isMe || message.messageState.startsWith("revoked")) return null;
+      if (!isMe || isRevoked) return null;
       if (message.status === "sending") return <span className="opacity-60">送信中…</span>;
       if (message.status === "failed")
         return (
@@ -817,11 +892,11 @@ export const MessageBubble = memo(
       readers.length > 0 &&
       message.read;
 
-    if (message.kind === "call" && !message.messageState.startsWith("revoked")) {
+    if (message.kind === "call" && !isRevoked) {
       return <CallEventMessage meta={message.callMeta} isMe={isMe} />;
     }
 
-    if (message.kind === "system" && !message.messageState.startsWith("revoked")) {
+    if (message.kind === "system" && !isRevoked) {
       return (
         <div className="my-1 flex w-full justify-center px-1">
           <span className="rounded-full bg-[color-mix(in_oklab,var(--vy-text)_10%,transparent)] px-3 py-1 text-center text-[0.7rem] text-[var(--vy-text-dim)]">
@@ -831,7 +906,7 @@ export const MessageBubble = memo(
       );
     }
 
-    const metaLine = !message.messageState.startsWith("revoked") && (
+    const metaLine = !isRevoked && (
       <div
         className={cn(
           "mt-1 flex items-center gap-1.5 px-1 text-[0.7rem] text-[var(--vy-text-dim)]",
@@ -915,6 +990,243 @@ export const MessageBubble = memo(
       />
     );
 
+    const renderBubbleContent = (target: Message) => {
+      if (target.kind === "call") {
+        return <CallEventMessage meta={target.callMeta} isMe={target.authorId === "me"} />;
+      }
+
+      if (target.kind === "system") {
+        return (
+          <div className="my-1 flex w-full justify-center px-1">
+            <span className="rounded-full bg-[color-mix(in_oklab,var(--vy-text)_10%,transparent)] px-3 py-1 text-center text-[0.7rem] text-[var(--vy-text-dim)]">
+              {target.text || "システムメッセージ"}
+            </span>
+          </div>
+        );
+      }
+
+      if (target.kind === "sticker") {
+        return (
+          <div
+            className={cn(
+              "vy-pop-in cursor-default",
+              target.stickerSticky && "relative flex w-full justify-center py-2",
+            )}
+            aria-label="スタンプ"
+          >
+            {target.stickerSticky && (
+              <span className="absolute -top-1 left-1 rounded-full bg-[color-mix(in_oklab,var(--vy-text)_15%,transparent)] px-1.5 py-0.5 text-[0.6rem] text-[var(--vy-text-dim)]">
+                くっつき
+              </span>
+            )}
+            {isStickerImageSrc(target.sticker) ? (
+              <img
+                src={target.stickerAnimated ? stickerAnimationUrl(target.sticker) : target.sticker}
+                alt="スタンプ"
+                onError={hideBrokenMedia}
+                className={cn("h-32 w-32 object-contain", target.stickerSticky && "drop-shadow-md")}
+                draggable={false}
+              />
+            ) : (
+              <span className="text-7xl leading-none">{target.sticker || "🎴"}</span>
+            )}
+          </div>
+        );
+      }
+
+      if (target.kind === "emoji") {
+        return (
+          <div className="vy-pop-in cursor-default text-6xl leading-none" aria-label="絵文字">
+            {target.sticons?.length ? (
+              <Highlighted
+                text={target.text ?? ""}
+                sticons={target.sticons}
+                mentions={target.mentions}
+              />
+            ) : (
+              target.text
+            )}
+          </div>
+        );
+      }
+
+      if (target.kind === "flex") {
+        return target.flexJson ? (
+          <FlexMessageView container={target.flexJson} altText={target.altText || target.text} />
+        ) : (
+          <div className="rounded-xl bg-white px-3 py-2 text-sm text-neutral-700 shadow-sm">
+            {target.altText || "Flexメッセージ"}
+          </div>
+        );
+      }
+
+      if (target.kind === "rich") {
+        return (
+          <RichMessageView
+            imageUrl={target.richImageUrl}
+            markup={target.richMarkup}
+            altText={target.altText || target.text}
+          />
+        );
+      }
+
+      if (target.kind === "location") {
+        return (
+          <div className="vy-msg-enter max-w-[280px] overflow-hidden rounded-msg shadow-sm">
+            {target.location?.latitude != null && target.location?.longitude != null ? (
+              <a
+                href={`https://www.google.com/maps/search/?api=1&query=${target.location.latitude},${target.location.longitude}`}
+                target="_blank"
+                rel="noreferrer"
+                className="block h-32 w-full bg-cover bg-center"
+                style={{
+                  backgroundImage: `url(https://maps.googleapis.com/maps/api/staticmap?center=${target.location.latitude},${target.location.longitude}&zoom=15&size=280x128&markers=color:red%7C${target.location.latitude},${target.location.longitude}&key=)`,
+                }}
+                aria-label="地図を開く"
+              />
+            ) : null}
+            <div className="bg-[var(--vy-msg-in)] px-3 py-2 text-[var(--vy-msg-in-text)]">
+              <p className="flex items-center gap-1.5 text-sm font-semibold">
+                <IconPin size={15} /> {target.location?.title || "位置情報"}
+              </p>
+              {target.location?.address && (
+                <p className="mt-0.5 text-xs text-[var(--vy-text-dim)]">
+                  {target.location.address}
+                </p>
+              )}
+              {target.location?.latitude != null && target.location?.longitude != null && (
+                <a
+                  href={`https://www.google.com/maps/search/?api=1&query=${target.location.latitude},${target.location.longitude}`}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="mt-1 inline-block text-xs font-medium"
+                  style={{ color: "var(--vy-accent)" }}
+                >
+                  地図を開く
+                </a>
+              )}
+            </div>
+          </div>
+        );
+      }
+
+      if (target.kind === "contact") {
+        return (
+          <div className="vy-msg-enter w-[240px] overflow-hidden rounded-msg shadow-sm">
+            <div className="flex items-center gap-3 bg-[var(--vy-msg-in)] px-3 py-3 text-[var(--vy-msg-in-text)]">
+              {target.contact?.thumbnailUrl ? (
+                <img
+                  src={target.contact.thumbnailUrl}
+                  alt=""
+                  onError={hideBrokenMedia}
+                  className="h-11 w-11 rounded-full object-cover"
+                />
+              ) : (
+                <span className="flex h-11 w-11 items-center justify-center rounded-full bg-[var(--vy-accent)] text-lg font-bold text-white">
+                  {(target.contact?.name || "?").charAt(0).toUpperCase()}
+                </span>
+              )}
+              <div className="min-w-0">
+                <p className="truncate text-sm font-semibold">{target.contact?.name || "連絡先"}</p>
+                <p className="text-[0.65rem] text-[var(--vy-text-dim)]">連絡先が共有されました</p>
+              </div>
+            </div>
+          </div>
+        );
+      }
+
+      return (
+        <div
+          className={cn(
+            "vy-msg-enter vy-bubble-pad relative select-none rounded-msg text-[length:inherit] leading-relaxed shadow-sm",
+          )}
+          style={{
+            background: isMe ? "var(--vy-msg-out)" : "var(--vy-msg-in)",
+            color: isMe ? "var(--vy-msg-out-text)" : "var(--vy-msg-in-text)",
+            borderTopRightRadius: isMe && settings.bubbleTail ? 6 : undefined,
+            borderTopLeftRadius: !isMe && settings.bubbleTail ? 6 : undefined,
+          }}
+        >
+          {replyQuote}
+          {(target.kind === "image" || target.kind === "video") &&
+            target.imageSrc &&
+            (streamerMode ? (
+              <SpoilerMedia
+                src={target.imageSrc}
+                alt={target.kind === "video" ? "動画サムネイル" : "送信された画像"}
+                video={target.kind === "video"}
+              />
+            ) : (
+              <button
+                type="button"
+                className="group relative block overflow-hidden rounded-xl text-left"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setLightbox(true);
+                }}
+                aria-label={target.kind === "video" ? "動画を拡大" : "画像を拡大"}
+              >
+                {target.kind === "video" ? (
+                  <div className="relative">
+                    <img
+                      src={target.imageSrc}
+                      alt="動画サムネイル"
+                      onError={hideBrokenMedia}
+                      className="h-auto w-[260px] max-w-full object-cover"
+                    />
+                    <span className="absolute inset-0 flex items-center justify-center bg-black/35">
+                      <span className="flex h-12 w-12 items-center justify-center rounded-full bg-black/50 text-white">
+                        <IconPlay size={22} />
+                      </span>
+                    </span>
+                  </div>
+                ) : (
+                  <img
+                    src={target.imageSrc}
+                    alt="送信された画像"
+                    onError={hideBrokenMedia}
+                    className="max-h-[360px] max-w-[240px] object-contain transition-opacity group-hover:opacity-95"
+                  />
+                )}
+              </button>
+            ))}
+          {target.kind === "audio" && target.audioSrc && (
+            <AudioBubble src={target.audioSrc} seconds={target.audioSeconds} />
+          )}
+          {target.kind === "text" && (
+            <div>
+              {showOriginal && target.originalText && (
+                <div className="mb-1 flex items-center justify-between border-b border-current/15 pb-1 text-[0.65rem] opacity-70">
+                  <span>編集前のメッセージ</span>
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setShowOriginal(false);
+                    }}
+                    className="underline hover:opacity-100"
+                  >
+                    戻す
+                  </button>
+                </div>
+              )}
+              <p className="vy-msg-text whitespace-pre-wrap break-words">
+                <Highlighted
+                  text={
+                    showOriginal && target.originalText ? target.originalText : (target.text ?? "")
+                  }
+                  query={highlight}
+                  sticons={target.sticons}
+                  mentions={target.mentions}
+                />
+              </p>
+            </div>
+          )}
+          {target.linkPreview && !streamerMode && <LinkPreviewCard preview={target.linkPreview} />}
+        </div>
+      );
+    };
+
     return (
       <div className={cn("flex w-full gap-2 px-1", isMe ? "flex-row-reverse" : "flex-row")}>
         {!isMe && chat.type === "group" && (
@@ -957,42 +1269,41 @@ export const MessageBubble = memo(
             </button>
           )}
 
-          {message.messageState.startsWith("revoked") ? (
+          {isRevoked ? (
             <div
               className={cn(
-                "relative rounded-2xl border px-4 py-2.5 text-sm",
-                message.messageState === "revoked-by-self"
-                  ? "border-dashed bg-[color-mix(in_oklab,var(--vy-accent)_8%,transparent)] italic"
-                  : "border-dashed bg-[color-mix(in_oklab,var(--vy-text)_6%,transparent)] line-through opacity-80",
-                message.messageState === "revoked-by-self" &&
-                  message.history &&
-                  message.history.length > 0
-                  ? ""
-                  : "opacity-70",
+                "relative overflow-hidden rounded-msg border border-dashed px-3 py-2.5 shadow-sm",
+                isRevoked && message.authorId === "me"
+                  ? "bg-[color-mix(in_oklab,var(--vy-accent)_7%,transparent)]"
+                  : "bg-[color-mix(in_oklab,var(--vy-text)_5%,var(--vy-surface-2))]",
               )}
               style={{
                 borderColor:
-                  message.messageState === "revoked-by-self"
-                    ? "var(--vy-accent)"
+                  isRevoked && message.authorId === "me"
+                    ? "color-mix(in oklab, var(--vy-accent) 55%, transparent)"
                     : "var(--vy-border)",
               }}
             >
-              <span className="flex items-center gap-1.5">
-                <IconTrash className="h-3.5 w-3.5 shrink-0" />
-                {message.messageState === "revoked-by-self"
-                  ? "あなたがメッセージの送信を取り消しました"
-                  : "メッセージの送信が取り消されました"}
+              <span
+                className={cn(
+                  "absolute right-2 top-2 rounded-full border px-2 py-0.5 text-[0.62rem] font-semibold tracking-wide",
+                  isRevoked && message.authorId === "me"
+                    ? "border-[color-mix(in_oklab,var(--vy-accent)_50%,transparent)] bg-[color-mix(in_oklab,var(--vy-accent)_18%,transparent)] text-[var(--vy-accent)]"
+                    : "border-[var(--vy-border)] bg-[color-mix(in_oklab,var(--vy-text)_10%,transparent)] text-[var(--vy-text-dim)]",
+                )}
+              >
+                取り消し済み
               </span>
-              {message.history && message.history.length > 0 ? (
-                <div className="mt-1.5 text-xs not-italic opacity-90">
-                  {(() => {
-                    const last = [...message.history]
-                      .reverse()
-                      .find((h) => h.state === "normal" || h.state === "edited");
-                    return last ? (last.text ?? "（なし）") : "";
-                  })()}
-                </div>
-              ) : null}
+              <div className="pr-16">{renderBubbleContent(revokedDisplayMessage)}</div>
+              <div className="mt-2 flex items-center gap-1.5 text-[0.7rem] text-[var(--vy-text-dim)]">
+                <IconTrash className="h-3.5 w-3.5 shrink-0 opacity-80" />
+                <span>{formatTime(message.createdAt)}</span>
+                <span className="opacity-70">
+                  {isRevoked && message.authorId === "me"
+                    ? "あなたが送信を取り消しました"
+                    : "送信が取り消されました"}
+                </span>
+              </div>
             </div>
           ) : message.kind === "sticker" ? (
             <button
@@ -1010,8 +1321,7 @@ export const MessageBubble = memo(
                   くっつき
                 </span>
               )}
-              {message.sticker &&
-              (message.sticker.startsWith("http") || message.sticker.startsWith("/api/")) ? (
+              {isStickerImageSrc(message.sticker) ? (
                 <img
                   src={
                     message.stickerAnimated ? stickerAnimationUrl(message.sticker) : message.sticker
@@ -1235,16 +1545,14 @@ export const MessageBubble = memo(
 
           {metaLine}
           {readerList}
-          {message.reactions &&
-            message.reactions.length > 0 &&
-            !message.messageState.startsWith("revoked") && (
-              <ReactionBadges
-                reactions={message.reactions}
-                myMid={self?.mid ?? ""}
-                onReact={react}
-                side={isMe ? "right" : "left"}
-              />
-            )}
+          {message.reactions && message.reactions.length > 0 && !isRevoked && (
+            <ReactionBadges
+              reactions={message.reactions}
+              myMid={self?.mid ?? ""}
+              onReact={react}
+              side={isMe ? "right" : "left"}
+            />
+          )}
         </div>
 
         {menu && (

--- a/Vyline/apps/desktop/src/components/message-bubble.tsx
+++ b/Vyline/apps/desktop/src/components/message-bubble.tsx
@@ -959,16 +959,32 @@ export const MessageBubble = memo(
 
           {message.messageState.startsWith("revoked") ? (
             <div
-              className="rounded-2xl border border-dashed px-4 py-2 text-sm italic opacity-70"
-              style={{ borderColor: "var(--vy-border)" }}
+              className={cn(
+                "relative rounded-2xl border px-4 py-2.5 text-sm",
+                message.messageState === "revoked-by-self"
+                  ? "border-dashed bg-[color-mix(in_oklab,var(--vy-accent)_8%,transparent)] italic"
+                  : "border-dashed bg-[color-mix(in_oklab,var(--vy-text)_6%,transparent)] line-through opacity-80",
+                message.messageState === "revoked-by-self" &&
+                  message.history &&
+                  message.history.length > 0
+                  ? ""
+                  : "opacity-70",
+              )}
+              style={{
+                borderColor:
+                  message.messageState === "revoked-by-self"
+                    ? "var(--vy-accent)"
+                    : "var(--vy-border)",
+              }}
             >
-              {message.messageState === "revoked-by-self"
-                ? "あなたがメッセージの送信を取り消しました"
-                : "メッセージの送信が取り消されました"}
-              {message.messageState === "revoked-by-self" &&
-              message.history &&
-              message.history.length > 0 ? (
-                <div className="mt-1 text-xs not-italic opacity-80">
+              <span className="flex items-center gap-1.5">
+                <IconTrash className="h-3.5 w-3.5 shrink-0" />
+                {message.messageState === "revoked-by-self"
+                  ? "あなたがメッセージの送信を取り消しました"
+                  : "メッセージの送信が取り消されました"}
+              </span>
+              {message.history && message.history.length > 0 ? (
+                <div className="mt-1.5 text-xs not-italic opacity-90">
                   {(() => {
                     const last = [...message.history]
                       .reverse()

--- a/Vyline/apps/desktop/src/components/message-bubble.tsx
+++ b/Vyline/apps/desktop/src/components/message-bubble.tsx
@@ -313,7 +313,7 @@ function Highlighted({
 }
 
 function replySnippet(m: Message): string {
-  if (m.revoked) return "取り消されたメッセージ";
+  if (m.messageState.startsWith("revoked")) return "取り消されたメッセージ";
   if (m.kind === "image") return "写真";
   if (m.kind === "video") return "動画";
   if (m.kind === "audio") return "音声";
@@ -458,6 +458,7 @@ export const MessageBubble = memo(
     const settings = useStore((s) => s.settings);
     const streamerMode = settings.streamerMode;
     const revokeMessage = useStore((s) => s.revokeMessage);
+    const restoreRevokedMessage = useStore((s) => s.restoreRevokedMessage);
     const editMessage = useStore((s) => s.editMessage);
     const retryMessage = useStore((s) => s.retryMessage);
     const markRead = useStore((s) => s.markRead);
@@ -474,6 +475,9 @@ export const MessageBubble = memo(
     const [editing, setEditing] = useState(false);
     const [showOriginal, setShowOriginal] = useState(false);
     const [showReaders, setShowReaders] = useState(false);
+    const [showHistory, setShowHistory] = useState(false);
+    const [history, setHistory] = useState<NonNullable<Message["history"]>>([]);
+    const [historyLoading, setHistoryLoading] = useState(false);
     const [lightbox, setLightbox] = useState(false);
     const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
     const longPressFired = useRef(false);
@@ -494,7 +498,7 @@ export const MessageBubble = memo(
     }
 
     function onTouchStart(e: React.TouchEvent) {
-      if (message.revoked) return;
+      if (message.messageState.startsWith("revoked")) return;
       const t = e.touches[0];
       longPressFired.current = false;
       longPressTimer.current = setTimeout(() => {
@@ -691,7 +695,7 @@ export const MessageBubble = memo(
           ]
         : []),
       ...(isMe &&
-      !message.revoked &&
+      !message.messageState.startsWith("revoked") &&
       message.kind === "text" &&
       message.status !== "sending" &&
       !message.id.startsWith("pending_")
@@ -712,8 +716,35 @@ export const MessageBubble = memo(
             },
           ]
         : []),
+      ...(message.history && message.history.length > 0
+        ? [
+            {
+              label: "履歴を表示",
+              icon: <IconChevron size={16} />,
+              onClick: async () => {
+                setHistoryLoading(true);
+                setShowHistory(true);
+                const h = await useStore.getState().fetchMessageHistory(message.chatId, message.id);
+                setHistory(h ?? []);
+                setHistoryLoading(false);
+              },
+            },
+          ]
+        : []),
       ...(isMe &&
-      !message.revoked &&
+      message.messageState === "revoked-by-self" &&
+      message.history &&
+      message.history.length > 0
+        ? [
+            {
+              label: "復元",
+              icon: <IconCheck size={16} />,
+              onClick: () => restoreRevokedMessage(message.chatId, message.id),
+            },
+          ]
+        : []),
+      ...(isMe &&
+      !message.messageState.startsWith("revoked") &&
       message.status !== "sending" &&
       !message.id.startsWith("pending_")
         ? [
@@ -739,7 +770,7 @@ export const MessageBubble = memo(
     const isMessageEdited = message.edited || Boolean(message.originalText);
 
     const readReceipt = (() => {
-      if (!isMe || message.revoked) return null;
+      if (!isMe || message.messageState.startsWith("revoked")) return null;
       if (message.status === "sending") return <span className="opacity-60">送信中…</span>;
       if (message.status === "failed")
         return (
@@ -786,11 +817,11 @@ export const MessageBubble = memo(
       readers.length > 0 &&
       message.read;
 
-    if (message.kind === "call" && !message.revoked) {
+    if (message.kind === "call" && !message.messageState.startsWith("revoked")) {
       return <CallEventMessage meta={message.callMeta} isMe={isMe} />;
     }
 
-    if (message.kind === "system" && !message.revoked) {
+    if (message.kind === "system" && !message.messageState.startsWith("revoked")) {
       return (
         <div className="my-1 flex w-full justify-center px-1">
           <span className="rounded-full bg-[color-mix(in_oklab,var(--vy-text)_10%,transparent)] px-3 py-1 text-center text-[0.7rem] text-[var(--vy-text-dim)]">
@@ -800,7 +831,7 @@ export const MessageBubble = memo(
       );
     }
 
-    const metaLine = !message.revoked && (
+    const metaLine = !message.messageState.startsWith("revoked") && (
       <div
         className={cn(
           "mt-1 flex items-center gap-1.5 px-1 text-[0.7rem] text-[var(--vy-text-dim)]",
@@ -926,14 +957,26 @@ export const MessageBubble = memo(
             </button>
           )}
 
-          {message.revoked ? (
+          {message.messageState.startsWith("revoked") ? (
             <div
               className="rounded-2xl border border-dashed px-4 py-2 text-sm italic opacity-70"
               style={{ borderColor: "var(--vy-border)" }}
             >
-              {isMe
+              {message.messageState === "revoked-by-self"
                 ? "あなたがメッセージの送信を取り消しました"
                 : "メッセージの送信が取り消されました"}
+              {message.messageState === "revoked-by-self" &&
+              message.history &&
+              message.history.length > 0 ? (
+                <div className="mt-1 text-xs not-italic opacity-80">
+                  {(() => {
+                    const last = [...message.history]
+                      .reverse()
+                      .find((h) => h.state === "normal" || h.state === "edited");
+                    return last ? (last.text ?? "（なし）") : "";
+                  })()}
+                </div>
+              ) : null}
             </div>
           ) : message.kind === "sticker" ? (
             <button
@@ -1176,14 +1219,16 @@ export const MessageBubble = memo(
 
           {metaLine}
           {readerList}
-          {message.reactions && message.reactions.length > 0 && !message.revoked && (
-            <ReactionBadges
-              reactions={message.reactions}
-              myMid={self?.mid ?? ""}
-              onReact={react}
-              side={isMe ? "right" : "left"}
-            />
-          )}
+          {message.reactions &&
+            message.reactions.length > 0 &&
+            !message.messageState.startsWith("revoked") && (
+              <ReactionBadges
+                reactions={message.reactions}
+                myMid={self?.mid ?? ""}
+                onReact={react}
+                side={isMe ? "right" : "left"}
+              />
+            )}
         </div>
 
         {menu && (
@@ -1209,6 +1254,54 @@ export const MessageBubble = memo(
             kind={message.kind === "video" ? "video" : "image"}
             onClose={() => setLightbox(false)}
           />
+        )}
+        {showHistory && (
+          <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+            onClick={(e) => {
+              if (e.target === e.currentTarget) setShowHistory(false);
+            }}
+          >
+            <div className="max-h-[80vh] w-[360px] overflow-y-auto rounded-xl border border-[var(--vy-border)] bg-[var(--vy-surface)] p-4 shadow-xl">
+              <div className="mb-3 flex items-center justify-between">
+                <h3 className="text-sm font-semibold">メッセージ履歴</h3>
+                <button
+                  type="button"
+                  onClick={() => setShowHistory(false)}
+                  className="rounded p-1 hover:bg-[var(--vy-surface-2)]"
+                >
+                  ✕
+                </button>
+              </div>
+              {historyLoading && <p className="text-xs text-[var(--vy-text-dim)]">読み込み中...</p>}
+              {!historyLoading && history.length === 0 && (
+                <p className="text-xs text-[var(--vy-text-dim)]">履歴がありません</p>
+              )}
+              {!historyLoading &&
+                history.map((entry, i) => (
+                  <div
+                    key={i}
+                    className="mb-2 rounded-lg border border-[var(--vy-border)] bg-[var(--vy-surface-2)] p-2.5"
+                  >
+                    <div className="mb-1 flex items-center gap-2 text-[0.65rem] text-[var(--vy-text-dim)]">
+                      <span className="rounded bg-[color-mix(in_oklab,var(--vy-text)_10%,transparent)] px-1.5 py-0.5">
+                        {entry.state === "normal"
+                          ? "通常"
+                          : entry.state === "edited"
+                            ? "編集済み"
+                            : entry.state === "revoked-by-other"
+                              ? "相手が削除"
+                              : "自分が削除"}
+                      </span>
+                      <span>{new Date(entry.updatedTime).toLocaleString()}</span>
+                    </div>
+                    <p className="whitespace-pre-wrap break-words text-sm">
+                      {entry.text ?? <span className="italic opacity-60">（なし）</span>}
+                    </p>
+                  </div>
+                ))}
+            </div>
+          </div>
         )}
       </div>
     );

--- a/Vyline/apps/desktop/src/components/message-bubble.tsx
+++ b/Vyline/apps/desktop/src/components/message-bubble.tsx
@@ -334,6 +334,12 @@ function stickerAnimationUrl(url: string): string {
   return u;
 }
 
+function isStickerImageSrc(src?: string): boolean {
+  return Boolean(
+    src && (src.startsWith("http") || src.startsWith("/api/") || src.startsWith("data:")),
+  );
+}
+
 // MessageReactionType → 表示絵文字（LINE 公式: NICE=2 LOVE=3 FUN=4 AMAZING=5 SAD=6 OMG=7）
 export const REACTION_EMOJI: Record<number, string> = {
   2: "👍",
@@ -1010,11 +1016,14 @@ export const MessageBubble = memo(
                   くっつき
                 </span>
               )}
-              {message.sticker &&
-              (message.sticker.startsWith("http") || message.sticker.startsWith("/api/")) ? (
+              {isStickerImageSrc(message.sticker) ? (
                 <img
                   src={
-                    message.stickerAnimated ? stickerAnimationUrl(message.sticker) : message.sticker
+                    message.sticker
+                      ? message.stickerAnimated
+                        ? stickerAnimationUrl(message.sticker)
+                        : message.sticker
+                      : ""
                   }
                   alt="スタンプ"
                   onError={hideBrokenMedia}
@@ -1025,7 +1034,7 @@ export const MessageBubble = memo(
                   draggable={false}
                 />
               ) : (
-                <span className="text-7xl leading-none">{message.sticker || "🎴"}</span>
+                <span className="text-7xl leading-none">{message.sticker || "🧩"}</span>
               )}
             </button>
           ) : message.kind === "emoji" ? (

--- a/Vyline/apps/desktop/src/components/message-input.tsx
+++ b/Vyline/apps/desktop/src/components/message-input.tsx
@@ -2,6 +2,7 @@ import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useStore } from "@/lib/store";
 import { cn } from "@/lib/utils";
 import { api } from "@/api/client";
+import { compressImageFile } from "@/utils/compressImage";
 import {
   IconSend,
   IconSmile,
@@ -95,12 +96,74 @@ function detectMentionTrigger(
   return null;
 }
 
+async function blobToBase64(blob: Blob): Promise<string> {
+  const bytes = new Uint8Array(await blob.arrayBuffer());
+  let binary = "";
+  const chunk = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunk));
+  }
+  return btoa(binary);
+}
+
+async function composeImageGrid(files: Blob[]): Promise<Blob> {
+  const bitmaps = await Promise.all(files.map((file) => createImageBitmap(file)));
+  try {
+    const count = bitmaps.length;
+    const cols = count <= 1 ? 1 : count === 2 ? 2 : count <= 4 ? 2 : count <= 9 ? 3 : 4;
+    const rows = Math.ceil(count / cols);
+    const candidates = [720, 640, 512, 384];
+
+    for (const cellSize of candidates) {
+      const canvas = document.createElement("canvas");
+      canvas.width = cols * cellSize;
+      canvas.height = rows * cellSize;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) continue;
+
+      ctx.fillStyle = "#ffffff";
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+      for (let index = 0; index < bitmaps.length; index++) {
+        const bitmap = bitmaps[index]!;
+        const col = index % cols;
+        const row = Math.floor(index / cols);
+        const slotX = col * cellSize;
+        const slotY = row * cellSize;
+        const padding = Math.max(12, Math.round(cellSize * 0.04));
+        const slotWidth = cellSize - padding * 2;
+        const slotHeight = cellSize - padding * 2;
+        const scale = Math.min(slotWidth / bitmap.width, slotHeight / bitmap.height);
+        const drawWidth = Math.max(1, Math.round(bitmap.width * scale));
+        const drawHeight = Math.max(1, Math.round(bitmap.height * scale));
+        const drawX = slotX + Math.round((cellSize - drawWidth) / 2);
+        const drawY = slotY + Math.round((cellSize - drawHeight) / 2);
+        ctx.drawImage(bitmap, drawX, drawY, drawWidth, drawHeight);
+      }
+
+      const blob = await new Promise<Blob | null>((resolve) =>
+        canvas.toBlob(resolve, "image/jpeg", 0.9),
+      );
+      if (blob && blob.size > 0 && blob.size <= 11_000_000) {
+        return blob;
+      }
+      if (blob && blob.size > 0 && cellSize === candidates.at(-1)) {
+        return blob;
+      }
+    }
+
+    throw new Error("画像の結合に失敗しました");
+  } finally {
+    for (const bitmap of bitmaps) bitmap.close();
+  }
+}
+
 export function MessageInput({ chatId }: { chatId: string }) {
   const draft = useStore((s) => s.drafts[chatId] ?? "");
   const setDraft = useStore((s) => s.setDraft);
   const sendMessage = useStore((s) => s.sendMessage);
   const sendSticker = useStore((s) => s.sendSticker);
-  const sendImageFile = useStore((s) => s.sendImageFile);
+  const sendCombinationSticker = useStore((s) => s.sendCombinationSticker);
   const sendAudio = useStore((s) => s.sendAudio);
   const accountId = useStore((s) => s.accountId);
   const enterToSend = useStore((s) => s.settings.enterToSend);
@@ -126,6 +189,15 @@ export function MessageInput({ chatId }: { chatId: string }) {
   const [mentionPicker, setMentionPicker] = useState<{ start: number; query: string } | null>(null);
   const [mentionIndex, setMentionIndex] = useState(0);
   const taRef = useRef<HTMLTextAreaElement>(null);
+  const [pendingMedia, setPendingMedia] = useState<
+    Array<{
+      id: string;
+      file: File;
+      url: string;
+      kind: "image" | "video";
+    }>
+  >([]);
+  const [sendingMediaBatch, setSendingMediaBatch] = useState(false);
 
   // 画像送信中かどうか（楽観メッセージの pending image を検出）
   const sendingImage = messages.some(
@@ -138,6 +210,11 @@ export function MessageInput({ chatId }: { chatId: string }) {
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const audioChunksRef = useRef<Blob[]>([]);
   const streamRef = useRef<MediaStream | null>(null);
+
+  useEffect(() => {
+    for (const item of pendingMedia) URL.revokeObjectURL(item.url);
+    setPendingMedia([]);
+  }, [chatId]);
 
   // ￼ プレースホルダの実幅（1em 比）を計測し、絵文字画像を同じ幅に描画する。
   // オーバーレイと textarea の折返し位置・キャレットを一致させるため。1em 固定だとフォント fallback 時にズレる。
@@ -295,6 +372,107 @@ export function MessageInput({ chatId }: { chatId: string }) {
     recorder.stop();
   }
 
+  function addPendingFiles(files: File[]) {
+    const targets = files.filter(
+      (file) => file.type.startsWith("image/") || file.type.startsWith("video/"),
+    );
+    if (targets.length === 0) return;
+    setPendingMedia((prev) => [
+      ...prev,
+      ...targets.map((file) => ({
+        id: `pending_media_${Date.now()}_${Math.random().toString(16).slice(2)}`,
+        file,
+        url: URL.createObjectURL(file),
+        kind: (file.type.startsWith("video/") ? "video" : "image") as "video" | "image",
+      })),
+    ]);
+  }
+
+  function removePendingMedia(id: string) {
+    setPendingMedia((prev) => {
+      const hit = prev.find((item) => item.id === id);
+      if (hit) URL.revokeObjectURL(hit.url);
+      return prev.filter((item) => item.id !== id);
+    });
+  }
+
+  function clearPendingMedia() {
+    setPendingMedia((prev) => {
+      for (const item of prev) URL.revokeObjectURL(item.url);
+      return [];
+    });
+  }
+
+  async function sendPendingMedia() {
+    if (sendingMediaBatch || pendingMedia.length === 0 || !accountId) return;
+    setSendingMediaBatch(true);
+    try {
+      const highQuality = useStore.getState().settings.highQualityImages;
+      const allImages = pendingMedia.every((item) => item.kind === "image");
+
+      if (allImages && pendingMedia.length > 1) {
+        const preparedImages = await Promise.all(
+          pendingMedia.map(async (item) => {
+            const prepared = highQuality
+              ? { blob: item.file, mime: item.file.type || "image/jpeg" }
+              : await compressImageFile(item.file);
+            if (!prepared.mime.startsWith("image/")) {
+              throw new Error(`画像として扱えないファイルです: ${item.file.name}`);
+            }
+            return prepared.blob;
+          }),
+        );
+        const mergedBlob = await composeImageGrid(preparedImages);
+        const dataBase64 = await blobToBase64(mergedBlob);
+        const res = await api.line.sendMedia(accountId, chatId, dataBase64, {
+          mimeType: "image/jpeg",
+          filename: `vyline-images-${pendingMedia.length}.jpg`,
+          mediaType: "image",
+        });
+        if (!res.ok) {
+          window.alert(res.error ?? "画像のまとめ送信に失敗しました");
+          return;
+        }
+      } else {
+        const items = await Promise.all(
+          pendingMedia.map(async (item) => {
+            const prepared =
+              item.kind === "video"
+                ? { blob: item.file, mime: item.file.type || "application/octet-stream" }
+                : highQuality
+                  ? { blob: item.file, mime: item.file.type || "application/octet-stream" }
+                  : await compressImageFile(item.file);
+            if (prepared.blob.size > 11_000_000) {
+              throw new Error(
+                prepared.blob === item.file
+                  ? `ファイルが大きすぎます: ${item.file.name}`
+                  : `画像が大きすぎます（圧縮後も 11MB 超）: ${item.file.name}`,
+              );
+            }
+            const dataBase64 = await blobToBase64(prepared.blob);
+            return {
+              dataBase64,
+              mimeType: prepared.mime,
+              filename: item.file.name || (item.kind === "video" ? "video.mp4" : "image.jpg"),
+              mediaType: item.kind,
+            };
+          }),
+        );
+        const res = await api.line.sendMediaBatch(accountId, chatId, items);
+        if (!res.ok) {
+          window.alert(res.error ?? "まとめて送信に失敗しました");
+          return;
+        }
+      }
+      clearPendingMedia();
+      await useStore.getState().refreshMessages(chatId, { force: true });
+    } catch (err) {
+      window.alert(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSendingMediaBatch(false);
+    }
+  }
+
   useEffect(() => {
     const ta = taRef.current;
     if (!ta) return;
@@ -385,14 +563,18 @@ export function MessageInput({ chatId }: { chatId: string }) {
     }
     if (e.key === "Enter" && !e.shiftKey && enterToSend && !composing) {
       e.preventDefault();
+      if (!draft.trim() && pendingMedia.length > 0) {
+        void sendPendingMedia();
+        return;
+      }
       send();
     }
   }
 
   function onFileChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const file = e.target.files?.[0];
-    if (file) {
-      void sendImageFile(chatId, file);
+    const files = Array.from(e.target.files ?? []);
+    if (files.length > 0) {
+      addPendingFiles(files);
       e.target.value = "";
     }
   }
@@ -401,16 +583,16 @@ export function MessageInput({ chatId }: { chatId: string }) {
     // クリップボードに画像があれば優先して画像として送信する（テキスト貼り付けは従来通り）
     const items = e.clipboardData?.items;
     if (!items || items.length === 0) return;
-    let file: File | null = null;
+    const files: File[] = [];
     for (const item of items) {
       if (item.kind === "file" && item.type.startsWith("image/")) {
-        file = item.getAsFile();
-        if (file) break;
+        const file = item.getAsFile();
+        if (file) files.push(file);
       }
     }
-    if (file) {
+    if (files.length > 0) {
       e.preventDefault();
-      void sendImageFile(chatId, file);
+      addPendingFiles(files);
     }
   }
 
@@ -465,12 +647,20 @@ export function MessageInput({ chatId }: { chatId: string }) {
       onDrop={(e) => {
         // スタンプ画像等のドロップでブラウザがナビゲート/URL挿入するのを防ぐ
         e.preventDefault();
+        if (e.dataTransfer.types.includes("application/x-vyline-sticker")) return;
+        const files = Array.from(e.dataTransfer.files ?? []).filter(
+          (file) => file.type.startsWith("image/") || file.type.startsWith("video/"),
+        );
+        if (files.length > 0) {
+          addPendingFiles(files);
+        }
       }}
     >
       <input
         ref={fileRef}
         type="file"
         accept="image/*,video/*"
+        multiple
         className="hidden"
         aria-hidden
         onChange={onFileChange}
@@ -485,8 +675,17 @@ export function MessageInput({ chatId }: { chatId: string }) {
           onPickEmoji={(packageId, sticonId) => {
             insertLineEmoji(packageId, sticonId);
           }}
-          onPickUnicode={(glyph) => {
-            insertAtCursor(glyph);
+          onSendCombinationSticker={async (
+            items: Array<{
+              packageId: string;
+              stickerId: string;
+              x?: number;
+              y?: number;
+              size?: number;
+            }>,
+          ) => {
+            await sendCombinationSticker(chatId, items);
+            setPicker(false);
           }}
         />
       )}
@@ -558,6 +757,61 @@ export function MessageInput({ chatId }: { chatId: string }) {
         </div>
       ) : (
         <>
+          {pendingMedia.length > 0 && (
+            <div className="vy-fade-in mb-2 rounded-2xl border border-[var(--vy-border)] bg-[var(--vy-surface)] p-2 shadow-sm">
+              <div className="mb-2 flex items-center justify-between gap-2 px-1">
+                <div className="text-xs font-medium text-[var(--vy-text-dim)]">
+                  {pendingMedia.length} 件のメディアを待機中
+                </div>
+                <button
+                  type="button"
+                  onClick={clearPendingMedia}
+                  className="text-xs text-[var(--vy-text-dim)] transition-colors hover:text-[var(--vy-text)]"
+                >
+                  クリア
+                </button>
+              </div>
+              <div className="grid max-h-56 grid-cols-3 gap-2 overflow-y-auto sm:grid-cols-4 md:grid-cols-5">
+                {pendingMedia.map((item) => (
+                  <div
+                    key={item.id}
+                    className="group relative overflow-hidden rounded-xl border border-[var(--vy-border)] bg-[var(--vy-surface-2)]"
+                  >
+                    {item.kind === "video" ? (
+                      <video src={item.url} className="h-24 w-full object-cover" muted />
+                    ) : (
+                      <img src={item.url} alt="" className="h-24 w-full object-cover" />
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => removePendingMedia(item.id)}
+                      className="absolute right-1 top-1 rounded-full bg-black/55 p-1 text-white opacity-90 transition hover:bg-black/75"
+                      aria-label="添付を削除"
+                    >
+                      <IconClose size={12} />
+                    </button>
+                  </div>
+                ))}
+              </div>
+              <div className="mt-2 flex items-center justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={clearPendingMedia}
+                  className="rounded-full border border-[var(--vy-border)] px-3 py-1 text-xs text-[var(--vy-text-dim)] transition-colors hover:bg-[var(--vy-surface-2)]"
+                >
+                  キャンセル
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void sendPendingMedia()}
+                  disabled={sendingMediaBatch}
+                  className="rounded-full bg-[var(--vy-accent)] px-4 py-1 text-xs font-semibold text-[var(--vy-accent-contrast)] disabled:opacity-60"
+                >
+                  {sendingMediaBatch ? "送信中…" : "まとめて送信"}
+                </button>
+              </div>
+            </div>
+          )}
           {mentionPicker && mentionOptions.length > 0 && (
             <div className="mb-1.5 max-h-52 overflow-y-auto rounded-xl border border-[var(--vy-border)] bg-[var(--vy-surface)] py-1 shadow-lg">
               <p className="px-3 py-1.5 text-[0.65rem] font-medium text-[var(--vy-text-dim)]">

--- a/Vyline/apps/desktop/src/components/message-input.tsx
+++ b/Vyline/apps/desktop/src/components/message-input.tsx
@@ -106,58 +106,6 @@ async function blobToBase64(blob: Blob): Promise<string> {
   return btoa(binary);
 }
 
-async function composeImageGrid(files: Blob[]): Promise<Blob> {
-  const bitmaps = await Promise.all(files.map((file) => createImageBitmap(file)));
-  try {
-    const count = bitmaps.length;
-    const cols = count <= 1 ? 1 : count === 2 ? 2 : count <= 4 ? 2 : count <= 9 ? 3 : 4;
-    const rows = Math.ceil(count / cols);
-    const candidates = [720, 640, 512, 384];
-
-    for (const cellSize of candidates) {
-      const canvas = document.createElement("canvas");
-      canvas.width = cols * cellSize;
-      canvas.height = rows * cellSize;
-      const ctx = canvas.getContext("2d");
-      if (!ctx) continue;
-
-      ctx.fillStyle = "#ffffff";
-      ctx.fillRect(0, 0, canvas.width, canvas.height);
-
-      for (let index = 0; index < bitmaps.length; index++) {
-        const bitmap = bitmaps[index]!;
-        const col = index % cols;
-        const row = Math.floor(index / cols);
-        const slotX = col * cellSize;
-        const slotY = row * cellSize;
-        const padding = Math.max(12, Math.round(cellSize * 0.04));
-        const slotWidth = cellSize - padding * 2;
-        const slotHeight = cellSize - padding * 2;
-        const scale = Math.min(slotWidth / bitmap.width, slotHeight / bitmap.height);
-        const drawWidth = Math.max(1, Math.round(bitmap.width * scale));
-        const drawHeight = Math.max(1, Math.round(bitmap.height * scale));
-        const drawX = slotX + Math.round((cellSize - drawWidth) / 2);
-        const drawY = slotY + Math.round((cellSize - drawHeight) / 2);
-        ctx.drawImage(bitmap, drawX, drawY, drawWidth, drawHeight);
-      }
-
-      const blob = await new Promise<Blob | null>((resolve) =>
-        canvas.toBlob(resolve, "image/jpeg", 0.9),
-      );
-      if (blob && blob.size > 0 && blob.size <= 11_000_000) {
-        return blob;
-      }
-      if (blob && blob.size > 0 && cellSize === candidates.at(-1)) {
-        return blob;
-      }
-    }
-
-    throw new Error("画像の結合に失敗しました");
-  } finally {
-    for (const bitmap of bitmaps) bitmap.close();
-  }
-}
-
 export function MessageInput({ chatId }: { chatId: string }) {
   const draft = useStore((s) => s.drafts[chatId] ?? "");
   const setDraft = useStore((s) => s.setDraft);
@@ -408,61 +356,34 @@ export function MessageInput({ chatId }: { chatId: string }) {
     setSendingMediaBatch(true);
     try {
       const highQuality = useStore.getState().settings.highQualityImages;
-      const allImages = pendingMedia.every((item) => item.kind === "image");
-
-      if (allImages && pendingMedia.length > 1) {
-        const preparedImages = await Promise.all(
-          pendingMedia.map(async (item) => {
-            const prepared = highQuality
-              ? { blob: item.file, mime: item.file.type || "image/jpeg" }
-              : await compressImageFile(item.file);
-            if (!prepared.mime.startsWith("image/")) {
-              throw new Error(`画像として扱えないファイルです: ${item.file.name}`);
-            }
-            return prepared.blob;
-          }),
-        );
-        const mergedBlob = await composeImageGrid(preparedImages);
-        const dataBase64 = await blobToBase64(mergedBlob);
-        const res = await api.line.sendMedia(accountId, chatId, dataBase64, {
-          mimeType: "image/jpeg",
-          filename: `vyline-images-${pendingMedia.length}.jpg`,
-          mediaType: "image",
-        });
-        if (!res.ok) {
-          window.alert(res.error ?? "画像のまとめ送信に失敗しました");
-          return;
-        }
-      } else {
-        const items = await Promise.all(
-          pendingMedia.map(async (item) => {
-            const prepared =
-              item.kind === "video"
+      const items = await Promise.all(
+        pendingMedia.map(async (item) => {
+          const prepared =
+            item.kind === "video"
+              ? { blob: item.file, mime: item.file.type || "application/octet-stream" }
+              : highQuality
                 ? { blob: item.file, mime: item.file.type || "application/octet-stream" }
-                : highQuality
-                  ? { blob: item.file, mime: item.file.type || "application/octet-stream" }
-                  : await compressImageFile(item.file);
-            if (prepared.blob.size > 11_000_000) {
-              throw new Error(
-                prepared.blob === item.file
-                  ? `ファイルが大きすぎます: ${item.file.name}`
-                  : `画像が大きすぎます（圧縮後も 11MB 超）: ${item.file.name}`,
-              );
-            }
-            const dataBase64 = await blobToBase64(prepared.blob);
-            return {
-              dataBase64,
-              mimeType: prepared.mime,
-              filename: item.file.name || (item.kind === "video" ? "video.mp4" : "image.jpg"),
-              mediaType: item.kind,
-            };
-          }),
-        );
-        const res = await api.line.sendMediaBatch(accountId, chatId, items);
-        if (!res.ok) {
-          window.alert(res.error ?? "まとめて送信に失敗しました");
-          return;
-        }
+                : await compressImageFile(item.file);
+          if (prepared.blob.size > 11_000_000) {
+            throw new Error(
+              prepared.blob === item.file
+                ? `ファイルが大きすぎます: ${item.file.name}`
+                : `画像が大きすぎます（圧縮後も 11MB 超）: ${item.file.name}`,
+            );
+          }
+          const dataBase64 = await blobToBase64(prepared.blob);
+          return {
+            dataBase64,
+            mimeType: prepared.mime,
+            filename: item.file.name || (item.kind === "video" ? "video.mp4" : "image.jpg"),
+            mediaType: item.kind,
+          };
+        }),
+      );
+      const res = await api.line.sendMediaBatch(accountId, chatId, items);
+      if (!res.ok) {
+        window.alert(res.error ?? "まとめて送信に失敗しました");
+        return;
       }
       clearPendingMedia();
       await useStore.getState().refreshMessages(chatId, { force: true });

--- a/Vyline/apps/desktop/src/components/message-input.tsx
+++ b/Vyline/apps/desktop/src/components/message-input.tsx
@@ -17,15 +17,16 @@ import { segmentTextWithSticon, type SticonResource } from "@/utils/lineSticon";
 import { buildMentionMetadata, recomputeMentionsOnEdit } from "@/utils/mention";
 import { mapMember } from "@/lib/mappers";
 import { PlusMenu } from "@/components/plus-menu";
+import type { MessageState } from "@/lib/store-types";
 
 function replyPreviewText(msg: {
   kind: string;
   text?: string;
   altText?: string;
   sticker?: string;
-  revoked?: boolean;
+  messageState?: MessageState;
 }): string {
-  if (msg.revoked) return "取り消されたメッセージ";
+  if (msg.messageState?.startsWith("revoked")) return "取り消されたメッセージ";
   if (msg.kind === "image") return "写真";
   if (msg.kind === "video") return "動画";
   if (msg.kind === "audio") return "音声メッセージ";

--- a/Vyline/apps/desktop/src/components/message-input.tsx
+++ b/Vyline/apps/desktop/src/components/message-input.tsx
@@ -656,7 +656,7 @@ export function MessageInput({ chatId }: { chatId: string }) {
                     ? undefined
                     : muteNext
                       ? "メッセージを入力（ミュート送信: 通知なし）"
-                      : "メッセージを入力（絵文字は文中に挿入）"
+                      : "メッセージを入力"
                 }
                 aria-label="メッセージを入力"
                 className={cn(

--- a/Vyline/apps/desktop/src/components/premium-badge.tsx
+++ b/Vyline/apps/desktop/src/components/premium-badge.tsx
@@ -1,0 +1,30 @@
+import { cn } from "@/lib/utils";
+
+export function PremiumBadge({
+  className,
+  size = 14,
+  compact = false,
+}: {
+  className?: string;
+  size?: number;
+  compact?: boolean;
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex shrink-0 items-center justify-center rounded-full font-bold text-white shadow-sm",
+        className,
+      )}
+      style={{
+        width: size,
+        height: size,
+        background: "linear-gradient(145deg, #a855f7, #6d28d9)",
+        fontSize: Math.max(8, size * 0.56),
+      }}
+      aria-label="LYP Premium"
+      title="LYP Premium"
+    >
+      {compact ? "" : "P"}
+    </span>
+  );
+}

--- a/Vyline/apps/desktop/src/components/profile-drawer.tsx
+++ b/Vyline/apps/desktop/src/components/profile-drawer.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useStore, displayName, commonGroupsWith, type Chat } from "@/lib/store";
 import { api } from "@/api/client";
 import { Avatar } from "@/components/vy-ui";
+import { PremiumBadge } from "@/components/premium-badge";
 import {
   IconClose,
   IconChat,
@@ -15,7 +16,6 @@ import {
   IconMemo,
 } from "@/components/icons";
 import { looksLikeMid, mapMember } from "@/lib/mappers";
-import { parseMusicProfile } from "@/lib/vyline-cache";
 import { dismissChatMid } from "@/utils/dismissedChats";
 
 type RichInfo = {
@@ -29,25 +29,6 @@ type RichInfo = {
   userType?: number;
 };
 
-function InfoItem({
-  label,
-  value,
-  mono,
-}: {
-  label: string;
-  value: string;
-  mono?: boolean;
-}) {
-  return (
-    <div className="rounded-lg border border-[var(--vy-border)] bg-[var(--vy-surface-2)] px-3 py-2">
-      <p className="text-[0.65rem] font-medium text-[var(--vy-text-dim)]">{label}</p>
-      <p className={mono ? "mt-1 font-mono text-xs break-all" : "mt-1 text-xs break-words"}>
-        {value}
-      </p>
-    </div>
-  );
-}
-
 export function ProfileDrawer({ chat }: { chat: Chat }) {
   const setProfileDrawer = useStore((s) => s.setProfileDrawer);
   const openChat = useStore((s) => s.openChat);
@@ -58,6 +39,7 @@ export function ProfileDrawer({ chat }: { chat: Chat }) {
   const settings = useStore((s) => s.settings);
   const setLocalName = useStore((s) => s.setLocalName);
   const accountId = useStore((s) => s.accountId);
+  const selfPremium = useStore((s) => s.self.premium?.active ?? false);
 
   const [editing, setEditing] = useState(false);
   const [nameInput, setNameInput] = useState(chat.localName ?? chat.name);
@@ -247,7 +229,6 @@ export function ProfileDrawer({ chat }: { chat: Chat }) {
   }, [accountId, chat.id, chat.type, streamerMode, chat.isSelf]);
 
   const name = displayName(chat, streamerMode);
-  const music = parseMusicProfile(rich.musicProfile);
   const backgroundUrl = chat.backgroundUrl ?? rich.backgroundUrl;
   const showBackground = Boolean(!streamerMode && settings.showBackground && backgroundUrl);
 
@@ -437,8 +418,7 @@ export function ProfileDrawer({ chat }: { chat: Chat }) {
               style={
                 showBackground
                   ? {
-                      backgroundImage:
-                        `linear-gradient(180deg, color-mix(in oklab, black 8%, transparent), color-mix(in oklab, black 20%, transparent)), url(${backgroundUrl})`,
+                      backgroundImage: `linear-gradient(180deg, color-mix(in oklab, black 8%, transparent), color-mix(in oklab, black 20%, transparent)), url(${backgroundUrl})`,
                       backgroundSize: "cover",
                       backgroundPosition: "center",
                     }
@@ -476,6 +456,7 @@ export function ProfileDrawer({ chat }: { chat: Chat }) {
               ) : (
                 <div className="mt-3 flex items-center gap-2">
                   <h2 className="text-xl font-bold">{name}</h2>
+                  {chat.isSelf && selfPremium && <PremiumBadge size={14} compact />}
                   {!streamerMode && !chat.isSelf && (
                     <button
                       type="button"
@@ -513,19 +494,11 @@ export function ProfileDrawer({ chat }: { chat: Chat }) {
             </div>
           </div>
 
-          {!streamerMode && (
-            <div className="mt-4 space-y-3 rounded-xl border border-[var(--vy-border)] px-3 py-2.5 text-sm">
-              {music && (
-                <InfoItem
-                  label="音楽"
-                  value={`${music.title || music.raw}${music.artist ? ` — ${music.artist}` : ""}`}
-                />
-              )}
-              {(chat.isOfficial || rich.userType === 2) && (
-                <span className="inline-flex w-fit items-center rounded-full bg-[color-mix(in_oklab,var(--vy-accent)_16%,transparent)] px-2.5 py-1 text-xs font-medium text-[var(--vy-accent)]">
-                  公式アカウント
-                </span>
-              )}
+          {!streamerMode && (chat.isOfficial || rich.userType === 2) && (
+            <div className="mt-4">
+              <span className="inline-flex w-fit items-center rounded-full bg-[color-mix(in_oklab,var(--vy-accent)_16%,transparent)] px-2.5 py-1 text-xs font-medium text-[var(--vy-accent)]">
+                公式アカウント
+              </span>
             </div>
           )}
 

--- a/Vyline/apps/desktop/src/components/profile-drawer.tsx
+++ b/Vyline/apps/desktop/src/components/profile-drawer.tsx
@@ -20,10 +20,33 @@ import { dismissChatMid } from "@/utils/dismissedChats";
 
 type RichInfo = {
   statusMessage?: string;
+  phoneticName?: string;
   musicProfile?: string;
   birthday?: string;
   backgroundUrl?: string;
+  pictureStatus?: string;
+  profileId?: string;
+  userType?: number;
 };
+
+function InfoItem({
+  label,
+  value,
+  mono,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className="rounded-lg border border-[var(--vy-border)] bg-[var(--vy-surface-2)] px-3 py-2">
+      <p className="text-[0.65rem] font-medium text-[var(--vy-text-dim)]">{label}</p>
+      <p className={mono ? "mt-1 font-mono text-xs break-all" : "mt-1 text-xs break-words"}>
+        {value}
+      </p>
+    </div>
+  );
+}
 
 export function ProfileDrawer({ chat }: { chat: Chat }) {
   const setProfileDrawer = useStore((s) => s.setProfileDrawer);
@@ -144,19 +167,27 @@ export function ProfileDrawer({ chat }: { chat: Chat }) {
           ok: boolean;
           profile?: {
             statusMessage?: string;
+            phoneticName?: string;
             musicProfile?: string;
             birthday?: { display?: string };
             backgroundUrl?: string;
             displayName?: string;
             thumbnailUrl?: string;
+            pictureStatus?: string;
+            profileId?: string;
+            userType?: number;
           };
         };
         if (!r.profile) return;
         setRich({
           statusMessage: r.profile.statusMessage,
+          phoneticName: r.profile.phoneticName,
           musicProfile: r.profile.musicProfile,
           birthday: r.profile.birthday?.display,
           backgroundUrl: r.profile.backgroundUrl,
+          pictureStatus: r.profile.pictureStatus,
+          profileId: r.profile.profileId,
+          userType: r.profile.userType,
         });
         const nextName =
           r.profile.displayName && !looksLikeMid(r.profile.displayName)
@@ -217,6 +248,8 @@ export function ProfileDrawer({ chat }: { chat: Chat }) {
 
   const name = displayName(chat, streamerMode);
   const music = parseMusicProfile(rich.musicProfile);
+  const backgroundUrl = chat.backgroundUrl ?? rich.backgroundUrl;
+  const showBackground = Boolean(!streamerMode && settings.showBackground && backgroundUrl);
 
   const handleTalk = () => {
     if (chat.type === "friend") {
@@ -402,11 +435,10 @@ export function ProfileDrawer({ chat }: { chat: Chat }) {
             <div
               className="h-28 bg-[color-mix(in_oklab,var(--vy-accent)_18%,var(--vy-surface-2))]"
               style={
-                !streamerMode &&
-                settings.showBackground &&
-                (chat.backgroundUrl ?? rich.backgroundUrl)
+                showBackground
                   ? {
-                      backgroundImage: `url(${rich.backgroundUrl})`,
+                      backgroundImage:
+                        `linear-gradient(180deg, color-mix(in oklab, black 8%, transparent), color-mix(in oklab, black 20%, transparent)), url(${backgroundUrl})`,
                       backgroundSize: "cover",
                       backgroundPosition: "center",
                     }
@@ -481,20 +513,18 @@ export function ProfileDrawer({ chat }: { chat: Chat }) {
             </div>
           </div>
 
-          {!streamerMode && (music || rich.birthday) && (
-            <div className="mt-4 space-y-2 rounded-xl border border-[var(--vy-border)] px-3 py-2.5 text-sm">
+          {!streamerMode && (
+            <div className="mt-4 space-y-3 rounded-xl border border-[var(--vy-border)] px-3 py-2.5 text-sm">
               {music && (
-                <p>
-                  <span className="text-[var(--vy-text-dim)]">音楽 · </span>
-                  {music.title || music.raw}
-                  {music.artist ? ` — ${music.artist}` : ""}
-                </p>
+                <InfoItem
+                  label="音楽"
+                  value={`${music.title || music.raw}${music.artist ? ` — ${music.artist}` : ""}`}
+                />
               )}
-              {rich.birthday && (
-                <p>
-                  <span className="text-[var(--vy-text-dim)]">誕生日 · </span>
-                  {rich.birthday}
-                </p>
+              {(chat.isOfficial || rich.userType === 2) && (
+                <span className="inline-flex w-fit items-center rounded-full bg-[color-mix(in_oklab,var(--vy-accent)_16%,transparent)] px-2.5 py-1 text-xs font-medium text-[var(--vy-accent)]">
+                  公式アカウント
+                </span>
               )}
             </div>
           )}

--- a/Vyline/apps/desktop/src/components/settings-sections.tsx
+++ b/Vyline/apps/desktop/src/components/settings-sections.tsx
@@ -1030,7 +1030,7 @@ function StorageSection() {
           icon={<IconDownload size={20} className="text-[var(--vy-accent)]" />}
           iconBg="bg-[color-mix(in_oklab,var(--vy-accent)_18%,var(--vy-surface-2))]"
           onDelete={() =>
-            clearType("CDN キャッシュ", () => api.line.clearVylineCdnCache(accountId))
+            clearType("CDN キャッシュ", () => api.line.clearVylineCdnCache(accountId!))
           }
           disabled={loading || !accountId}
         />
@@ -1041,7 +1041,7 @@ function StorageSection() {
           icon={<IconDownload size={20} className="text-[var(--vy-accent)]" />}
           iconBg="bg-[color-mix(in_oklab,var(--vy-accent)_18%,var(--vy-surface-2))]"
           onDelete={() =>
-            clearType("アイコンキャッシュ", () => api.line.clearVylineIconCache(accountId))
+            clearType("アイコンキャッシュ", () => api.line.clearVylineIconCache(accountId!))
           }
           disabled={loading || !accountId}
         />
@@ -1052,7 +1052,7 @@ function StorageSection() {
           icon={<IconDownload size={20} className="text-[#3b82f6]" />}
           iconBg="bg-[color-mix(in_oklab,#3b82f6_18%,var(--vy-surface-2))]"
           onDelete={() =>
-            clearType("保存画像", () => api.line.clearVylineSavedMediaType(accountId, "image"))
+            clearType("保存画像", () => api.line.clearVylineSavedMediaType(accountId!, "image"))
           }
           disabled={loading || !accountId}
         />
@@ -1063,7 +1063,7 @@ function StorageSection() {
           icon={<IconDownload size={20} className="text-[#a855f7]" />}
           iconBg="bg-[color-mix(in_oklab,#a855f7_18%,var(--vy-surface-2))]"
           onDelete={() =>
-            clearType("保存動画", () => api.line.clearVylineSavedMediaType(accountId, "video"))
+            clearType("保存動画", () => api.line.clearVylineSavedMediaType(accountId!, "video"))
           }
           disabled={loading || !accountId}
         />
@@ -1074,7 +1074,7 @@ function StorageSection() {
           icon={<IconDownload size={20} className="text-[#22c55e]" />}
           iconBg="bg-[color-mix(in_oklab,#22c55e_18%,var(--vy-surface-2))]"
           onDelete={() =>
-            clearType("保存音声", () => api.line.clearVylineSavedMediaType(accountId, "audio"))
+            clearType("保存音声", () => api.line.clearVylineSavedMediaType(accountId!, "audio"))
           }
           disabled={loading || !accountId}
         />
@@ -1085,7 +1085,7 @@ function StorageSection() {
           icon={<IconDownload size={20} className="text-[#6b7280]" />}
           iconBg="bg-[color-mix(in_oklab,#6b7280_18%,var(--vy-surface-2))]"
           onDelete={() =>
-            clearType("保存ファイル", () => api.line.clearVylineSavedMediaType(accountId, "file"))
+            clearType("保存ファイル", () => api.line.clearVylineSavedMediaType(accountId!, "file"))
           }
           disabled={loading || !accountId}
         />

--- a/Vyline/apps/desktop/src/components/settings-sections.tsx
+++ b/Vyline/apps/desktop/src/components/settings-sections.tsx
@@ -95,25 +95,6 @@ function Card({ children }: { children: React.ReactNode }) {
   );
 }
 
-function SettingMeta({
-  label,
-  value,
-  mono,
-}: {
-  label: string;
-  value: string;
-  mono?: boolean;
-}) {
-  return (
-    <div className="rounded-xl border border-[var(--vy-border)] bg-[var(--vy-surface-2)] px-3 py-2">
-      <p className="text-[0.65rem] font-medium text-[var(--vy-text-dim)]">{label}</p>
-      <p className={mono ? "mt-1 font-mono text-xs break-all" : "mt-1 text-xs break-words"}>
-        {value}
-      </p>
-    </div>
-  );
-}
-
 export function SettingsSections() {
   const setScreen = useStore((s) => s.setScreen);
   const settings = useStore((s) => s.settings);

--- a/Vyline/apps/desktop/src/components/settings-sections.tsx
+++ b/Vyline/apps/desktop/src/components/settings-sections.tsx
@@ -912,6 +912,8 @@ function StorageSection() {
     vylineTotal: number;
     cacheSize: number;
     savedMediaSize: number;
+    cache: { cdn: number; icons: number };
+    savedMedia: { image: number; video: number; audio: number; file: number };
     error?: string;
   } | null>(null);
   const [loading, setLoading] = useState(false);
@@ -932,48 +934,21 @@ function StorageSection() {
     }
   };
 
-  const clearCache = async () => {
+  const clearType = async (
+    label: string,
+    action: () => Promise<{ ok: boolean; removed?: number }>,
+  ) => {
     if (!accountId) return;
-    if (
-      !window.confirm(
-        "キャッシュを削除します。再取得可能なアイコン・スタンプなどのデータが消えます。よろしいですか？",
-      )
-    )
-      return;
+    if (!window.confirm(`${label}を削除します。この操作は取り消せません。よろしいですか？`)) return;
     setLoading(true);
     setMsg(null);
     try {
-      const res = await api.line.clearVylineCache(accountId);
+      const res = await action();
       if (res.ok) {
-        setMsg(`キャッシュを削除しました (${res.removed ?? 0} 件)`);
+        setMsg(`${label}を削除しました (${res.removed ?? 0} 件)`);
         await load();
       } else {
-        setMsg(res.error ?? "削除に失敗しました");
-      }
-    } catch (e) {
-      setMsg(e instanceof Error ? e.message : String(e));
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const clearSavedMedia = async () => {
-    if (!accountId) return;
-    if (
-      !window.confirm(
-        "保存メディアを削除します。チャットの画像・動画・ファイルがすべて消えます。この操作は取り消せません。よろしいですか？",
-      )
-    )
-      return;
-    setLoading(true);
-    setMsg(null);
-    try {
-      const res = await api.line.clearVylineSavedMedia(accountId);
-      if (res.ok) {
-        setMsg(`保存メディアを削除しました (${res.removed ?? 0} 件)`);
-        await load();
-      } else {
-        setMsg(res.error ?? "削除に失敗しました");
+        setMsg("削除に失敗しました");
       }
     } catch (e) {
       setMsg(e instanceof Error ? e.message : String(e));
@@ -986,10 +961,16 @@ function StorageSection() {
     void load();
   }, [accountId]);
 
-  const cachePct =
-    storage && storage.vylineTotal > 0 ? (storage.cacheSize / storage.vylineTotal) * 100 : 0;
-  const mediaPct =
-    storage && storage.vylineTotal > 0 ? (storage.savedMediaSize / storage.vylineTotal) * 100 : 0;
+  const segments = storage
+    ? [
+        { key: "cdn", label: "CDN", size: storage.cache.cdn, color: "var(--vy-accent)" },
+        { key: "icons", label: "アイコン", size: storage.cache.icons, color: "var(--vy-accent)" },
+        { key: "image", label: "画像", size: storage.savedMedia.image, color: "#3b82f6" },
+        { key: "video", label: "動画", size: storage.savedMedia.video, color: "#a855f7" },
+        { key: "audio", label: "音声", size: storage.savedMedia.audio, color: "#22c55e" },
+        { key: "file", label: "ファイル", size: storage.savedMedia.file, color: "#6b7280" },
+      ]
+    : [];
 
   return (
     <Section title="ストレージ" desc="アプリが使用している容量を管理します">
@@ -1014,88 +995,100 @@ function StorageSection() {
             </div>
 
             <div className="mt-4 flex h-3 overflow-hidden rounded-full bg-[var(--vy-surface-2)]">
-              <div
-                className="h-full bg-[var(--vy-accent)] transition-all duration-500"
-                style={{ width: `${cachePct}%` }}
-              />
-              <div
-                className="h-full bg-[var(--vy-danger)] transition-all duration-500"
-                style={{ width: `${mediaPct}%` }}
-              />
+              {segments.map((s) => {
+                const pct = storage.vylineTotal > 0 ? (s.size / storage.vylineTotal) * 100 : 0;
+                return (
+                  <div
+                    key={s.key}
+                    className="h-full transition-all duration-500"
+                    style={{ background: s.color, width: `${pct}%` }}
+                  />
+                );
+              })}
             </div>
 
             <div className="mt-3 flex flex-wrap items-center gap-4 text-xs text-[var(--vy-text-dim)]">
-              <span className="flex items-center gap-1.5">
-                <span className="inline-block h-2 w-2 rounded-full bg-[var(--vy-accent)]" />
-                キャッシュ {formatBytes(storage.cacheSize)}
-              </span>
-              <span className="flex items-center gap-1.5">
-                <span className="inline-block h-2 w-2 rounded-full bg-[var(--vy-danger)]" />
-                保存メディア {formatBytes(storage.savedMediaSize)}
-              </span>
+              {segments.map((s) => (
+                <span key={s.key} className="flex items-center gap-1.5">
+                  <span
+                    className="inline-block h-2 w-2 rounded-full"
+                    style={{ background: s.color }}
+                  />
+                  {s.label} {formatBytes(s.size)}
+                </span>
+              ))}
             </div>
           </div>
         </div>
       )}
 
-      <div className="grid gap-4 sm:grid-cols-2">
-        <div className="overflow-hidden rounded-2xl border border-[var(--vy-border)] bg-[var(--vy-surface)]">
-          <div className="p-5">
-            <div className="flex items-center gap-3">
-              <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-[color-mix(in_oklab,var(--vy-accent)_18%,var(--vy-surface-2))]">
-                <IconDownload size={20} className="text-[var(--vy-accent)]" />
-              </div>
-              <div className="min-w-0 flex-1">
-                <p className="text-sm font-medium">キャッシュ</p>
-                <p className="text-xs text-[var(--vy-text-dim)]">
-                  アイコン・スタンプなど再取得可能
-                </p>
-              </div>
-            </div>
-            <div className="mt-4 flex items-baseline justify-between">
-              <span className="text-lg font-semibold font-mono">
-                {storage ? formatBytes(storage.cacheSize) : "---"}
-              </span>
-            </div>
-            <button
-              type="button"
-              onClick={clearCache}
-              disabled={loading || !accountId}
-              className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-xl border border-[var(--vy-border)] px-3 py-2 text-xs font-medium transition-colors hover:bg-[var(--vy-surface-2)] disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              <IconTrash size={14} />
-              {loading ? "処理中…" : "キャッシュを削除"}
-            </button>
-          </div>
-        </div>
-
-        <div className="overflow-hidden rounded-2xl border border-[var(--vy-danger)]/30 bg-[var(--vy-surface)]">
-          <div className="p-5">
-            <div className="flex items-center gap-3">
-              <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-[color-mix(in_oklab,var(--vy-danger)_12%,var(--vy-surface-2))]">
-                <IconHardDrive size={20} className="text-[var(--vy-danger)]" />
-              </div>
-              <div className="min-w-0 flex-1">
-                <p className="text-sm font-medium">保存メディア</p>
-                <p className="text-xs text-[var(--vy-text-dim)]">チャット画像・動画・ファイル</p>
-              </div>
-            </div>
-            <div className="mt-4 flex items-baseline justify-between">
-              <span className="text-lg font-semibold font-mono">
-                {storage ? formatBytes(storage.savedMediaSize) : "---"}
-              </span>
-            </div>
-            <button
-              type="button"
-              onClick={clearSavedMedia}
-              disabled={loading || !accountId}
-              className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-xl border border-[var(--vy-danger)] px-3 py-2 text-xs font-medium text-[var(--vy-danger)] transition-colors hover:bg-[color-mix(in_oklab,var(--vy-danger)_12%,transparent)] disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              <IconTrash size={14} />
-              {loading ? "処理中…" : "保存メディアを削除"}
-            </button>
-          </div>
-        </div>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <TypeCard
+          title="CDN キャッシュ"
+          desc="スタンプ・LINE絵文字など"
+          size={storage?.cache.cdn ?? 0}
+          icon={<IconDownload size={20} className="text-[var(--vy-accent)]" />}
+          iconBg="bg-[color-mix(in_oklab,var(--vy-accent)_18%,var(--vy-surface-2))]"
+          onDelete={() =>
+            clearType("CDN キャッシュ", () => api.line.clearVylineCdnCache(accountId))
+          }
+          disabled={loading || !accountId}
+        />
+        <TypeCard
+          title="アイコンキャッシュ"
+          desc="プロフィール画像など"
+          size={storage?.cache.icons ?? 0}
+          icon={<IconDownload size={20} className="text-[var(--vy-accent)]" />}
+          iconBg="bg-[color-mix(in_oklab,var(--vy-accent)_18%,var(--vy-surface-2))]"
+          onDelete={() =>
+            clearType("アイコンキャッシュ", () => api.line.clearVylineIconCache(accountId))
+          }
+          disabled={loading || !accountId}
+        />
+        <TypeCard
+          title="画像"
+          desc="チャット画像"
+          size={storage?.savedMedia.image ?? 0}
+          icon={<IconDownload size={20} className="text-[#3b82f6]" />}
+          iconBg="bg-[color-mix(in_oklab,#3b82f6_18%,var(--vy-surface-2))]"
+          onDelete={() =>
+            clearType("保存画像", () => api.line.clearVylineSavedMediaType(accountId, "image"))
+          }
+          disabled={loading || !accountId}
+        />
+        <TypeCard
+          title="動画"
+          desc="チャット動画"
+          size={storage?.savedMedia.video ?? 0}
+          icon={<IconDownload size={20} className="text-[#a855f7]" />}
+          iconBg="bg-[color-mix(in_oklab,#a855f7_18%,var(--vy-surface-2))]"
+          onDelete={() =>
+            clearType("保存動画", () => api.line.clearVylineSavedMediaType(accountId, "video"))
+          }
+          disabled={loading || !accountId}
+        />
+        <TypeCard
+          title="音声"
+          desc="ボイスメッセージなど"
+          size={storage?.savedMedia.audio ?? 0}
+          icon={<IconDownload size={20} className="text-[#22c55e]" />}
+          iconBg="bg-[color-mix(in_oklab,#22c55e_18%,var(--vy-surface-2))]"
+          onDelete={() =>
+            clearType("保存音声", () => api.line.clearVylineSavedMediaType(accountId, "audio"))
+          }
+          disabled={loading || !accountId}
+        />
+        <TypeCard
+          title="ファイル"
+          desc="PDF など"
+          size={storage?.savedMedia.file ?? 0}
+          icon={<IconDownload size={20} className="text-[#6b7280]" />}
+          iconBg="bg-[color-mix(in_oklab,#6b7280_18%,var(--vy-surface-2))]"
+          onDelete={() =>
+            clearType("保存ファイル", () => api.line.clearVylineSavedMediaType(accountId, "file"))
+          }
+          disabled={loading || !accountId}
+        />
       </div>
 
       {msg && (
@@ -1109,6 +1102,52 @@ function StorageSection() {
         </p>
       )}
     </Section>
+  );
+}
+
+function TypeCard({
+  title,
+  desc,
+  size,
+  icon,
+  iconBg,
+  onDelete,
+  disabled,
+}: {
+  title: string;
+  desc: string;
+  size: number;
+  icon: React.ReactNode;
+  iconBg: string;
+  onDelete: () => void;
+  disabled: boolean;
+}) {
+  return (
+    <div className="overflow-hidden rounded-2xl border border-[var(--vy-border)] bg-[var(--vy-surface)]">
+      <div className="p-5">
+        <div className="flex items-center gap-3">
+          <div className={`flex h-10 w-10 items-center justify-center rounded-xl ${iconBg}`}>
+            {icon}
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="text-sm font-medium">{title}</p>
+            <p className="text-xs text-[var(--vy-text-dim)]">{desc}</p>
+          </div>
+        </div>
+        <div className="mt-4 flex items-baseline justify-between">
+          <span className="text-lg font-semibold font-mono">{formatBytes(size)}</span>
+        </div>
+        <button
+          type="button"
+          onClick={onDelete}
+          disabled={disabled}
+          className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-xl border border-[var(--vy-border)] px-3 py-2 text-xs font-medium transition-colors hover:bg-[var(--vy-surface-2)] disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <IconTrash size={14} />
+          削除
+        </button>
+      </div>
+    </div>
   );
 }
 

--- a/Vyline/apps/desktop/src/components/settings-sections.tsx
+++ b/Vyline/apps/desktop/src/components/settings-sections.tsx
@@ -20,7 +20,14 @@ function formatBytes(bytes: number): string {
   return `${(bytes / k ** i).toFixed(1)} ${sizes[i]}`;
 }
 
+function formatPercent(value: number): string {
+  if (!Number.isFinite(value)) return "0%";
+  const digits = value >= 10 ? 0 : 1;
+  return `${value.toFixed(digits)}%`;
+}
+
 import { Toggle, Avatar } from "@/components/vy-ui";
+import { PremiumBadge } from "@/components/premium-badge";
 import { VyThemePanel } from "@/components/vy-theme-panel";
 import {
   IconArrowLeft,
@@ -88,6 +95,25 @@ function Card({ children }: { children: React.ReactNode }) {
   );
 }
 
+function SettingMeta({
+  label,
+  value,
+  mono,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className="rounded-xl border border-[var(--vy-border)] bg-[var(--vy-surface-2)] px-3 py-2">
+      <p className="text-[0.65rem] font-medium text-[var(--vy-text-dim)]">{label}</p>
+      <p className={mono ? "mt-1 font-mono text-xs break-all" : "mt-1 text-xs break-words"}>
+        {value}
+      </p>
+    </div>
+  );
+}
+
 export function SettingsSections() {
   const setScreen = useStore((s) => s.setScreen);
   const settings = useStore((s) => s.settings);
@@ -98,7 +124,6 @@ export function SettingsSections() {
   const [section, setSection] = useState<Section>("read");
   const [nameDraft, setNameDraft] = useState(self.name);
   const [statusDraft, setStatusDraft] = useState(self.status);
-  const [birthdayDraft, setBirthdayDraft] = useState("");
   const [profileSaving, setProfileSaving] = useState(false);
   const [profileMsg, setProfileMsg] = useState<string | null>(null);
 
@@ -113,17 +138,10 @@ export function SettingsSections() {
       const body: {
         displayName?: string;
         statusMessage?: string;
-        birthday?: { day: string; year?: string };
       } = {
         displayName: nameDraft.trim(),
         statusMessage: statusDraft,
       };
-      const bday = birthdayDraft.replace(/[^0-9]/g, "");
-      if (bday.length === 4) {
-        body.birthday = { day: bday };
-      } else if (bday.length === 8) {
-        body.birthday = { year: bday.slice(0, 4), day: bday.slice(4) };
-      }
       const res = await api.line.updateProfile(accountId, body);
       if (!res.ok || !res.profile) {
         setProfileMsg(
@@ -137,6 +155,10 @@ export function SettingsSections() {
         birthday: res.profile.birthday?.display,
         avatarUrl: res.profile.thumbnailUrl || self.avatarUrl,
         mid: res.profile.mid,
+        phoneticName: res.profile.phoneticName || self.phoneticName,
+        pictureStatus: res.profile.pictureStatus || self.pictureStatus,
+        profileId: res.profile.profileId || self.profileId,
+        premium: res.profile.premium ?? self.premium,
       });
       setProfileMsg("LINE プロフィールを更新しました");
     } catch (err) {
@@ -177,9 +199,11 @@ export function SettingsSections() {
         setProfileMsg("背景画像をアップロードしました");
         // カバー URL は直後に取れないことがあるのでタイムスタンプ付きヒント
         updateSelf({
-          backgroundUrl: self.backgroundUrl
-            ? `${self.backgroundUrl.split("?")[0]}?t=${Date.now()}`
-            : self.backgroundUrl,
+          backgroundUrl: res.backgroundUrl
+            ? `${res.backgroundUrl.split("?")[0]}?t=${Date.now()}`
+            : self.backgroundUrl
+              ? `${self.backgroundUrl.split("?")[0]}?t=${Date.now()}`
+              : self.backgroundUrl,
         });
       } else {
         setProfileMsg(res.error ?? "背景更新に失敗しました");
@@ -297,6 +321,10 @@ export function SettingsSections() {
                         </label>
                       </div>
                       <div className="min-w-0 flex-1 pb-1">
+                        <div className="flex items-center gap-1.5">
+                          <p className="truncate text-base font-semibold">{self.name}</p>
+                          {self.premium?.active && <PremiumBadge size={14} compact />}
+                        </div>
                         <p className="text-xs text-[var(--vy-text-dim)]">
                           下の欄で表示名・ステメを編集
                         </p>
@@ -320,24 +348,7 @@ export function SettingsSections() {
                         className="mt-2 w-full rounded-lg border border-[var(--vy-border)] bg-[var(--vy-surface-2)] px-3 py-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-[var(--vy-accent)]"
                       />
                     </div>
-                    <div className="py-3">
-                      <label className="text-sm font-medium">誕生日（MMDD / YYYYMMDD・任意）</label>
-                      <input
-                        value={birthdayDraft}
-                        onChange={(e) => setBirthdayDraft(e.target.value)}
-                        placeholder={self.birthday || "0701"}
-                        className="mt-2 w-full rounded-lg border border-[var(--vy-border)] bg-[var(--vy-surface-2)] px-3 py-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-[var(--vy-accent)]"
-                      />
-                      <p className="mt-1 text-[0.7rem] text-[var(--vy-text-dim)]">
-                        一部デバイス種別では誕生日更新がサーバ拒否されることがあります
-                      </p>
-                    </div>
                   </Card>
-                  {self.musicProfile && (
-                    <p className="mt-2 text-xs text-[var(--vy-text-dim)]">
-                      音楽（表示のみ）: {self.musicProfile.slice(0, 80)}
-                    </p>
-                  )}
                   <button
                     type="button"
                     disabled={profileSaving}
@@ -971,30 +982,42 @@ function StorageSection() {
         { key: "file", label: "ファイル", size: storage.savedMedia.file, color: "#6b7280" },
       ]
     : [];
+  const diskFree = storage?.disk?.freeBytes ?? 0;
+  const diskUsed = storage?.disk?.usedBytes ?? 0;
+  const diskTotal = storage?.disk?.totalBytes ?? 0;
+  const diskUsedPct = diskTotal > 0 ? (diskUsed / diskTotal) * 100 : 0;
 
   return (
     <Section title="ストレージ" desc="アプリが使用している容量を管理します">
       {storage && (
         <div className="mb-6 overflow-hidden rounded-2xl border border-[var(--vy-border)] bg-[var(--vy-surface)]">
           <div className="p-5">
-            <div className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
               <div>
                 <p className="text-sm font-medium text-[var(--vy-text-dim)]">
                   ドライブ {storage.driveLetter ?? "---"}
                 </p>
-                {storage.disk && (
-                  <p className="text-xs text-[var(--vy-text-dim)]">
-                    合計 {formatBytes(storage.disk.totalBytes)} / 空き{" "}
-                    {formatBytes(storage.disk.freeBytes)}
-                  </p>
-                )}
+                <p className="mt-2 text-3xl font-semibold tracking-tight">
+                  {formatBytes(storage.vylineTotal)}
+                </p>
+                <p className="mt-2 text-sm text-[var(--vy-text-dim)]">
+                  アプリが保存している CDN
+                  キャッシュ、プロフィール画像、チャットメディアの合計です。
+                </p>
               </div>
-              <p className="text-2xl font-bold tracking-tight">
-                {formatBytes(storage.vylineTotal)}
-              </p>
+
+              <div className="rounded-xl border border-[var(--vy-border)] px-4 py-3">
+                <p className="text-xs text-[var(--vy-text-dim)]">ドライブ使用率</p>
+                <p className="mt-1 text-xl font-semibold tracking-tight">
+                  {formatPercent(diskUsedPct)}
+                </p>
+                <p className="mt-1 text-xs text-[var(--vy-text-dim)]">
+                  空き {formatBytes(diskFree)}
+                </p>
+              </div>
             </div>
 
-            <div className="mt-4 flex h-3 overflow-hidden rounded-full bg-[var(--vy-surface-2)]">
+            <div className="mt-5 h-3 overflow-hidden rounded-full bg-[var(--vy-surface-2)]">
               {segments.map((s) => {
                 const pct = storage.vylineTotal > 0 ? (s.size / storage.vylineTotal) * 100 : 0;
                 return (
@@ -1007,14 +1030,18 @@ function StorageSection() {
               })}
             </div>
 
-            <div className="mt-3 flex flex-wrap items-center gap-4 text-xs text-[var(--vy-text-dim)]">
+            <div className="mt-4 flex flex-wrap gap-2 text-xs text-[var(--vy-text-dim)]">
               {segments.map((s) => (
-                <span key={s.key} className="flex items-center gap-1.5">
+                <span
+                  key={s.key}
+                  className="inline-flex items-center gap-2 rounded-full border border-[var(--vy-border)] px-3 py-1.5"
+                >
                   <span
                     className="inline-block h-2 w-2 rounded-full"
                     style={{ background: s.color }}
                   />
-                  {s.label} {formatBytes(s.size)}
+                  <span>{s.label}</span>
+                  <span className="font-mono">{formatBytes(s.size)}</span>
                 </span>
               ))}
             </div>
@@ -1022,72 +1049,104 @@ function StorageSection() {
         </div>
       )}
 
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <div>
+          <p className="text-sm font-medium">削除候補</p>
+          <p className="text-xs text-[var(--vy-text-dim)]">容量の大きいものから並べています。</p>
+        </div>
+        {storage && (
+          <p className="text-xs text-[var(--vy-text-dim)]">
+            合計 {formatBytes(storage.cacheSize + storage.savedMediaSize)}
+          </p>
+        )}
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
         <TypeCard
           title="CDN キャッシュ"
           desc="スタンプ・LINE絵文字など"
           size={storage?.cache.cdn ?? 0}
+          ratio={storage && storage.vylineTotal > 0 ? storage.cache.cdn / storage.vylineTotal : 0}
           icon={<IconDownload size={20} className="text-[var(--vy-accent)]" />}
           iconBg="bg-[color-mix(in_oklab,var(--vy-accent)_18%,var(--vy-surface-2))]"
           onDelete={() =>
             clearType("CDN キャッシュ", () => api.line.clearVylineCdnCache(accountId!))
           }
           disabled={loading || !accountId}
+          accent="var(--vy-accent)"
         />
         <TypeCard
           title="アイコンキャッシュ"
           desc="プロフィール画像など"
           size={storage?.cache.icons ?? 0}
+          ratio={storage && storage.vylineTotal > 0 ? storage.cache.icons / storage.vylineTotal : 0}
           icon={<IconDownload size={20} className="text-[var(--vy-accent)]" />}
           iconBg="bg-[color-mix(in_oklab,var(--vy-accent)_18%,var(--vy-surface-2))]"
           onDelete={() =>
             clearType("アイコンキャッシュ", () => api.line.clearVylineIconCache(accountId!))
           }
           disabled={loading || !accountId}
+          accent="var(--vy-accent)"
         />
         <TypeCard
           title="画像"
           desc="チャット画像"
           size={storage?.savedMedia.image ?? 0}
+          ratio={
+            storage && storage.vylineTotal > 0 ? storage.savedMedia.image / storage.vylineTotal : 0
+          }
           icon={<IconDownload size={20} className="text-[#3b82f6]" />}
           iconBg="bg-[color-mix(in_oklab,#3b82f6_18%,var(--vy-surface-2))]"
           onDelete={() =>
             clearType("保存画像", () => api.line.clearVylineSavedMediaType(accountId!, "image"))
           }
           disabled={loading || !accountId}
+          accent="#3b82f6"
         />
         <TypeCard
           title="動画"
           desc="チャット動画"
           size={storage?.savedMedia.video ?? 0}
+          ratio={
+            storage && storage.vylineTotal > 0 ? storage.savedMedia.video / storage.vylineTotal : 0
+          }
           icon={<IconDownload size={20} className="text-[#a855f7]" />}
           iconBg="bg-[color-mix(in_oklab,#a855f7_18%,var(--vy-surface-2))]"
           onDelete={() =>
             clearType("保存動画", () => api.line.clearVylineSavedMediaType(accountId!, "video"))
           }
           disabled={loading || !accountId}
+          accent="#a855f7"
         />
         <TypeCard
           title="音声"
           desc="ボイスメッセージなど"
           size={storage?.savedMedia.audio ?? 0}
+          ratio={
+            storage && storage.vylineTotal > 0 ? storage.savedMedia.audio / storage.vylineTotal : 0
+          }
           icon={<IconDownload size={20} className="text-[#22c55e]" />}
           iconBg="bg-[color-mix(in_oklab,#22c55e_18%,var(--vy-surface-2))]"
           onDelete={() =>
             clearType("保存音声", () => api.line.clearVylineSavedMediaType(accountId!, "audio"))
           }
           disabled={loading || !accountId}
+          accent="#22c55e"
         />
         <TypeCard
           title="ファイル"
           desc="PDF など"
           size={storage?.savedMedia.file ?? 0}
+          ratio={
+            storage && storage.vylineTotal > 0 ? storage.savedMedia.file / storage.vylineTotal : 0
+          }
           icon={<IconDownload size={20} className="text-[#6b7280]" />}
           iconBg="bg-[color-mix(in_oklab,#6b7280_18%,var(--vy-surface-2))]"
           onDelete={() =>
             clearType("保存ファイル", () => api.line.clearVylineSavedMediaType(accountId!, "file"))
           }
           disabled={loading || !accountId}
+          accent="#6b7280"
         />
       </div>
 
@@ -1109,42 +1168,69 @@ function TypeCard({
   title,
   desc,
   size,
+  ratio,
   icon,
   iconBg,
+  accent,
   onDelete,
   disabled,
 }: {
   title: string;
   desc: string;
   size: number;
+  ratio: number;
   icon: React.ReactNode;
   iconBg: string;
+  accent: string;
   onDelete: () => void;
   disabled: boolean;
 }) {
+  const hasData = size > 0;
   return (
     <div className="overflow-hidden rounded-2xl border border-[var(--vy-border)] bg-[var(--vy-surface)]">
       <div className="p-5">
-        <div className="flex items-center gap-3">
-          <div className={`flex h-10 w-10 items-center justify-center rounded-xl ${iconBg}`}>
-            {icon}
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex min-w-0 items-center gap-3">
+            <div
+              className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-xl ${iconBg}`}
+            >
+              {icon}
+            </div>
+            <div className="min-w-0">
+              <p className="truncate text-sm font-medium">{title}</p>
+              <p className="mt-1 text-xs text-[var(--vy-text-dim)]">{desc}</p>
+            </div>
           </div>
-          <div className="min-w-0 flex-1">
-            <p className="text-sm font-medium">{title}</p>
-            <p className="text-xs text-[var(--vy-text-dim)]">{desc}</p>
+
+          <div className="shrink-0 text-right">
+            <p className="text-[11px] text-[var(--vy-text-dim)]">使用量</p>
+            <p className="mt-1 font-mono text-base font-semibold">{formatBytes(size)}</p>
           </div>
         </div>
-        <div className="mt-4 flex items-baseline justify-between">
-          <span className="text-lg font-semibold font-mono">{formatBytes(size)}</span>
+
+        <div className="mt-4">
+          <div className="h-2 overflow-hidden rounded-full bg-[var(--vy-surface-2)]">
+            <div
+              className="h-full rounded-full transition-all duration-500"
+              style={{ background: accent, width: `${Math.max(ratio * 100, hasData ? 4 : 0)}%` }}
+            />
+          </div>
+          <p className="mt-2 text-xs text-[var(--vy-text-dim)]">
+            {hasData ? `Vyline 全体の ${formatPercent(ratio * 100)}` : "保存データはありません"}
+          </p>
         </div>
+
         <button
           type="button"
           onClick={onDelete}
-          disabled={disabled}
-          className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-xl border border-[var(--vy-border)] px-3 py-2 text-xs font-medium transition-colors hover:bg-[var(--vy-surface-2)] disabled:cursor-not-allowed disabled:opacity-50"
+          disabled={disabled || !hasData}
+          className={cn(
+            "mt-4 inline-flex w-full items-center justify-center gap-2 rounded-xl border border-[var(--vy-border)] px-3 py-2 text-xs font-medium transition-colors",
+            "hover:bg-[var(--vy-surface-2)] disabled:cursor-not-allowed disabled:opacity-50",
+          )}
         >
           <IconTrash size={14} />
-          削除
+          {hasData ? "削除" : "データなし"}
         </button>
       </div>
     </div>

--- a/Vyline/apps/desktop/src/components/settings-sections.tsx
+++ b/Vyline/apps/desktop/src/components/settings-sections.tsx
@@ -11,6 +11,15 @@ function formatRelativeTime(ts: number): string {
   if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}時間前`;
   return `${Math.floor(diff / 86_400_000)}日前`;
 }
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return "0 B";
+  const k = 1024;
+  const sizes = ["B", "KB", "MB", "GB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${(bytes / k ** i).toFixed(1)} ${sizes[i]}`;
+}
+
 import { Toggle, Avatar } from "@/components/vy-ui";
 import { VyThemePanel } from "@/components/vy-theme-panel";
 import {
@@ -23,6 +32,9 @@ import {
   IconChevron,
   IconSpark,
   IconBell,
+  IconHardDrive,
+  IconTrash,
+  IconDownload,
 } from "@/components/icons";
 
 type Section =
@@ -33,6 +45,7 @@ type Section =
   | "privacy"
   | "notifications"
   | "advanced"
+  | "storage"
   | "info";
 
 const NAV: { key: Section; label: string; icon: React.ReactNode }[] = [
@@ -43,6 +56,7 @@ const NAV: { key: Section; label: string; icon: React.ReactNode }[] = [
   { key: "notifications", label: "通知", icon: <IconBell size={18} /> },
   { key: "privacy", label: "プライバシー", icon: <IconShield size={18} /> },
   { key: "advanced", label: "詳細・復元", icon: <IconChevron size={18} /> },
+  { key: "storage", label: "ストレージ", icon: <IconHardDrive size={18} /> },
   { key: "info", label: "情報", icon: <IconSpark size={18} /> },
 ];
 
@@ -487,6 +501,8 @@ export function SettingsSections() {
 
               {section === "advanced" && <AdvancedSection />}
 
+              {section === "storage" && <StorageSection />}
+
               {section === "info" && <InfoSection />}
             </div>
           </div>
@@ -813,14 +829,6 @@ function AdvancedSection() {
             インポート
           </button>
         </Row>
-        <Row title="キャッシュを削除" desc="メディアの一時ファイルを削除します">
-          <button
-            type="button"
-            className="rounded-lg border border-[var(--vy-border)] px-3 py-1.5 text-xs font-medium transition-colors hover:bg-[var(--vy-surface-2)]"
-          >
-            削除
-          </button>
-        </Row>
         <Row title="デバッグログを表示" desc="接続状態や送受信ログを確認します（開発者向け）">
           <button
             type="button"
@@ -889,6 +897,215 @@ function AdvancedSection() {
       {!accountId && (
         <p className="mt-3 px-1 text-xs text-[var(--vy-text-dim)]">
           復元には LINE ログインが必要です。
+        </p>
+      )}
+    </Section>
+  );
+}
+
+function StorageSection() {
+  const accountId = useStore((s) => s.accountId);
+  const [storage, setStorage] = useState<{
+    ok: boolean;
+    driveLetter?: string;
+    disk?: { totalBytes: number; freeBytes: number; usedBytes: number };
+    vylineTotal: number;
+    cacheSize: number;
+    savedMediaSize: number;
+    error?: string;
+  } | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [msg, setMsg] = useState<string | null>(null);
+
+  const load = async () => {
+    if (!accountId) return;
+    setLoading(true);
+    setMsg(null);
+    try {
+      const res = await api.line.vylineStorage(accountId);
+      if (res.ok) setStorage(res);
+      else setMsg(res.error ?? "取得に失敗しました");
+    } catch (e) {
+      setMsg(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const clearCache = async () => {
+    if (!accountId) return;
+    if (
+      !window.confirm(
+        "キャッシュを削除します。再取得可能なアイコン・スタンプなどのデータが消えます。よろしいですか？",
+      )
+    )
+      return;
+    setLoading(true);
+    setMsg(null);
+    try {
+      const res = await api.line.clearVylineCache(accountId);
+      if (res.ok) {
+        setMsg(`キャッシュを削除しました (${res.removed ?? 0} 件)`);
+        await load();
+      } else {
+        setMsg(res.error ?? "削除に失敗しました");
+      }
+    } catch (e) {
+      setMsg(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const clearSavedMedia = async () => {
+    if (!accountId) return;
+    if (
+      !window.confirm(
+        "保存メディアを削除します。チャットの画像・動画・ファイルがすべて消えます。この操作は取り消せません。よろしいですか？",
+      )
+    )
+      return;
+    setLoading(true);
+    setMsg(null);
+    try {
+      const res = await api.line.clearVylineSavedMedia(accountId);
+      if (res.ok) {
+        setMsg(`保存メディアを削除しました (${res.removed ?? 0} 件)`);
+        await load();
+      } else {
+        setMsg(res.error ?? "削除に失敗しました");
+      }
+    } catch (e) {
+      setMsg(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void load();
+  }, [accountId]);
+
+  const cachePct =
+    storage && storage.vylineTotal > 0 ? (storage.cacheSize / storage.vylineTotal) * 100 : 0;
+  const mediaPct =
+    storage && storage.vylineTotal > 0 ? (storage.savedMediaSize / storage.vylineTotal) * 100 : 0;
+
+  return (
+    <Section title="ストレージ" desc="アプリが使用している容量を管理します">
+      {storage && (
+        <div className="mb-6 overflow-hidden rounded-2xl border border-[var(--vy-border)] bg-[var(--vy-surface)]">
+          <div className="p-5">
+            <div className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
+              <div>
+                <p className="text-sm font-medium text-[var(--vy-text-dim)]">
+                  ドライブ {storage.driveLetter ?? "---"}
+                </p>
+                {storage.disk && (
+                  <p className="text-xs text-[var(--vy-text-dim)]">
+                    合計 {formatBytes(storage.disk.totalBytes)} / 空き{" "}
+                    {formatBytes(storage.disk.freeBytes)}
+                  </p>
+                )}
+              </div>
+              <p className="text-2xl font-bold tracking-tight">
+                {formatBytes(storage.vylineTotal)}
+              </p>
+            </div>
+
+            <div className="mt-4 flex h-3 overflow-hidden rounded-full bg-[var(--vy-surface-2)]">
+              <div
+                className="h-full bg-[var(--vy-accent)] transition-all duration-500"
+                style={{ width: `${cachePct}%` }}
+              />
+              <div
+                className="h-full bg-[var(--vy-danger)] transition-all duration-500"
+                style={{ width: `${mediaPct}%` }}
+              />
+            </div>
+
+            <div className="mt-3 flex flex-wrap items-center gap-4 text-xs text-[var(--vy-text-dim)]">
+              <span className="flex items-center gap-1.5">
+                <span className="inline-block h-2 w-2 rounded-full bg-[var(--vy-accent)]" />
+                キャッシュ {formatBytes(storage.cacheSize)}
+              </span>
+              <span className="flex items-center gap-1.5">
+                <span className="inline-block h-2 w-2 rounded-full bg-[var(--vy-danger)]" />
+                保存メディア {formatBytes(storage.savedMediaSize)}
+              </span>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="overflow-hidden rounded-2xl border border-[var(--vy-border)] bg-[var(--vy-surface)]">
+          <div className="p-5">
+            <div className="flex items-center gap-3">
+              <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-[color-mix(in_oklab,var(--vy-accent)_18%,var(--vy-surface-2))]">
+                <IconDownload size={20} className="text-[var(--vy-accent)]" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-medium">キャッシュ</p>
+                <p className="text-xs text-[var(--vy-text-dim)]">
+                  アイコン・スタンプなど再取得可能
+                </p>
+              </div>
+            </div>
+            <div className="mt-4 flex items-baseline justify-between">
+              <span className="text-lg font-semibold font-mono">
+                {storage ? formatBytes(storage.cacheSize) : "---"}
+              </span>
+            </div>
+            <button
+              type="button"
+              onClick={clearCache}
+              disabled={loading || !accountId}
+              className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-xl border border-[var(--vy-border)] px-3 py-2 text-xs font-medium transition-colors hover:bg-[var(--vy-surface-2)] disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <IconTrash size={14} />
+              {loading ? "処理中…" : "キャッシュを削除"}
+            </button>
+          </div>
+        </div>
+
+        <div className="overflow-hidden rounded-2xl border border-[var(--vy-danger)]/30 bg-[var(--vy-surface)]">
+          <div className="p-5">
+            <div className="flex items-center gap-3">
+              <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-[color-mix(in_oklab,var(--vy-danger)_12%,var(--vy-surface-2))]">
+                <IconHardDrive size={20} className="text-[var(--vy-danger)]" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-medium">保存メディア</p>
+                <p className="text-xs text-[var(--vy-text-dim)]">チャット画像・動画・ファイル</p>
+              </div>
+            </div>
+            <div className="mt-4 flex items-baseline justify-between">
+              <span className="text-lg font-semibold font-mono">
+                {storage ? formatBytes(storage.savedMediaSize) : "---"}
+              </span>
+            </div>
+            <button
+              type="button"
+              onClick={clearSavedMedia}
+              disabled={loading || !accountId}
+              className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-xl border border-[var(--vy-danger)] px-3 py-2 text-xs font-medium text-[var(--vy-danger)] transition-colors hover:bg-[color-mix(in_oklab,var(--vy-danger)_12%,transparent)] disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <IconTrash size={14} />
+              {loading ? "処理中…" : "保存メディアを削除"}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {msg && (
+        <div className="mt-4 rounded-xl border border-[var(--vy-border)] bg-[var(--vy-surface)] px-4 py-3">
+          <p className="text-xs text-[var(--vy-text-dim)]">{msg}</p>
+        </div>
+      )}
+      {!accountId && (
+        <p className="mt-3 px-1 text-xs text-[var(--vy-text-dim)]">
+          ストレージ情報を取得するにはログインが必要です。
         </p>
       )}
     </Section>

--- a/Vyline/apps/desktop/src/components/sidebar.tsx
+++ b/Vyline/apps/desktop/src/components/sidebar.tsx
@@ -11,6 +11,7 @@ import {
 import { cn } from "@/lib/utils";
 import { Avatar } from "@/components/vy-ui";
 import { OfficialBadge } from "@/components/official-badge";
+import { PremiumBadge } from "@/components/premium-badge";
 import { MessageContextMenu, type MenuItem } from "@/components/message-context-menu";
 import { api } from "@/api/client";
 import { useAuthStore } from "@/stores/authStore";
@@ -53,6 +54,28 @@ function buildPreviewMap(
   messages: ReturnType<typeof useStore.getState>["messages"],
   chats: Chat[],
 ): Map<string, { text: string; time: number } | null> {
+  const previewForMessage = (m: (typeof messages)[number]): string => {
+    if (m.messageState.startsWith("revoked")) {
+      if (m.revokedSnapshot) return `取り消し済み: ${previewForMessage(m.revokedSnapshot)}`;
+      const last = m.history
+        ? [...m.history].reverse().find((h) => h.state === "normal" || h.state === "edited")
+        : undefined;
+      return last?.text ? `取り消し済み: ${last.text}` : "取り消し済みのメッセージ";
+    }
+    if (m.kind === "sticker") return m.altText || "[スタンプ]";
+    if (m.kind === "image") return "[画像]";
+    if (m.kind === "video") return "[動画]";
+    if (m.kind === "audio") return "[音声メッセージ]";
+    if (m.kind === "flex" || m.kind === "rich")
+      return m.altText || m.text || (m.kind === "flex" ? "[Flex]" : "[リッチメッセージ]");
+    if (m.kind === "call") return "[通話]";
+    if (m.kind === "emoji") return "[絵文字]";
+    if (m.kind === "location") return "[位置情報]";
+    if (m.kind === "contact") return "[連絡先]";
+    if (m.kind === "system") return m.text ?? "";
+    return m.text ?? "";
+  };
+
   const lastByChat = new Map<string, (typeof messages)[number]>();
   for (const m of messages) {
     lastByChat.set(m.chatId, m);
@@ -68,20 +91,7 @@ function buildPreviewMap(
       );
       continue;
     }
-    let text = "";
-    if (last.messageState.startsWith("revoked")) text = "メッセージの送信を取り消しました";
-    else if (last.kind === "sticker") text = last.altText || "[スタンプ]";
-    else if (last.kind === "image") text = "[画像]";
-    else if (last.kind === "video") text = "[動画]";
-    else if (last.kind === "audio") text = "[音声メッセージ]";
-    else if (last.kind === "flex" || last.kind === "rich")
-      text = last.altText || last.text || (last.kind === "flex" ? "[Flex]" : "[リッチメッセージ]");
-    else if (last.kind === "call") text = "[通話]";
-    else if (last.kind === "emoji") text = "[絵文字]";
-    else if (last.kind === "location") text = "[位置情報]";
-    else if (last.kind === "contact") text = "[連絡先]";
-    else if (last.kind === "system") text = last.text ?? "";
-    else text = last.text ?? chat.lastMessagePreview ?? "";
+    let text = previewForMessage(last) || chat.lastMessagePreview || "";
     if (last.authorId === "me" && text) text = `あなた: ${text}`;
     out.set(chat.id, { text, time: Math.max(last.createdAt, apiTime) });
   }
@@ -339,7 +349,10 @@ export function Sidebar() {
           onClick={() => setScreen("settings")}
           className="min-w-0 flex-1 text-left outline-none"
         >
-          <p className="truncate text-sm font-semibold">{self.name}</p>
+          <div className="flex min-w-0 items-center gap-1.5">
+            <p className="truncate text-sm font-semibold">{self.name}</p>
+            {self.premium?.active && <PremiumBadge size={14} compact />}
+          </div>
           <p className="truncate text-xs text-[var(--vy-text-dim)]">{self.status}</p>
         </button>
         <button
@@ -719,6 +732,8 @@ function AccountSwitcher() {
 
   const currentSession = sessions.find((s) => s.accountId === accountId);
   const currentName = currentSession?.displayName || accountId || "未ログイン";
+  const selfPremium = useStore((s) => s.self.premium?.active ?? false);
+  const currentPremium = currentSession?.premium?.active ?? selfPremium;
 
   const handleSwitch = (id: string) => {
     setOpen(false);
@@ -751,7 +766,10 @@ function AccountSwitcher() {
           imageUrl={currentSession?.picturePath}
         />
         <div className="min-w-0 flex-1">
-          <p className="truncate text-sm font-semibold">{currentName}</p>
+          <div className="flex min-w-0 items-center gap-1.5">
+            <p className="truncate text-sm font-semibold">{currentName}</p>
+            {currentPremium && <PremiumBadge size={14} compact />}
+          </div>
           <p className="truncate text-[0.65rem] text-[var(--vy-text-dim)]">{accountId}</p>
         </div>
         <IconChevron
@@ -767,6 +785,7 @@ function AccountSwitcher() {
             .map((id) => {
               const s = sessions.find((s) => s.accountId === id);
               const name = s?.displayName || id;
+              const isPremium = s?.premium?.active ?? false;
               return (
                 <button
                   key={id}
@@ -782,7 +801,10 @@ function AccountSwitcher() {
                     imageUrl={s?.picturePath}
                   />
                   <div className="min-w-0 flex-1">
-                    <p className="truncate text-xs font-medium">{name}</p>
+                    <div className="flex min-w-0 items-center gap-1">
+                      <p className="truncate text-xs font-medium">{name}</p>
+                      {isPremium && <PremiumBadge size={12} compact />}
+                    </div>
                     <p className="truncate text-[0.6rem] text-[var(--vy-text-dim)]">{id}</p>
                   </div>
                 </button>

--- a/Vyline/apps/desktop/src/components/sidebar.tsx
+++ b/Vyline/apps/desktop/src/components/sidebar.tsx
@@ -69,7 +69,7 @@ function buildPreviewMap(
       continue;
     }
     let text = "";
-    if (last.revoked) text = "メッセージの送信を取り消しました";
+    if (last.messageState.startsWith("revoked")) text = "メッセージの送信を取り消しました";
     else if (last.kind === "sticker") text = last.altText || "[スタンプ]";
     else if (last.kind === "image") text = "[画像]";
     else if (last.kind === "video") text = "[動画]";

--- a/Vyline/apps/desktop/src/components/sidebar.tsx
+++ b/Vyline/apps/desktop/src/components/sidebar.tsx
@@ -53,6 +53,7 @@ const SORTS: ChatSort[] = ["recent", "unread", "custom"];
 function buildPreviewMap(
   messages: ReturnType<typeof useStore.getState>["messages"],
   chats: Chat[],
+  prev?: Map<string, { text: string; time: number } | null>,
 ): Map<string, { text: string; time: number } | null> {
   const previewForMessage = (m: (typeof messages)[number]): string => {
     if (m.messageState.startsWith("revoked")) {
@@ -83,17 +84,18 @@ function buildPreviewMap(
   const out = new Map<string, { text: string; time: number } | null>();
   for (const chat of chats) {
     const last = lastByChat.get(chat.id);
+    // 前回と同内容なら前回のオブジェクトを使い ChatRow の memo を有効に保つ
+    const prevEntry = prev?.get(chat.id);
+    const stable = (text: string, time: number) =>
+      prevEntry && prevEntry.text === text && prevEntry.time === time ? prevEntry : { text, time };
     const apiTime = chat.lastMessageTime ?? 0;
     if (!last) {
-      out.set(
-        chat.id,
-        chat.lastMessagePreview ? { text: chat.lastMessagePreview, time: apiTime } : null,
-      );
+      out.set(chat.id, chat.lastMessagePreview ? stable(chat.lastMessagePreview, apiTime) : null);
       continue;
     }
     let text = previewForMessage(last) || chat.lastMessagePreview || "";
     if (last.authorId === "me" && text) text = `あなた: ${text}`;
-    out.set(chat.id, { text, time: Math.max(last.createdAt, apiTime) });
+    out.set(chat.id, stable(text, Math.max(last.createdAt, apiTime)));
   }
   return out;
 }
@@ -143,7 +145,14 @@ export function Sidebar() {
   const dragIdRef = useRef<string | null>(null);
   const liveOrderRef = useRef<string[] | null>(null);
 
-  const previewMap = useMemo(() => buildPreviewMap(messages, chats), [messages, chats]);
+  const previewMapRef = useRef<Map<string, { text: string; time: number } | null>>(new Map());
+  const previewMap = useMemo(
+    () => buildPreviewMap(messages, chats, previewMapRef.current),
+    [messages, chats],
+  );
+  useEffect(() => {
+    previewMapRef.current = previewMap;
+  }, [previewMap]);
 
   const filtered = useMemo(() => {
     let list = chats;

--- a/Vyline/apps/desktop/src/components/sticker-emoji-panel.tsx
+++ b/Vyline/apps/desktop/src/components/sticker-emoji-panel.tsx
@@ -94,10 +94,19 @@ function CombinationPreview({ items }: { items: CombinationPick[] }) {
           return (
             <img
               key={`${item.packageId}-${item.stickerId}-${i}`}
-              src={item.url.startsWith("http") ? `/api/cdn/line?u=${encodeURIComponent(item.url)}` : item.url}
+              src={
+                item.url.startsWith("http")
+                  ? `/api/cdn/line?u=${encodeURIComponent(item.url)}`
+                  : item.url
+              }
               alt={item.name || item.stickerId}
               className="absolute object-contain"
-              style={{ left: `${tile.x}%`, top: `${tile.y}%`, width: `${tile.w}%`, height: `${tile.h}%` }}
+              style={{
+                left: `${tile.x}%`,
+                top: `${tile.y}%`,
+                width: `${tile.w}%`,
+                height: `${tile.h}%`,
+              }}
               loading="lazy"
               referrerPolicy="no-referrer"
             />
@@ -288,7 +297,9 @@ export function StickerEmojiPanel({
         (x) => x.packageId === item.packageId && x.stickerId === item.stickerId,
       );
       if (exists) {
-        return prev.filter((x) => !(x.packageId === item.packageId && x.stickerId === item.stickerId));
+        return prev.filter(
+          (x) => !(x.packageId === item.packageId && x.stickerId === item.stickerId),
+        );
       }
       if (prev.length >= 6) {
         setComboError("組み合わせは最大6枚までです");
@@ -461,7 +472,9 @@ export function StickerEmojiPanel({
                 {comboCreatedId && (
                   <div className="mt-2 rounded-xl border border-[color-mix(in_oklab,var(--vy-accent)_35%,var(--vy-border))] bg-[color-mix(in_oklab,var(--vy-accent)_10%,transparent)] px-3 py-2 text-xs">
                     <span className="font-semibold text-[var(--vy-text)]">作成済み</span>
-                    <span className="ml-2 break-all text-[var(--vy-text-dim)]">{comboCreatedId}</span>
+                    <span className="ml-2 break-all text-[var(--vy-text-dim)]">
+                      {comboCreatedId}
+                    </span>
                     <button
                       type="button"
                       onClick={() => void copyText(comboCreatedId)}

--- a/Vyline/apps/desktop/src/components/sticker-emoji-panel.tsx
+++ b/Vyline/apps/desktop/src/components/sticker-emoji-panel.tsx
@@ -16,7 +16,12 @@ import {
   setCachedStickersCatalog,
   type StickersCatalogCache,
 } from "@/lib/stickerCatalogCache";
-import type { CombinationStickerPlacement } from "@/utils/combinationStickers";
+import {
+  COMBO_EDITOR_SIZE,
+  COMBO_ITEM_MAX_SIZE,
+  COMBO_ITEM_MIN_SIZE,
+  type CombinationStickerPlacement,
+} from "@/utils/combinationStickers";
 
 export type CatalogItem = { id: string; url: string; alt?: string };
 export type CatalogPack = {
@@ -40,8 +45,9 @@ type ComboItem = CombinationStickerPlacement & { uid: string };
 type MenuState = { x: number; y: number; fav: StickerFavorite } | null;
 
 const COMBO_LIMIT = 6;
-const COMBO_SIZE = 360;
-const COMBO_ITEM_SIZE = 92;
+// 正規座標空間 240x240 (backend の scale=512/240 前提と同期。表示枠も同サイズで固定)
+const COMBO_SIZE = COMBO_EDITOR_SIZE;
+const COMBO_ITEM_SIZE = 80;
 const LONG_PRESS_MS = 300;
 
 function assetUrl(url: string): string {
@@ -107,6 +113,7 @@ export function StickerEmojiPanel({
   const [comboBusy, setComboBusy] = useState(false);
   const [comboError, setComboError] = useState<string | null>(null);
   const [draggingComboId, setDraggingComboId] = useState<string | null>(null);
+  const [resizingComboId, setResizingComboId] = useState<string | null>(null);
   const comboCanvasRef = useRef<HTMLDivElement>(null);
   const dragOffsetRef = useRef({ x: 0, y: 0 });
   const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -327,9 +334,23 @@ export function StickerEmojiPanel({
   }
 
   function handleComboPointerMove(ev: ReactPointerEvent<HTMLDivElement>): void {
-    if (!draggingComboId) return;
     const rect = comboCanvasRef.current?.getBoundingClientRect();
     if (!rect) return;
+    if (resizingComboId) {
+      const item = comboItems.find((x) => x.uid === resizingComboId);
+      if (!item) return;
+      const dist = Math.hypot(ev.clientX - rect.left - item.x, ev.clientY - rect.top - item.y);
+      const size = Math.round(Math.max(COMBO_ITEM_MIN_SIZE, Math.min(COMBO_ITEM_MAX_SIZE, dist)));
+      setComboItems((prev) =>
+        prev.map((x) => {
+          if (x.uid !== resizingComboId) return x;
+          const pos = normalizePoint(x.x, x.y, size);
+          return { ...x, size, ...pos };
+        }),
+      );
+      return;
+    }
+    if (!draggingComboId) return;
     const item = comboItems.find((x) => x.uid === draggingComboId);
     if (!item) return;
     const next = normalizePoint(
@@ -342,6 +363,16 @@ export function StickerEmojiPanel({
 
   function handleComboPointerUp(): void {
     setDraggingComboId(null);
+    setResizingComboId(null);
+  }
+
+  function handleComboResizeDown(uidValue: string, ev: ReactPointerEvent<HTMLButtonElement>): void {
+    const item = comboItems.find((x) => x.uid === uidValue);
+    if (!item) return;
+    ev.preventDefault();
+    ev.stopPropagation();
+    ev.currentTarget.setPointerCapture(ev.pointerId);
+    setResizingComboId(uidValue);
   }
 
   function startLongPress(payload: DragPayload): void {
@@ -432,6 +463,7 @@ export function StickerEmojiPanel({
           alt={item.alt || ""}
           className="max-h-full max-w-full object-contain"
           loading="lazy"
+          draggable={false}
           referrerPolicy="no-referrer"
         />
       </button>
@@ -439,8 +471,8 @@ export function StickerEmojiPanel({
   }
 
   return (
-    <div className="vy-scale-in absolute bottom-full left-3 mb-2 flex h-[min(720px,86vh)] w-[min(680px,96vw)] flex-col overflow-hidden rounded-2xl border border-[var(--vy-border)] bg-[var(--vy-surface)] shadow-2xl md:left-5">
-      <div className="flex items-center gap-1 border-b border-[var(--vy-border)] px-2 pt-2">
+    <div className="vy-scale-in absolute bottom-full left-3 mb-2 flex h-[min(500px,72vh)] w-[min(460px,90vw)] flex-col overflow-hidden rounded-2xl border border-[var(--vy-border)] bg-[var(--vy-surface)] shadow-2xl md:left-5">
+      <div className="flex items-center gap-1 border-b border-[var(--vy-border)] px-1.5 pt-1.5">
         {(
           [
             ["sticker", "スタンプ"],
@@ -453,7 +485,7 @@ export function StickerEmojiPanel({
             type="button"
             onClick={() => setTab(id)}
             className={cn(
-              "rounded-t-lg px-3 py-1.5 text-xs font-semibold transition-colors",
+              "rounded-t-lg px-2.5 py-1 text-[0.72rem] font-semibold transition-colors",
               tab === id
                 ? "bg-[var(--vy-surface-2)] text-[var(--vy-text)]"
                 : "text-[var(--vy-text-dim)] hover:text-[var(--vy-text)]",
@@ -462,7 +494,7 @@ export function StickerEmojiPanel({
             {label}
           </button>
         ))}
-        <span className="ml-auto flex items-center gap-1 px-2 text-[0.65rem] text-[var(--vy-text-dim)]">
+        <span className="ml-auto flex items-center gap-1 px-1.5 text-[0.6rem] text-[var(--vy-text-dim)]">
           {catalog?.premium.active && <PremiumBadge size={12} compact />}
           <span>
             {catalog?.premium.active
@@ -475,7 +507,7 @@ export function StickerEmojiPanel({
       </div>
 
       {tab !== "favorite" && (
-        <div className="flex gap-1 overflow-x-auto border-b border-[var(--vy-border)] px-2 py-1.5 [scrollbar-width:thin]">
+        <div className="flex gap-1 overflow-x-auto border-b border-[var(--vy-border)] px-1.5 py-1 [scrollbar-width:thin]">
           {packs.map((p) => (
             <button
               key={p.packageId}
@@ -483,7 +515,7 @@ export function StickerEmojiPanel({
               title={p.name}
               onClick={() => setPackId(p.packageId)}
               className={cn(
-                "flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border transition-colors",
+                "flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border transition-colors",
                 activePack?.packageId === p.packageId
                   ? "border-[var(--vy-accent)] bg-[color-mix(in_oklab,var(--vy-accent)_18%,transparent)]"
                   : "border-transparent hover:bg-[var(--vy-surface-2)]",
@@ -492,8 +524,9 @@ export function StickerEmojiPanel({
               <img
                 src={assetUrl(p.tabUrl)}
                 alt=""
-                className="h-7 w-7 object-contain"
+                className="h-6 w-6 object-contain"
                 loading="lazy"
+                draggable={false}
                 referrerPolicy="no-referrer"
               />
             </button>
@@ -501,23 +534,25 @@ export function StickerEmojiPanel({
         </div>
       )}
 
-      <div className="min-h-0 flex-1 overflow-y-auto p-2">
+      <div className="min-h-0 flex-1 overflow-y-auto p-1.5">
         {comboMode && activePack?.type === "sticker" && (
-          <div className="mb-2 rounded-2xl border border-[var(--vy-border)] bg-[var(--vy-surface-2)] p-2">
+          <div className="mb-2 rounded-2xl border border-[var(--vy-border)] bg-[var(--vy-surface-2)] p-1.5">
             <div className="flex items-center gap-2">
               <div className="min-w-0 flex-1">
-                <p className="text-xs font-semibold text-[var(--vy-text)]">ドラッグで組み合わせ</p>
-                <p className="mt-0.5 text-[0.7rem] text-[var(--vy-text-dim)]">
+                <p className="text-[0.72rem] font-semibold text-[var(--vy-text)]">
+                  ドラッグで組み合わせ
+                </p>
+                <p className="mt-0.5 text-[0.62rem] text-[var(--vy-text-dim)]">
                   長押しで開き、ここにスタンプを落として自由に配置できます。
                 </p>
               </div>
-              <span className="rounded-full bg-[color-mix(in_oklab,var(--vy-text)_10%,transparent)] px-2 py-0.5 text-[0.65rem] text-[var(--vy-text-dim)]">
+              <span className="rounded-full bg-[color-mix(in_oklab,var(--vy-text)_10%,transparent)] px-2 py-0.5 text-[0.6rem] text-[var(--vy-text-dim)]">
                 {comboItems.length} 枚
               </span>
               <button
                 type="button"
                 onClick={clearCombo}
-                className="rounded-full border border-[var(--vy-border)] px-3 py-1.5 text-xs text-[var(--vy-text-dim)] transition-colors hover:bg-[var(--vy-surface)]"
+                className="rounded-full border border-[var(--vy-border)] px-2.5 py-1 text-[0.68rem] text-[var(--vy-text-dim)] transition-colors hover:bg-[var(--vy-surface)]"
               >
                 クリア
               </button>
@@ -525,7 +560,7 @@ export function StickerEmojiPanel({
                 type="button"
                 onClick={() => void sendCombo()}
                 disabled={comboBusy || comboItems.length === 0}
-                className="rounded-full bg-[var(--vy-accent)] px-3 py-1.5 text-xs font-semibold text-[var(--vy-accent-contrast)] transition-opacity disabled:cursor-not-allowed disabled:opacity-50"
+                className="rounded-full bg-[var(--vy-accent)] px-2.5 py-1 text-[0.68rem] font-semibold text-[var(--vy-accent-contrast)] transition-opacity disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {comboBusy ? "送信中…" : "送信"}
               </button>
@@ -533,7 +568,8 @@ export function StickerEmojiPanel({
 
             <div
               ref={comboCanvasRef}
-              className="relative mt-2 h-[360px] overflow-hidden rounded-2xl border border-[var(--vy-border)] bg-[linear-gradient(135deg,color-mix(in_oklab,var(--vy-surface-2)_82%,transparent),color-mix(in_oklab,var(--vy-surface)_94%,transparent))]"
+              className="relative mx-auto mt-2 overflow-hidden rounded-2xl border border-[var(--vy-border)] bg-[linear-gradient(135deg,color-mix(in_oklab,var(--vy-surface-2)_82%,transparent),color-mix(in_oklab,var(--vy-surface)_94%,transparent))]"
+              style={{ width: COMBO_SIZE, height: COMBO_SIZE }}
               onPointerMove={handleComboPointerMove}
               onPointerUp={handleComboPointerUp}
               onPointerLeave={handleComboPointerUp}
@@ -543,10 +579,10 @@ export function StickerEmojiPanel({
               <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,color-mix(in_oklab,var(--vy-accent)_12%,transparent),transparent_38%),radial-gradient(circle_at_bottom_right,color-mix(in_oklab,var(--vy-text)_8%,transparent),transparent_42%)]" />
               {comboItems.length === 0 ? (
                 <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 text-center">
-                  <div className="rounded-full border border-dashed border-[var(--vy-border)] px-4 py-2 text-xs text-[var(--vy-text-dim)]">
+                  <div className="rounded-full border border-dashed border-[var(--vy-border)] px-3 py-1.5 text-[0.68rem] text-[var(--vy-text-dim)]">
                     スタンプをここへドラッグ
                   </div>
-                  <p className="max-w-[18rem] text-[0.7rem] text-[var(--vy-text-dim)]">
+                  <p className="max-w-[16rem] text-[0.62rem] text-[var(--vy-text-dim)]">
                     対応しているスタンプだけが入ります。置いたあとも掴んで動かせます。
                   </p>
                 </div>
@@ -580,7 +616,16 @@ export function StickerEmojiPanel({
                     </button>
                     <button
                       type="button"
-                      className="absolute -right-2 -top-2 flex h-6 w-6 items-center justify-center rounded-full border border-[var(--vy-border)] bg-[var(--vy-surface-2)] text-[0.65rem] text-[var(--vy-text-dim)] shadow-lg"
+                      aria-label="サイズを変更"
+                      title="ドラッグでサイズ変更"
+                      className="absolute -bottom-1.5 -right-1.5 h-4 w-4 cursor-nwse-resize rounded-full border border-[var(--vy-border)] bg-[var(--vy-surface)] opacity-80 shadow-md transition-opacity hover:opacity-100"
+                      onPointerDown={(ev) => handleComboResizeDown(item.uid, ev)}
+                    >
+                      <span className="pointer-events-none absolute inset-[3px] rounded-full bg-[var(--vy-text-dim)]" />
+                    </button>
+                    <button
+                      type="button"
+                      className="absolute -right-2 -top-2 flex h-5 w-5 items-center justify-center rounded-full border border-[var(--vy-border)] bg-[var(--vy-surface-2)] text-[0.6rem] text-[var(--vy-text-dim)] shadow-lg"
                       onClick={() => {
                         setComboItems((prev) => prev.filter((x) => x.uid !== item.uid));
                         if (comboItems.length <= 1) setComboMode(false);
@@ -656,7 +701,7 @@ export function StickerEmojiPanel({
                     setMenu({ x: e.clientX, y: e.clientY, fav: f });
                   }}
                   className={cn(
-                    "flex aspect-square items-center justify-center rounded-xl p-1 transition-colors active:scale-95",
+                    "flex aspect-square items-center justify-center rounded-xl p-0.5 transition-colors active:scale-95",
                     draggable ? "hover:bg-[var(--vy-surface-2)]" : "cursor-not-allowed opacity-55",
                   )}
                 >
@@ -665,6 +710,7 @@ export function StickerEmojiPanel({
                     alt={f.name || ""}
                     className="max-h-full max-w-full object-contain"
                     loading="lazy"
+                    draggable={false}
                     referrerPolicy="no-referrer"
                   />
                 </button>

--- a/Vyline/apps/desktop/src/components/sticker-emoji-panel.tsx
+++ b/Vyline/apps/desktop/src/components/sticker-emoji-panel.tsx
@@ -1,4 +1,5 @@
-import { memo, useEffect, useMemo, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
+import type { DragEvent, PointerEvent as ReactPointerEvent } from "react";
 import { api } from "@/api/client";
 import { cn } from "@/lib/utils";
 import { copyText } from "@/utils/clipboard";
@@ -15,6 +16,7 @@ import {
   setCachedStickersCatalog,
   type StickersCatalogCache,
 } from "@/lib/stickerCatalogCache";
+import type { CombinationStickerPlacement } from "@/utils/combinationStickers";
 
 export type CatalogItem = { id: string; url: string; alt?: string };
 export type CatalogPack = {
@@ -26,140 +28,62 @@ export type CatalogPack = {
 };
 
 type Catalog = StickersCatalogCache;
-type CombinationPick = { packageId: string; stickerId: string; url: string; name?: string };
+type Tab = "sticker" | "emoji" | "favorite";
+type DragPayload = {
+  type: "sticker" | "emoji";
+  packageId: string;
+  stickerId: string;
+  url: string;
+  name?: string;
+};
+type ComboItem = CombinationStickerPlacement & { uid: string };
+type MenuState = { x: number; y: number; fav: StickerFavorite } | null;
 
-/** 絵文字/スタンプ画像を先読みしてブラウザ＋CDNキャッシュを温める */
+const COMBO_LIMIT = 6;
+const COMBO_SIZE = 360;
+const COMBO_ITEM_SIZE = 92;
+const LONG_PRESS_MS = 300;
+
+function assetUrl(url: string): string {
+  return url.startsWith("http") ? `/api/cdn/line?u=${encodeURIComponent(url)}` : url;
+}
+
 function prefetchImgs(urls: string[]): void {
   for (const u of urls) {
-    const src = u.startsWith("http") ? `/api/cdn/line?u=${encodeURIComponent(u)}` : u;
     const img = new Image();
     img.decoding = "async";
-    img.src = src;
+    img.src = assetUrl(u);
   }
 }
 
-function CombinationPreview({ items }: { items: CombinationPick[] }) {
-  const count = items.length;
-  const tiles = (() => {
-    switch (count) {
-      case 1:
-        return [{ x: 18, y: 18, w: 64, h: 64 }];
-      case 2:
-        return [
-          { x: 4, y: 18, w: 38, h: 64 },
-          { x: 58, y: 18, w: 38, h: 64 },
-        ];
-      case 3:
-        return [
-          { x: 22, y: 4, w: 52, h: 44 },
-          { x: 6, y: 50, w: 30, h: 36 },
-          { x: 58, y: 50, w: 30, h: 36 },
-        ];
-      case 4:
-        return [
-          { x: 6, y: 6, w: 36, h: 36 },
-          { x: 50, y: 6, w: 36, h: 36 },
-          { x: 6, y: 50, w: 36, h: 36 },
-          { x: 50, y: 50, w: 36, h: 36 },
-        ];
-      case 5:
-        return [
-          { x: 10, y: 6, w: 28, h: 28 },
-          { x: 50, y: 6, w: 28, h: 28 },
-          { x: 4, y: 42, w: 24, h: 24 },
-          { x: 30, y: 42, w: 24, h: 24 },
-          { x: 56, y: 42, w: 24, h: 24 },
-        ];
-      default:
-        return [
-          { x: 6, y: 8, w: 24, h: 24 },
-          { x: 32, y: 8, w: 24, h: 24 },
-          { x: 58, y: 8, w: 24, h: 24 },
-          { x: 6, y: 42, w: 24, h: 24 },
-          { x: 32, y: 42, w: 24, h: 24 },
-          { x: 58, y: 42, w: 24, h: 24 },
-        ];
-    }
-  })();
-
-  return (
-    <div className="relative h-24 w-24 overflow-hidden rounded-2xl border border-[var(--vy-border)] bg-[var(--vy-surface)] shadow-inner">
-      {count === 0 ? (
-        <div className="flex h-full items-center justify-center text-[0.65rem] text-[var(--vy-text-dim)]">
-          追加したスタンプがここに並びます
-        </div>
-      ) : (
-        tiles.map((tile, i) => {
-          const item = items[i]!;
-          return (
-            <img
-              key={`${item.packageId}-${item.stickerId}-${i}`}
-              src={item.url.startsWith("http") ? `/api/cdn/line?u=${encodeURIComponent(item.url)}` : item.url}
-              alt={item.name || item.stickerId}
-              className="absolute object-contain"
-              style={{ left: `${tile.x}%`, top: `${tile.y}%`, width: `${tile.w}%`, height: `${tile.h}%` }}
-              loading="lazy"
-              referrerPolicy="no-referrer"
-            />
-          );
-        })
-      )}
-      {count > 6 && (
-        <div className="absolute inset-0 flex items-center justify-center rounded-2xl bg-[color-mix(in_oklab,var(--vy-surface)_32%,transparent)] text-xs font-semibold">
-          +{count - 6}
-        </div>
-      )}
-    </div>
-  );
+function readDragPayload(ev: DragEvent): DragPayload | null {
+  const raw = ev.dataTransfer.getData("application/x-vyline-sticker");
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as DragPayload;
+    if (!parsed.packageId || !parsed.stickerId || !parsed.url) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
 }
 
-const UNICODE_EMOJI = [
-  "😀",
-  "😂",
-  "🥹",
-  "😊",
-  "😍",
-  "🤔",
-  "😎",
-  "😴",
-  "🥳",
-  "😇",
-  "🙌",
-  "👍",
-  "🙏",
-  "👏",
-  "🔥",
-  "💯",
-  "✨",
-  "🎉",
-  "❤️",
-  "💙",
-  "💚",
-  "💛",
-  "🧡",
-  "💜",
-  "😭",
-  "😤",
-  "🥺",
-  "😘",
-  "🤝",
-  "👀",
-];
-
-type Tab = "sticker" | "emoji" | "unicode" | "favorite";
-
-type MenuState = { x: number; y: number; fav: StickerFavorite } | null;
+function uid(): string {
+  return `${Date.now()}_${Math.random().toString(16).slice(2)}`;
+}
 
 export function StickerEmojiPanel({
   accountId,
   onPickSticker,
   onPickEmoji,
-  onPickUnicode,
+  onSendCombinationSticker,
 }: {
   accountId: string | null;
   onPickSticker: (packageId: string, stickerId: string, isPremium?: boolean) => void;
   onPickEmoji: (packageId: string, sticonId: string) => void;
-  onPickUnicode: (glyph: string) => void;
+  onSendCombinationSticker: (
+    items: Array<{ packageId: string; stickerId: string; x?: number; y?: number; size?: number }>,
+  ) => Promise<void> | void;
 }) {
   const [tab, setTab] = useState<Tab>("sticker");
   const [favorites, setFavorites] = useState<StickerFavorite[]>(() =>
@@ -173,20 +97,24 @@ export function StickerEmojiPanel({
     accountId ? !getCachedStickersCatalog(accountId) : false,
   );
   const [error, setError] = useState<string | null>(null);
+  const [availability, setAvailability] = useState<Record<string, boolean> | null>(null);
   const [packId, setPackId] = useState<string | null>(() => {
     const cached = accountId ? getCachedStickersCatalog(accountId) : null;
     return cached?.stickerPacks[0]?.packageId ?? cached?.emojiPacks[0]?.packageId ?? null;
   });
   const [comboMode, setComboMode] = useState(false);
-  const [comboItems, setComboItems] = useState<CombinationPick[]>([]);
+  const [comboItems, setComboItems] = useState<ComboItem[]>([]);
   const [comboBusy, setComboBusy] = useState(false);
   const [comboError, setComboError] = useState<string | null>(null);
-  const [comboCreatedId, setComboCreatedId] = useState<string | null>(null);
+  const [draggingComboId, setDraggingComboId] = useState<string | null>(null);
+  const comboCanvasRef = useRef<HTMLDivElement>(null);
+  const dragOffsetRef = useRef({ x: 0, y: 0 });
+  const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const longPressTriggeredRef = useRef(false);
 
   useEffect(() => {
     if (!accountId) return;
     let cancelled = false;
-
     const cached = getCachedStickersCatalog(accountId);
     if (cached) {
       setCatalog(cached);
@@ -239,26 +167,8 @@ export function StickerEmojiPanel({
     };
   }, [accountId]);
 
-  const packs = useMemo(() => {
-    if (!catalog) return [];
-    if (tab === "sticker") return catalog.stickerPacks;
-    if (tab === "emoji") return catalog.emojiPacks;
-    return [];
-  }, [catalog, tab]);
-
-  const activePack = packs.find((p) => p.packageId === packId) ?? packs[0];
-  const selectedCountText = `${comboItems.length} 枚選択中`;
-
   useEffect(() => {
-    if (tab === "unicode") return;
-    if (!packs.some((p) => p.packageId === packId)) {
-      setPackId(packs[0]?.packageId ?? null);
-    }
-  }, [tab, packs, packId]);
-
-  // カタログ／選択パックが変わったら画像を先読み（開く前にキャッシュを温める）
-  useEffect(() => {
-    if (!catalog) return;
+    if (!catalog || !accountId) return;
     const tabIcons = [
       ...catalog.stickerPacks.map((p) => p.tabUrl),
       ...catalog.emojiPacks.map((p) => p.tabUrl),
@@ -268,78 +178,274 @@ export function StickerEmojiPanel({
       catalog.emojiPacks.find((p) => p.packageId === packId);
     const items = active ? active.items.map((i) => i.url) : [];
     prefetchImgs([...tabIcons, ...items]);
-  }, [catalog, packId]);
+  }, [catalog, packId, accountId]);
 
-  function toggleComboMode(): void {
-    setComboMode((next) => {
-      const enabled = !next;
-      if (!enabled) {
-        setComboError(null);
-      }
-      return enabled;
+  useEffect(() => {
+    if (!accountId || !catalog) return;
+    let cancelled = false;
+    const packageIds = catalog.stickerPacks.map((p) => p.packageId);
+    if (packageIds.length === 0) {
+      setAvailability({});
+      return;
+    }
+    setAvailability(null);
+    void Promise.all(
+      packageIds.map(async (packageId) => {
+        try {
+          const res = await api.line.isStickerAvailableForCombinationSticker(accountId, packageId);
+          return [packageId, Boolean(res.ok && res.availableForCombinationSticker)] as const;
+        } catch {
+          return [packageId, false] as const;
+        }
+      }),
+    ).then((entries) => {
+      if (cancelled) return;
+      setAvailability(Object.fromEntries(entries));
     });
+    return () => {
+      cancelled = true;
+    };
+  }, [accountId, catalog]);
+
+  const packs = useMemo(() => {
+    if (!catalog) return [];
+    if (tab === "sticker") return catalog.stickerPacks;
+    if (tab === "emoji") return catalog.emojiPacks;
+    return [];
+  }, [catalog, tab]);
+
+  const activePack = packs.find((p) => p.packageId === packId) ?? packs[0];
+
+  useEffect(() => {
+    if (!packs.some((p) => p.packageId === packId)) {
+      setPackId(packs[0]?.packageId ?? null);
+    }
+  }, [packs, packId]);
+
+  function canDragSticker(type: "sticker" | "emoji", packageId: string): boolean {
+    if (type !== "sticker") return false;
+    if (availability == null) return false;
+    return Boolean(availability[packageId]);
   }
 
-  function addComboItem(item: CombinationPick): void {
+  function normalizePoint(x: number, y: number, size: number): { x: number; y: number } {
+    return {
+      x: Math.max(0, Math.min(COMBO_SIZE - size, x)),
+      y: Math.max(0, Math.min(COMBO_SIZE - size, y)),
+    };
+  }
+
+  function addComboItem(payload: DragPayload, at?: { x: number; y: number }): void {
+    if (payload.type !== "sticker") return;
+    setComboMode(true);
     setComboError(null);
-    setComboCreatedId(null);
     setComboItems((prev) => {
-      const exists = prev.some(
-        (x) => x.packageId === item.packageId && x.stickerId === item.stickerId,
-      );
-      if (exists) {
-        return prev.filter((x) => !(x.packageId === item.packageId && x.stickerId === item.stickerId));
-      }
-      if (prev.length >= 6) {
-        setComboError("組み合わせは最大6枚までです");
+      if (prev.length >= COMBO_LIMIT) {
+        setComboError(`組み合わせは最大${COMBO_LIMIT}枚までです`);
         return prev;
       }
-      return [...prev, item];
+      const size = COMBO_ITEM_SIZE;
+      const base = at ?? { x: COMBO_SIZE / 2 - size / 2, y: COMBO_SIZE / 2 - size / 2 };
+      const pos = normalizePoint(base.x - size / 2, base.y - size / 2, size);
+      return [
+        ...prev,
+        {
+          ...payload,
+          uid: uid(),
+          x: pos.x,
+          y: pos.y,
+          size,
+        },
+      ];
     });
   }
 
-  async function createComboSticker(): Promise<void> {
-    if (!accountId) return;
+  function clearCombo(): void {
+    setComboItems([]);
+    setComboMode(false);
+    setComboError(null);
+  }
+
+  async function sendCombo(): Promise<void> {
+    if (comboBusy) return;
     if (comboItems.length === 0) {
-      setComboError("スタンプを1つ以上選んでください");
+      setComboError("スタンプを1つ以上置いてください");
       return;
     }
     setComboBusy(true);
     setComboError(null);
     try {
-      const packageIds = [...new Set(comboItems.map((item) => item.packageId))];
-      const canCreate = await api.line.canCreateCombinationSticker(accountId, packageIds);
-      if (!canCreate.ok || !canCreate.canCreate) {
-        setComboError("この組み合わせは作成できません");
-        return;
-      }
-      const created = await api.line.createCombinationSticker(
-        accountId,
-        comboItems.map((item) => ({ packageId: item.packageId, stickerId: item.stickerId })),
+      await onSendCombinationSticker(
+        comboItems.map(({ packageId, stickerId, x, y, size }) => ({
+          packageId,
+          stickerId,
+          x,
+          y,
+          size,
+        })),
       );
-      if (!created.ok) {
-        setComboError(created.error || "作成に失敗しました");
-        return;
-      }
-      setComboCreatedId(created.id);
-      setComboItems([]);
-      void copyText(`組み合わせスタンプを作成しました: ${created.id}`);
+      clearCombo();
     } catch (err) {
-      setComboError(String(err));
+      setComboError(err instanceof Error ? err.message : String(err));
     } finally {
       setComboBusy(false);
     }
   }
 
+  function handleComboDrop(ev: DragEvent<HTMLDivElement>): void {
+    ev.preventDefault();
+    ev.stopPropagation();
+    const payload = readDragPayload(ev);
+    if (!payload) return;
+    const rect = comboCanvasRef.current?.getBoundingClientRect();
+    addComboItem(
+      payload,
+      rect ? { x: ev.clientX - rect.left, y: ev.clientY - rect.top } : undefined,
+    );
+  }
+
+  function handleComboDragOver(ev: DragEvent<HTMLDivElement>): void {
+    ev.preventDefault();
+    ev.dataTransfer.dropEffect = "copy";
+  }
+
+  function handleComboPointerDown(
+    uidValue: string,
+    ev: ReactPointerEvent<HTMLButtonElement>,
+  ): void {
+    const rect = comboCanvasRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const item = comboItems.find((x) => x.uid === uidValue);
+    if (!item) return;
+    ev.preventDefault();
+    ev.currentTarget.setPointerCapture(ev.pointerId);
+    setDraggingComboId(uidValue);
+    dragOffsetRef.current = {
+      x: ev.clientX - rect.left - item.x,
+      y: ev.clientY - rect.top - item.y,
+    };
+  }
+
+  function handleComboPointerMove(ev: ReactPointerEvent<HTMLDivElement>): void {
+    if (!draggingComboId) return;
+    const rect = comboCanvasRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const item = comboItems.find((x) => x.uid === draggingComboId);
+    if (!item) return;
+    const next = normalizePoint(
+      ev.clientX - rect.left - dragOffsetRef.current.x,
+      ev.clientY - rect.top - dragOffsetRef.current.y,
+      item.size,
+    );
+    setComboItems((prev) => prev.map((x) => (x.uid === draggingComboId ? { ...x, ...next } : x)));
+  }
+
+  function handleComboPointerUp(): void {
+    setDraggingComboId(null);
+  }
+
+  function startLongPress(payload: DragPayload): void {
+    if (!canDragSticker(payload.type, payload.packageId)) return;
+    stopLongPress();
+    longPressTriggeredRef.current = false;
+    longPressTimerRef.current = setTimeout(() => {
+      longPressTriggeredRef.current = true;
+      addComboItem(payload);
+    }, LONG_PRESS_MS);
+  }
+
+  function stopLongPress(): void {
+    if (longPressTimerRef.current) clearTimeout(longPressTimerRef.current);
+    longPressTimerRef.current = null;
+  }
+
+  function handleStickerClick(payload: DragPayload, action: () => void): void {
+    if (longPressTriggeredRef.current) {
+      longPressTriggeredRef.current = false;
+      return;
+    }
+    if (comboMode && payload.type === "sticker") {
+      addComboItem(payload);
+      return;
+    }
+    action();
+  }
+
+  function renderGridItem(item: CatalogItem, pack: CatalogPack) {
+    const payload: DragPayload = {
+      type: pack.type,
+      packageId: pack.packageId,
+      stickerId: item.id,
+      url: item.url,
+      name: item.alt || pack.name,
+    };
+    const draggable = canDragSticker(pack.type, pack.packageId);
+    return (
+      <button
+        key={item.id}
+        type="button"
+        title={item.alt || item.id}
+        draggable={draggable}
+        onPointerDown={() => startLongPress(payload)}
+        onPointerMove={stopLongPress}
+        onPointerUp={stopLongPress}
+        onPointerCancel={stopLongPress}
+        onPointerLeave={stopLongPress}
+        onDragStart={(ev) => {
+          if (!draggable) {
+            ev.preventDefault();
+            return;
+          }
+          ev.dataTransfer.effectAllowed = "copy";
+          ev.dataTransfer.setData("application/x-vyline-sticker", JSON.stringify(payload));
+        }}
+        onClick={() =>
+          handleStickerClick(payload, () => {
+            if (pack.type === "sticker") {
+              onPickSticker(pack.packageId, item.id, catalog?.premium?.active);
+            } else {
+              onPickEmoji(pack.packageId, item.id);
+            }
+          })
+        }
+        onContextMenu={(e) => {
+          e.preventDefault();
+          setMenu({
+            x: e.clientX,
+            y: e.clientY,
+            fav: {
+              type: pack.type,
+              packageId: pack.packageId,
+              id: item.id,
+              url: item.url,
+              name: item.alt || pack.name,
+            },
+          });
+        }}
+        className={cn(
+          "flex aspect-square items-center justify-center rounded-xl p-1 transition-colors active:scale-95",
+          draggable ? "hover:bg-[var(--vy-surface-2)]" : "cursor-not-allowed opacity-55",
+        )}
+      >
+        <img
+          src={assetUrl(item.url)}
+          alt={item.alt || ""}
+          className="max-h-full max-w-full object-contain"
+          loading="lazy"
+          referrerPolicy="no-referrer"
+        />
+      </button>
+    );
+  }
+
   return (
-    <div className="vy-scale-in absolute bottom-full left-3 mb-2 flex h-[320px] w-[min(380px,92vw)] flex-col overflow-hidden rounded-2xl border border-[var(--vy-border)] bg-[var(--vy-surface)] shadow-2xl md:left-5">
+    <div className="vy-scale-in absolute bottom-full left-3 mb-2 flex h-[min(720px,86vh)] w-[min(680px,96vw)] flex-col overflow-hidden rounded-2xl border border-[var(--vy-border)] bg-[var(--vy-surface)] shadow-2xl md:left-5">
       <div className="flex items-center gap-1 border-b border-[var(--vy-border)] px-2 pt-2">
         {(
           [
             ["sticker", "スタンプ"],
             ["emoji", "絵文字"],
             ["favorite", "★"],
-            ["unicode", "Unicode"],
           ] as const
         ).map(([id, label]) => (
           <button
@@ -366,23 +472,9 @@ export function StickerEmojiPanel({
               : "Premium —"}
           </span>
         </span>
-        {tab === "sticker" && (
-          <button
-            type="button"
-            onClick={toggleComboMode}
-            className={cn(
-              "mb-1 rounded-full px-2.5 py-1 text-[0.65rem] font-semibold transition-colors",
-              comboMode
-                ? "bg-[var(--vy-accent)] text-[var(--vy-accent-contrast)]"
-                : "bg-[var(--vy-surface-2)] text-[var(--vy-text-dim)] hover:text-[var(--vy-text)]",
-            )}
-          >
-            {comboMode ? "組み合わせ中" : "組み合わせ作成"}
-          </button>
-        )}
       </div>
 
-      {tab !== "unicode" && (
+      {tab !== "favorite" && (
         <div className="flex gap-1 overflow-x-auto border-b border-[var(--vy-border)] px-2 py-1.5 [scrollbar-width:thin]">
           {packs.map((p) => (
             <button
@@ -398,7 +490,7 @@ export function StickerEmojiPanel({
               )}
             >
               <img
-                src={p.tabUrl}
+                src={assetUrl(p.tabUrl)}
                 alt=""
                 className="h-7 w-7 object-contain"
                 loading="lazy"
@@ -410,207 +502,201 @@ export function StickerEmojiPanel({
       )}
 
       <div className="min-h-0 flex-1 overflow-y-auto p-2">
-        {comboMode && tab === "sticker" && (
+        {comboMode && activePack?.type === "sticker" && (
           <div className="mb-2 rounded-2xl border border-[var(--vy-border)] bg-[var(--vy-surface-2)] p-2">
-            <div className="flex items-start gap-3">
-              <CombinationPreview items={comboItems} />
+            <div className="flex items-center gap-2">
               <div className="min-w-0 flex-1">
-                <div className="flex items-center gap-2">
-                  <p className="text-xs font-semibold text-[var(--vy-text)]">組み合わせ作成</p>
-                  <span className="rounded-full bg-[color-mix(in_oklab,var(--vy-text)_10%,transparent)] px-2 py-0.5 text-[0.65rem] text-[var(--vy-text-dim)]">
-                    {selectedCountText}
-                  </span>
-                </div>
-                <p className="mt-1 text-[0.7rem] text-[var(--vy-text-dim)]">
-                  スタンプを最大6枚まで選んで、作成ボタンを押してください。
+                <p className="text-xs font-semibold text-[var(--vy-text)]">ドラッグで組み合わせ</p>
+                <p className="mt-0.5 text-[0.7rem] text-[var(--vy-text-dim)]">
+                  長押しで開き、ここにスタンプを落として自由に配置できます。
                 </p>
-                <div className="mt-2 flex flex-wrap gap-1">
-                  {comboItems.map((item) => (
+              </div>
+              <span className="rounded-full bg-[color-mix(in_oklab,var(--vy-text)_10%,transparent)] px-2 py-0.5 text-[0.65rem] text-[var(--vy-text-dim)]">
+                {comboItems.length} 枚
+              </span>
+              <button
+                type="button"
+                onClick={clearCombo}
+                className="rounded-full border border-[var(--vy-border)] px-3 py-1.5 text-xs text-[var(--vy-text-dim)] transition-colors hover:bg-[var(--vy-surface)]"
+              >
+                クリア
+              </button>
+              <button
+                type="button"
+                onClick={() => void sendCombo()}
+                disabled={comboBusy || comboItems.length === 0}
+                className="rounded-full bg-[var(--vy-accent)] px-3 py-1.5 text-xs font-semibold text-[var(--vy-accent-contrast)] transition-opacity disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {comboBusy ? "送信中…" : "送信"}
+              </button>
+            </div>
+
+            <div
+              ref={comboCanvasRef}
+              className="relative mt-2 h-[360px] overflow-hidden rounded-2xl border border-[var(--vy-border)] bg-[linear-gradient(135deg,color-mix(in_oklab,var(--vy-surface-2)_82%,transparent),color-mix(in_oklab,var(--vy-surface)_94%,transparent))]"
+              onPointerMove={handleComboPointerMove}
+              onPointerUp={handleComboPointerUp}
+              onPointerLeave={handleComboPointerUp}
+              onDragOver={handleComboDragOver}
+              onDrop={handleComboDrop}
+            >
+              <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,color-mix(in_oklab,var(--vy-accent)_12%,transparent),transparent_38%),radial-gradient(circle_at_bottom_right,color-mix(in_oklab,var(--vy-text)_8%,transparent),transparent_42%)]" />
+              {comboItems.length === 0 ? (
+                <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 text-center">
+                  <div className="rounded-full border border-dashed border-[var(--vy-border)] px-4 py-2 text-xs text-[var(--vy-text-dim)]">
+                    スタンプをここへドラッグ
+                  </div>
+                  <p className="max-w-[18rem] text-[0.7rem] text-[var(--vy-text-dim)]">
+                    対応しているスタンプだけが入ります。置いたあとも掴んで動かせます。
+                  </p>
+                </div>
+              ) : null}
+
+              {comboItems.map((item) => {
+                const dragging = draggingComboId === item.uid;
+                return (
+                  <div
+                    key={item.uid}
+                    className={cn(
+                      "absolute rounded-2xl border border-transparent bg-transparent transition-transform",
+                      dragging &&
+                        "scale-105 border-[color-mix(in_oklab,var(--vy-accent)_65%,transparent)]",
+                    )}
+                    style={{ left: item.x, top: item.y, width: item.size, height: item.size }}
+                  >
                     <button
-                      key={`${item.packageId}-${item.stickerId}`}
                       type="button"
-                      onClick={() => addComboItem(item)}
-                      className="inline-flex items-center gap-1 rounded-full border border-[var(--vy-border)] px-2 py-1 text-[0.65rem] text-[var(--vy-text-dim)] transition-colors hover:bg-[var(--vy-surface)]"
+                      className="absolute inset-0 rounded-2xl"
+                      onPointerDown={(ev) => handleComboPointerDown(item.uid, ev)}
                     >
-                      <span className="max-w-24 truncate">{item.name || item.stickerId}</span>
-                      <span aria-hidden>×</span>
+                      <img
+                        src={assetUrl(item.url)}
+                        alt={item.name || item.stickerId}
+                        className="pointer-events-none h-full w-full object-contain drop-shadow-[0_2px_8px_rgba(0,0,0,0.18)]"
+                        loading="lazy"
+                        draggable={false}
+                        referrerPolicy="no-referrer"
+                      />
                     </button>
-                  ))}
-                </div>
-                <div className="mt-3 flex flex-wrap gap-2">
-                  <button
-                    type="button"
-                    onClick={() => void createComboSticker()}
-                    disabled={comboBusy || comboItems.length === 0}
-                    className="rounded-full bg-[var(--vy-accent)] px-3 py-1.5 text-xs font-semibold text-[var(--vy-accent-contrast)] transition-opacity disabled:cursor-not-allowed disabled:opacity-50"
-                  >
-                    {comboBusy ? "作成中…" : "作成"}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setComboItems([]);
-                      setComboError(null);
-                      setComboCreatedId(null);
-                    }}
-                    className="rounded-full border border-[var(--vy-border)] px-3 py-1.5 text-xs text-[var(--vy-text-dim)] transition-colors hover:bg-[var(--vy-surface)]"
-                  >
-                    クリア
-                  </button>
-                </div>
-                {comboCreatedId && (
-                  <div className="mt-2 rounded-xl border border-[color-mix(in_oklab,var(--vy-accent)_35%,var(--vy-border))] bg-[color-mix(in_oklab,var(--vy-accent)_10%,transparent)] px-3 py-2 text-xs">
-                    <span className="font-semibold text-[var(--vy-text)]">作成済み</span>
-                    <span className="ml-2 break-all text-[var(--vy-text-dim)]">{comboCreatedId}</span>
                     <button
                       type="button"
-                      onClick={() => void copyText(comboCreatedId)}
-                      className="ml-2 rounded-full bg-[var(--vy-surface)] px-2 py-0.5 font-medium text-[var(--vy-text)]"
+                      className="absolute -right-2 -top-2 flex h-6 w-6 items-center justify-center rounded-full border border-[var(--vy-border)] bg-[var(--vy-surface-2)] text-[0.65rem] text-[var(--vy-text-dim)] shadow-lg"
+                      onClick={() => {
+                        setComboItems((prev) => prev.filter((x) => x.uid !== item.uid));
+                        if (comboItems.length <= 1) setComboMode(false);
+                      }}
+                      aria-label="組み合わせから削除"
                     >
-                      コピー
+                      ×
                     </button>
                   </div>
-                )}
-                {comboError && <p className="mt-2 text-xs text-[var(--vy-danger)]">{comboError}</p>}
-              </div>
+                );
+              })}
             </div>
+            {comboError && <p className="mt-2 text-xs text-[var(--vy-danger)]">{comboError}</p>}
           </div>
         )}
+
         {loading && !catalog && (
           <p className="px-2 py-6 text-center text-xs text-[var(--vy-text-dim)]">読み込み中…</p>
         )}
         {error && !loading && !catalog && (
           <p className="px-2 py-6 text-center text-xs text-[var(--vy-danger)]">{error}</p>
         )}
-        {!error && tab === "unicode" && (
-          <div className="grid grid-cols-8 gap-1">
-            {UNICODE_EMOJI.map((g) => (
-              <button
-                key={g}
-                type="button"
-                onClick={() => onPickUnicode(g)}
-                className="flex h-9 items-center justify-center rounded-lg text-xl transition-transform hover:scale-110 hover:bg-[var(--vy-surface-2)]"
-              >
-                {g}
-              </button>
-            ))}
-          </div>
-        )}
-        {tab === "favorite" && (
+
+        {tab === "favorite" ? (
           <div className="grid grid-cols-4 gap-1">
             {favorites.length === 0 && (
               <p className="col-span-4 px-2 py-6 text-center text-xs text-[var(--vy-text-dim)]">
                 右クリックでスタンプ / 絵文字をお気に入りに追加できます
               </p>
             )}
-            {favorites.map((f) => (
-              <button
-                key={`${f.type}-${f.id}`}
-                type="button"
-                title={f.name || f.id}
-                onClick={() => {
-                  if (comboMode && f.type === "sticker") {
-                    addComboItem({
-                      packageId: f.packageId,
-                      stickerId: f.id,
-                      url: f.url,
-                      name: f.name || f.id,
-                    });
-                  } else if (f.type === "sticker")
-                    onPickSticker(f.packageId, f.id, catalog?.premium?.active);
-                  else onPickEmoji(f.packageId, f.id);
-                }}
-                onContextMenu={(e) => {
-                  e.preventDefault();
-                  setMenu({ x: e.clientX, y: e.clientY, fav: f });
-                }}
-                className="flex aspect-square items-center justify-center rounded-xl p-1 transition-colors hover:bg-[var(--vy-surface-2)] active:scale-95"
-              >
-                <img
-                  src={
-                    f.url.startsWith("http")
-                      ? `/api/cdn/line?u=${encodeURIComponent(f.url)}`
-                      : f.url
-                  }
-                  alt={f.name || ""}
-                  className="max-h-full max-w-full object-contain"
-                  loading="lazy"
-                  referrerPolicy="no-referrer"
-                />
-              </button>
-            ))}
-          </div>
-        )}
-        {catalog && tab !== "unicode" && tab !== "favorite" && activePack && (
-          <div className={cn("grid gap-1", tab === "sticker" ? "grid-cols-4" : "grid-cols-6")}>
-            {activePack.items.map((item) => {
-              const isFav = favorites.some((f) => f.type === activePack.type && f.id === item.id);
+            {favorites.map((f) => {
+              const payload: DragPayload = {
+                type: f.type,
+                packageId: f.packageId,
+                stickerId: f.id,
+                url: f.url,
+                name: f.name || f.id,
+              };
+              const draggable = canDragSticker(f.type, f.packageId);
               return (
-                <div key={item.id} className="relative">
-                  <button
-                    type="button"
-                    title={item.alt || item.id}
-                    onClick={() => {
-                      if (comboMode && activePack.type === "sticker") {
-                        addComboItem({
-                          packageId: activePack.packageId,
-                          stickerId: item.id,
-                          url: item.url,
-                          name: item.alt || activePack.name,
-                        });
-                      } else if (activePack.type === "sticker") {
-                        onPickSticker(activePack.packageId, item.id, catalog?.premium?.active);
+                <button
+                  key={`${f.type}-${f.id}`}
+                  type="button"
+                  title={f.name || f.id}
+                  draggable={draggable}
+                  onPointerDown={() => startLongPress(payload)}
+                  onPointerMove={stopLongPress}
+                  onPointerUp={stopLongPress}
+                  onPointerCancel={stopLongPress}
+                  onPointerLeave={stopLongPress}
+                  onDragStart={(ev) => {
+                    if (!draggable) {
+                      ev.preventDefault();
+                      return;
+                    }
+                    ev.dataTransfer.effectAllowed = "copy";
+                    ev.dataTransfer.setData(
+                      "application/x-vyline-sticker",
+                      JSON.stringify(payload),
+                    );
+                  }}
+                  onClick={() =>
+                    handleStickerClick(payload, () => {
+                      if (f.type === "sticker") {
+                        onPickSticker(f.packageId, f.id, catalog?.premium?.active);
                       } else {
-                        onPickEmoji(activePack.packageId, item.id);
+                        onPickEmoji(f.packageId, f.id);
                       }
-                    }}
-                    onContextMenu={(e) => {
-                      e.preventDefault();
-                      setMenu({
-                        x: e.clientX,
-                        y: e.clientY,
-                        fav: {
-                          type: activePack.type,
-                          packageId: activePack.packageId,
-                          id: item.id,
-                          url: item.url,
-                          name: item.alt || activePack.name,
-                        },
-                      });
-                    }}
-                    className="flex aspect-square items-center justify-center rounded-xl p-1 transition-colors hover:bg-[var(--vy-surface-2)] active:scale-95"
-                  >
-                    <img
-                      src={
-                        item.url.startsWith("http")
-                          ? `/api/cdn/line?u=${encodeURIComponent(item.url)}`
-                          : item.url
-                      }
-                      alt={item.alt || ""}
-                      className="max-h-full max-w-full object-contain"
-                      loading="lazy"
-                      referrerPolicy="no-referrer"
-                    />
-                  </button>
-                  {isFav && (
-                    <span className="pointer-events-none absolute right-0.5 top-0.5 text-[0.6rem] text-[var(--vy-accent)]">
-                      ★
-                    </span>
+                    })
+                  }
+                  onContextMenu={(e) => {
+                    e.preventDefault();
+                    setMenu({ x: e.clientX, y: e.clientY, fav: f });
+                  }}
+                  className={cn(
+                    "flex aspect-square items-center justify-center rounded-xl p-1 transition-colors active:scale-95",
+                    draggable ? "hover:bg-[var(--vy-surface-2)]" : "cursor-not-allowed opacity-55",
                   )}
-                  {comboMode && activePack.type === "sticker" && (
-                    <span className="pointer-events-none absolute left-0.5 top-0.5 rounded-full bg-[var(--vy-accent)] px-1 py-0.5 text-[0.55rem] font-bold text-[var(--vy-accent-contrast)]">
-                      +
-                    </span>
-                  )}
-                </div>
+                >
+                  <img
+                    src={assetUrl(f.url)}
+                    alt={f.name || ""}
+                    className="max-h-full max-w-full object-contain"
+                    loading="lazy"
+                    referrerPolicy="no-referrer"
+                  />
+                </button>
               );
             })}
           </div>
-        )}
-        {catalog && tab !== "unicode" && tab !== "favorite" && !activePack && (
-          <p className="px-2 py-6 text-center text-xs text-[var(--vy-text-dim)]">
-            パックがありません
-          </p>
+        ) : (
+          <>
+            {catalog && activePack ? (
+              <div className={cn("grid gap-1", tab === "sticker" ? "grid-cols-4" : "grid-cols-6")}>
+                {activePack.items.map((item) => {
+                  const isFav = favorites.some(
+                    (f) => f.type === activePack.type && f.id === item.id,
+                  );
+                  return (
+                    <div key={item.id} className="relative">
+                      {renderGridItem(item, activePack)}
+                      {isFav && (
+                        <span className="pointer-events-none absolute right-0.5 top-0.5 text-[0.6rem] text-[var(--vy-accent)]">
+                          ★
+                        </span>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            ) : (
+              <p className="px-2 py-6 text-center text-xs text-[var(--vy-text-dim)]">
+                パックがありません
+              </p>
+            )}
+          </>
         )}
       </div>
 

--- a/Vyline/apps/desktop/src/components/sticker-emoji-panel.tsx
+++ b/Vyline/apps/desktop/src/components/sticker-emoji-panel.tsx
@@ -2,6 +2,7 @@ import { memo, useEffect, useMemo, useState } from "react";
 import { api } from "@/api/client";
 import { cn } from "@/lib/utils";
 import { copyText } from "@/utils/clipboard";
+import { PremiumBadge } from "@/components/premium-badge";
 import {
   lineStoreUrl,
   loadStickerFavorites,
@@ -25,6 +26,7 @@ export type CatalogPack = {
 };
 
 type Catalog = StickersCatalogCache;
+type CombinationPick = { packageId: string; stickerId: string; url: string; name?: string };
 
 /** 絵文字/スタンプ画像を先読みしてブラウザ＋CDNキャッシュを温める */
 function prefetchImgs(urls: string[]): void {
@@ -34,6 +36,81 @@ function prefetchImgs(urls: string[]): void {
     img.decoding = "async";
     img.src = src;
   }
+}
+
+function CombinationPreview({ items }: { items: CombinationPick[] }) {
+  const count = items.length;
+  const tiles = (() => {
+    switch (count) {
+      case 1:
+        return [{ x: 18, y: 18, w: 64, h: 64 }];
+      case 2:
+        return [
+          { x: 4, y: 18, w: 38, h: 64 },
+          { x: 58, y: 18, w: 38, h: 64 },
+        ];
+      case 3:
+        return [
+          { x: 22, y: 4, w: 52, h: 44 },
+          { x: 6, y: 50, w: 30, h: 36 },
+          { x: 58, y: 50, w: 30, h: 36 },
+        ];
+      case 4:
+        return [
+          { x: 6, y: 6, w: 36, h: 36 },
+          { x: 50, y: 6, w: 36, h: 36 },
+          { x: 6, y: 50, w: 36, h: 36 },
+          { x: 50, y: 50, w: 36, h: 36 },
+        ];
+      case 5:
+        return [
+          { x: 10, y: 6, w: 28, h: 28 },
+          { x: 50, y: 6, w: 28, h: 28 },
+          { x: 4, y: 42, w: 24, h: 24 },
+          { x: 30, y: 42, w: 24, h: 24 },
+          { x: 56, y: 42, w: 24, h: 24 },
+        ];
+      default:
+        return [
+          { x: 6, y: 8, w: 24, h: 24 },
+          { x: 32, y: 8, w: 24, h: 24 },
+          { x: 58, y: 8, w: 24, h: 24 },
+          { x: 6, y: 42, w: 24, h: 24 },
+          { x: 32, y: 42, w: 24, h: 24 },
+          { x: 58, y: 42, w: 24, h: 24 },
+        ];
+    }
+  })();
+
+  return (
+    <div className="relative h-24 w-24 overflow-hidden rounded-2xl border border-[var(--vy-border)] bg-[var(--vy-surface)] shadow-inner">
+      {count === 0 ? (
+        <div className="flex h-full items-center justify-center text-[0.65rem] text-[var(--vy-text-dim)]">
+          追加したスタンプがここに並びます
+        </div>
+      ) : (
+        tiles.map((tile, i) => {
+          const item = items[i]!;
+          return (
+            <img
+              key={`${item.packageId}-${item.stickerId}-${i}`}
+              src={item.url.startsWith("http") ? `/api/cdn/line?u=${encodeURIComponent(item.url)}` : item.url}
+              alt={item.name || item.stickerId}
+              className="absolute object-contain"
+              style={{ left: `${tile.x}%`, top: `${tile.y}%`, width: `${tile.w}%`, height: `${tile.h}%` }}
+              loading="lazy"
+              referrerPolicy="no-referrer"
+            />
+          );
+        })
+      )}
+      {count > 6 && (
+        <div className="absolute inset-0 flex items-center justify-center rounded-2xl bg-[color-mix(in_oklab,var(--vy-surface)_32%,transparent)] text-xs font-semibold">
+          +{count - 6}
+        </div>
+      )}
+    </div>
+  );
 }
 
 const UNICODE_EMOJI = [
@@ -100,6 +177,11 @@ export function StickerEmojiPanel({
     const cached = accountId ? getCachedStickersCatalog(accountId) : null;
     return cached?.stickerPacks[0]?.packageId ?? cached?.emojiPacks[0]?.packageId ?? null;
   });
+  const [comboMode, setComboMode] = useState(false);
+  const [comboItems, setComboItems] = useState<CombinationPick[]>([]);
+  const [comboBusy, setComboBusy] = useState(false);
+  const [comboError, setComboError] = useState<string | null>(null);
+  const [comboCreatedId, setComboCreatedId] = useState<string | null>(null);
 
   useEffect(() => {
     if (!accountId) return;
@@ -165,6 +247,7 @@ export function StickerEmojiPanel({
   }, [catalog, tab]);
 
   const activePack = packs.find((p) => p.packageId === packId) ?? packs[0];
+  const selectedCountText = `${comboItems.length} 枚選択中`;
 
   useEffect(() => {
     if (tab === "unicode") return;
@@ -186,6 +269,67 @@ export function StickerEmojiPanel({
     const items = active ? active.items.map((i) => i.url) : [];
     prefetchImgs([...tabIcons, ...items]);
   }, [catalog, packId]);
+
+  function toggleComboMode(): void {
+    setComboMode((next) => {
+      const enabled = !next;
+      if (!enabled) {
+        setComboError(null);
+      }
+      return enabled;
+    });
+  }
+
+  function addComboItem(item: CombinationPick): void {
+    setComboError(null);
+    setComboCreatedId(null);
+    setComboItems((prev) => {
+      const exists = prev.some(
+        (x) => x.packageId === item.packageId && x.stickerId === item.stickerId,
+      );
+      if (exists) {
+        return prev.filter((x) => !(x.packageId === item.packageId && x.stickerId === item.stickerId));
+      }
+      if (prev.length >= 6) {
+        setComboError("組み合わせは最大6枚までです");
+        return prev;
+      }
+      return [...prev, item];
+    });
+  }
+
+  async function createComboSticker(): Promise<void> {
+    if (!accountId) return;
+    if (comboItems.length === 0) {
+      setComboError("スタンプを1つ以上選んでください");
+      return;
+    }
+    setComboBusy(true);
+    setComboError(null);
+    try {
+      const packageIds = [...new Set(comboItems.map((item) => item.packageId))];
+      const canCreate = await api.line.canCreateCombinationSticker(accountId, packageIds);
+      if (!canCreate.ok || !canCreate.canCreate) {
+        setComboError("この組み合わせは作成できません");
+        return;
+      }
+      const created = await api.line.createCombinationSticker(
+        accountId,
+        comboItems.map((item) => ({ packageId: item.packageId, stickerId: item.stickerId })),
+      );
+      if (!created.ok) {
+        setComboError(created.error || "作成に失敗しました");
+        return;
+      }
+      setComboCreatedId(created.id);
+      setComboItems([]);
+      void copyText(`組み合わせスタンプを作成しました: ${created.id}`);
+    } catch (err) {
+      setComboError(String(err));
+    } finally {
+      setComboBusy(false);
+    }
+  }
 
   return (
     <div className="vy-scale-in absolute bottom-full left-3 mb-2 flex h-[320px] w-[min(380px,92vw)] flex-col overflow-hidden rounded-2xl border border-[var(--vy-border)] bg-[var(--vy-surface)] shadow-2xl md:left-5">
@@ -212,13 +356,30 @@ export function StickerEmojiPanel({
             {label}
           </button>
         ))}
-        <span className="ml-auto px-2 text-[0.65rem] text-[var(--vy-text-dim)]">
-          {catalog?.premium.active
-            ? catalog.premium.onFreeTrial
-              ? "Premium お試し"
-              : "Premium"
-            : "Premium —"}
+        <span className="ml-auto flex items-center gap-1 px-2 text-[0.65rem] text-[var(--vy-text-dim)]">
+          {catalog?.premium.active && <PremiumBadge size={12} compact />}
+          <span>
+            {catalog?.premium.active
+              ? catalog.premium.onFreeTrial
+                ? "Premium お試し"
+                : "Premium"
+              : "Premium —"}
+          </span>
         </span>
+        {tab === "sticker" && (
+          <button
+            type="button"
+            onClick={toggleComboMode}
+            className={cn(
+              "mb-1 rounded-full px-2.5 py-1 text-[0.65rem] font-semibold transition-colors",
+              comboMode
+                ? "bg-[var(--vy-accent)] text-[var(--vy-accent-contrast)]"
+                : "bg-[var(--vy-surface-2)] text-[var(--vy-text-dim)] hover:text-[var(--vy-text)]",
+            )}
+          >
+            {comboMode ? "組み合わせ中" : "組み合わせ作成"}
+          </button>
+        )}
       </div>
 
       {tab !== "unicode" && (
@@ -249,6 +410,72 @@ export function StickerEmojiPanel({
       )}
 
       <div className="min-h-0 flex-1 overflow-y-auto p-2">
+        {comboMode && tab === "sticker" && (
+          <div className="mb-2 rounded-2xl border border-[var(--vy-border)] bg-[var(--vy-surface-2)] p-2">
+            <div className="flex items-start gap-3">
+              <CombinationPreview items={comboItems} />
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <p className="text-xs font-semibold text-[var(--vy-text)]">組み合わせ作成</p>
+                  <span className="rounded-full bg-[color-mix(in_oklab,var(--vy-text)_10%,transparent)] px-2 py-0.5 text-[0.65rem] text-[var(--vy-text-dim)]">
+                    {selectedCountText}
+                  </span>
+                </div>
+                <p className="mt-1 text-[0.7rem] text-[var(--vy-text-dim)]">
+                  スタンプを最大6枚まで選んで、作成ボタンを押してください。
+                </p>
+                <div className="mt-2 flex flex-wrap gap-1">
+                  {comboItems.map((item) => (
+                    <button
+                      key={`${item.packageId}-${item.stickerId}`}
+                      type="button"
+                      onClick={() => addComboItem(item)}
+                      className="inline-flex items-center gap-1 rounded-full border border-[var(--vy-border)] px-2 py-1 text-[0.65rem] text-[var(--vy-text-dim)] transition-colors hover:bg-[var(--vy-surface)]"
+                    >
+                      <span className="max-w-24 truncate">{item.name || item.stickerId}</span>
+                      <span aria-hidden>×</span>
+                    </button>
+                  ))}
+                </div>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    onClick={() => void createComboSticker()}
+                    disabled={comboBusy || comboItems.length === 0}
+                    className="rounded-full bg-[var(--vy-accent)] px-3 py-1.5 text-xs font-semibold text-[var(--vy-accent-contrast)] transition-opacity disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {comboBusy ? "作成中…" : "作成"}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setComboItems([]);
+                      setComboError(null);
+                      setComboCreatedId(null);
+                    }}
+                    className="rounded-full border border-[var(--vy-border)] px-3 py-1.5 text-xs text-[var(--vy-text-dim)] transition-colors hover:bg-[var(--vy-surface)]"
+                  >
+                    クリア
+                  </button>
+                </div>
+                {comboCreatedId && (
+                  <div className="mt-2 rounded-xl border border-[color-mix(in_oklab,var(--vy-accent)_35%,var(--vy-border))] bg-[color-mix(in_oklab,var(--vy-accent)_10%,transparent)] px-3 py-2 text-xs">
+                    <span className="font-semibold text-[var(--vy-text)]">作成済み</span>
+                    <span className="ml-2 break-all text-[var(--vy-text-dim)]">{comboCreatedId}</span>
+                    <button
+                      type="button"
+                      onClick={() => void copyText(comboCreatedId)}
+                      className="ml-2 rounded-full bg-[var(--vy-surface)] px-2 py-0.5 font-medium text-[var(--vy-text)]"
+                    >
+                      コピー
+                    </button>
+                  </div>
+                )}
+                {comboError && <p className="mt-2 text-xs text-[var(--vy-danger)]">{comboError}</p>}
+              </div>
+            </div>
+          </div>
+        )}
         {loading && !catalog && (
           <p className="px-2 py-6 text-center text-xs text-[var(--vy-text-dim)]">読み込み中…</p>
         )}
@@ -282,7 +509,14 @@ export function StickerEmojiPanel({
                 type="button"
                 title={f.name || f.id}
                 onClick={() => {
-                  if (f.type === "sticker")
+                  if (comboMode && f.type === "sticker") {
+                    addComboItem({
+                      packageId: f.packageId,
+                      stickerId: f.id,
+                      url: f.url,
+                      name: f.name || f.id,
+                    });
+                  } else if (f.type === "sticker")
                     onPickSticker(f.packageId, f.id, catalog?.premium?.active);
                   else onPickEmoji(f.packageId, f.id);
                 }}
@@ -317,7 +551,14 @@ export function StickerEmojiPanel({
                     type="button"
                     title={item.alt || item.id}
                     onClick={() => {
-                      if (activePack.type === "sticker") {
+                      if (comboMode && activePack.type === "sticker") {
+                        addComboItem({
+                          packageId: activePack.packageId,
+                          stickerId: item.id,
+                          url: item.url,
+                          name: item.alt || activePack.name,
+                        });
+                      } else if (activePack.type === "sticker") {
                         onPickSticker(activePack.packageId, item.id, catalog?.premium?.active);
                       } else {
                         onPickEmoji(activePack.packageId, item.id);
@@ -354,6 +595,11 @@ export function StickerEmojiPanel({
                   {isFav && (
                     <span className="pointer-events-none absolute right-0.5 top-0.5 text-[0.6rem] text-[var(--vy-accent)]">
                       ★
+                    </span>
+                  )}
+                  {comboMode && activePack.type === "sticker" && (
+                    <span className="pointer-events-none absolute left-0.5 top-0.5 rounded-full bg-[var(--vy-accent)] px-1 py-0.5 text-[0.55rem] font-bold text-[var(--vy-accent-contrast)]">
+                      +
                     </span>
                   )}
                 </div>

--- a/Vyline/apps/desktop/src/hooks/useVylineSync.ts
+++ b/Vyline/apps/desktop/src/hooks/useVylineSync.ts
@@ -157,7 +157,7 @@ export function useVylineSync(enabled = true) {
           m.authorId === "me" &&
           m.id &&
           !m.id.startsWith("pending_") &&
-          !m.revoked &&
+          !m.messageState.startsWith("revoked") &&
           now - m.createdAt < 15 * 60_000,
       );
     };

--- a/Vyline/apps/desktop/src/hooks/useVylineSync.ts
+++ b/Vyline/apps/desktop/src/hooks/useVylineSync.ts
@@ -198,21 +198,21 @@ export function useVylineSync(enabled = true) {
 
     if (!line.chats.length && useStore.getState().chats.length > 0) return;
 
-      hydrateLineData({
-        profile: line.profile
-          ? {
-              displayName: line.profile.displayName,
-              phoneticName: line.profile.phoneticName,
-              pictureStatus: line.profile.pictureStatus,
-              statusMessage: line.profile.statusMessage,
-              thumbnailUrl: line.profile.thumbnailUrl,
-              musicProfile: line.profile.musicProfile,
-              birthday: line.profile.birthday,
-              backgroundUrl: line.profile.backgroundUrl,
-              profileId: line.profile.profileId,
-              premium: line.profile.premium ?? null,
-            }
-          : null,
+    hydrateLineData({
+      profile: line.profile
+        ? {
+            displayName: line.profile.displayName,
+            phoneticName: line.profile.phoneticName,
+            pictureStatus: line.profile.pictureStatus,
+            statusMessage: line.profile.statusMessage,
+            thumbnailUrl: line.profile.thumbnailUrl,
+            musicProfile: line.profile.musicProfile,
+            birthday: line.profile.birthday,
+            backgroundUrl: line.profile.backgroundUrl,
+            profileId: line.profile.profileId,
+            premium: line.profile.premium ?? null,
+          }
+        : null,
 
       chats: line.chats,
 

--- a/Vyline/apps/desktop/src/hooks/useVylineSync.ts
+++ b/Vyline/apps/desktop/src/hooks/useVylineSync.ts
@@ -198,16 +198,21 @@ export function useVylineSync(enabled = true) {
 
     if (!line.chats.length && useStore.getState().chats.length > 0) return;
 
-    hydrateLineData({
-      profile: line.profile
-        ? {
-            displayName: line.profile.displayName,
-
-            statusMessage: line.profile.statusMessage,
-
-            thumbnailUrl: line.profile.thumbnailUrl,
-          }
-        : null,
+      hydrateLineData({
+        profile: line.profile
+          ? {
+              displayName: line.profile.displayName,
+              phoneticName: line.profile.phoneticName,
+              pictureStatus: line.profile.pictureStatus,
+              statusMessage: line.profile.statusMessage,
+              thumbnailUrl: line.profile.thumbnailUrl,
+              musicProfile: line.profile.musicProfile,
+              birthday: line.profile.birthday,
+              backgroundUrl: line.profile.backgroundUrl,
+              profileId: line.profile.profileId,
+              premium: line.profile.premium ?? null,
+            }
+          : null,
 
       chats: line.chats,
 

--- a/Vyline/apps/desktop/src/lib/mappers.ts
+++ b/Vyline/apps/desktop/src/lib/mappers.ts
@@ -118,7 +118,9 @@ function messageStatus(m: LineMessage): MessageStatus {
     if (m.seen || (m.readCount != null && m.readCount > 0)) return "read";
     return "sent";
   }
-  return "read";
+  // For received messages, status depends on whether we've read it
+  if (m.seen || (m.readCount != null && m.readCount > 0)) return "read";
+  return "sent";
 }
 
 function messageKind(m: LineMessage): MessageKind {
@@ -249,7 +251,9 @@ export function mapMessage(
     ? m.seen ||
       (m.readCount != null && m.readCount > 0) ||
       (m.seen === undefined && m.readCount === undefined)
-    : true;
+    : // For received messages, only mark as read if server confirms (seen/readCount > 0)
+      // Otherwise default to false to avoid false read receipts in personal chats
+      Boolean(m.seen) || (m.readCount != null && m.readCount > 0);
 
   let text = sanitizeText(m.text);
   if (kind === "system") {

--- a/Vyline/apps/desktop/src/lib/mappers.ts
+++ b/Vyline/apps/desktop/src/lib/mappers.ts
@@ -307,11 +307,11 @@ export function mapMessage(
     text,
     sticker:
       kind === "sticker" && comboStickerId
-        ? (getCombinationStickerPreview(accountId, comboStickerId) ?? undefined)
+        ? (getCombinationStickerPreview(accountId, comboStickerId) ?? "🧩")
         : kind === "sticker" && stickerId
           ? lineStickerUrl(stickerId)
           : kind === "sticker"
-            ? "🎴"
+            ? "🧩"
             : undefined,
     imageSrc,
     audioSrc,

--- a/Vyline/apps/desktop/src/lib/mappers.ts
+++ b/Vyline/apps/desktop/src/lib/mappers.ts
@@ -299,20 +299,27 @@ export function mapMessage(
       ? parseContactFromMeta(m.contentMetadata as Record<string, unknown> | null, text)
       : undefined;
 
+  let stickerSrc: string | undefined;
+  if (kind === "sticker") {
+    // コンビネーション: CSSTKID → メッセージID の順でローカルプレビューを引く。
+    // 履歴レスポンスに CSSTKID が載らない場合でも、送信時に保存したプレビューで表示を維持する。
+    const comboPreview = comboStickerId
+      ? getCombinationStickerPreview(accountId, comboStickerId)
+      : null;
+    const preview = comboPreview ?? getCombinationStickerPreview(accountId, m.id);
+    if (preview) stickerSrc = preview;
+    else if (comboStickerId) stickerSrc = lineStickerUrl(comboStickerId);
+    else if (stickerId) stickerSrc = lineStickerUrl(stickerId);
+    else stickerSrc = "🧩";
+  }
+
   const result: Message = {
     id: m.id,
     chatId,
     authorId,
     kind,
     text,
-    sticker:
-      kind === "sticker" && comboStickerId
-        ? (getCombinationStickerPreview(accountId, comboStickerId) ?? "🧩")
-        : kind === "sticker" && stickerId
-          ? lineStickerUrl(stickerId)
-          : kind === "sticker"
-            ? "🧩"
-            : undefined,
+    sticker: stickerSrc,
     imageSrc,
     audioSrc,
     audioSeconds: kind === "audio" ? parseAudioDuration(m.contentMetadata ?? null) : undefined,

--- a/Vyline/apps/desktop/src/lib/mappers.ts
+++ b/Vyline/apps/desktop/src/lib/mappers.ts
@@ -1,5 +1,6 @@
 import type { Chat as LineChat, Message as LineMessage } from "@vyline/types";
 import { extractStickerId, lineStickerUrl } from "../utils/lineMedia.js";
+import { getCombinationStickerPreview } from "../utils/combinationStickers.js";
 import {
   contentTypeLabel,
   isAudioContent,
@@ -235,7 +236,10 @@ export function mapMessage(
         ? "revoked-by-self"
         : "revoked-by-other"
       : "normal");
+  const meta = (m.contentMetadata ?? null) as Record<string, unknown> | null;
   const stickerId = extractStickerId(m.contentMetadata ?? null);
+  const comboStickerId =
+    typeof meta?.CSSTKID === "string" && meta.CSSTKID.trim() ? meta.CSSTKID.trim() : null;
   const authorId = m.isMyMessage ? "me" : m.from;
 
   let imageSrc: string | undefined;
@@ -273,7 +277,6 @@ export function mapMessage(
     }
   }
 
-  const meta = (m.contentMetadata ?? null) as Record<string, unknown> | null;
   const altText = altTextFromMeta(meta);
   if ((kind === "flex" || kind === "rich") && !text && altText) {
     text = altText;
@@ -303,11 +306,13 @@ export function mapMessage(
     kind,
     text,
     sticker:
-      kind === "sticker" && stickerId
-        ? lineStickerUrl(stickerId)
-        : kind === "sticker"
-          ? "🎴"
-          : undefined,
+      kind === "sticker" && comboStickerId
+        ? (getCombinationStickerPreview(accountId, comboStickerId) ?? undefined)
+        : kind === "sticker" && stickerId
+          ? lineStickerUrl(stickerId)
+          : kind === "sticker"
+            ? "🎴"
+            : undefined,
     imageSrc,
     audioSrc,
     audioSeconds: kind === "audio" ? parseAudioDuration(m.contentMetadata ?? null) : undefined,
@@ -348,6 +353,9 @@ export function mapMessage(
     editedAt: m.updatedTime != null && m.updatedTime > 0 ? m.updatedTime : undefined,
     originalText: m.originalText || (meta?.ORIGINAL_TEXT as string | undefined),
     history: m.history?.length ? m.history : undefined,
+    ...(m.revokedSnapshot
+      ? { revokedSnapshot: mapMessage(m.revokedSnapshot, chatId, accountId, _contactCache) }
+      : {}),
     contact,
     location,
   };

--- a/Vyline/apps/desktop/src/lib/mappers.ts
+++ b/Vyline/apps/desktop/src/lib/mappers.ts
@@ -247,13 +247,16 @@ export function mapMessage(
     audioSrc = `/api/line/${encodeURIComponent(accountId)}/media/${encodeURIComponent(chatId)}/${encodeURIComponent(m.id)}?preview=0`;
   }
 
+  const isPersonalChat = chatId.startsWith("u");
   const read = m.isMyMessage
-    ? m.seen ||
-      (m.readCount != null && m.readCount > 0) ||
-      (m.seen === undefined && m.readCount === undefined)
-    : // For received messages, only mark as read if server confirms (seen/readCount > 0)
-      // Otherwise default to false to avoid false read receipts in personal chats
-      Boolean(m.seen) || (m.readCount != null && m.readCount > 0);
+    ? isPersonalChat
+      ? Boolean(m.seen)
+      : m.seen ||
+        (m.readCount != null && m.readCount > 0) ||
+        (m.seen === undefined && m.readCount === undefined)
+    : isPersonalChat
+      ? Boolean(m.seen)
+      : Boolean(m.seen) || (m.readCount != null && m.readCount > 0);
 
   let text = sanitizeText(m.text);
   if (kind === "system") {

--- a/Vyline/apps/desktop/src/lib/mappers.ts
+++ b/Vyline/apps/desktop/src/lib/mappers.ts
@@ -226,7 +226,13 @@ export function mapMessage(
   _contactCache?: Map<string, ContactInfo>,
 ): Message {
   const kind = messageKind(m);
-  const revoked = m.contentType === "UNSENT" || m.contentType === "UNSEND";
+  const messageState =
+    m.messageState ??
+    (m.contentType === "UNSENT" || m.contentType === "UNSEND"
+      ? m.isMyMessage
+        ? "revoked-by-self"
+        : "revoked-by-other"
+      : "normal");
   const stickerId = extractStickerId(m.contentMetadata ?? null);
   const authorId = m.isMyMessage ? "me" : m.from;
 
@@ -239,7 +245,11 @@ export function mapMessage(
     audioSrc = `/api/line/${encodeURIComponent(accountId)}/media/${encodeURIComponent(chatId)}/${encodeURIComponent(m.id)}?preview=0`;
   }
 
-  const read = m.isMyMessage ? Boolean(m.seen || (m.readCount != null && m.readCount > 0)) : true;
+  const read = m.isMyMessage
+    ? m.seen ||
+      (m.readCount != null && m.readCount > 0) ||
+      (m.seen === undefined && m.readCount === undefined)
+    : true;
 
   let text = sanitizeText(m.text);
   if (kind === "system") {
@@ -311,7 +321,7 @@ export function mapMessage(
     status: messageStatus(m),
     read,
     readBy: m.readBy,
-    revoked,
+    messageState,
     replyToId: m.relatedMessageId ?? undefined,
     reactions: m.reactions
       ?.filter((r) => Number.isFinite(r.type))
@@ -330,6 +340,7 @@ export function mapMessage(
       Boolean(m.originalText),
     editedAt: m.updatedTime != null && m.updatedTime > 0 ? m.updatedTime : undefined,
     originalText: m.originalText || (meta?.ORIGINAL_TEXT as string | undefined),
+    history: m.history?.length ? m.history : undefined,
     contact,
     location,
   };

--- a/Vyline/apps/desktop/src/lib/store-types.ts
+++ b/Vyline/apps/desktop/src/lib/store-types.ts
@@ -151,6 +151,10 @@ export type RetryIntent =
       contentMetadata?: Record<string, string>;
     }
   | { kind: "sticker"; packageId: string; stickerId: string; isPremium?: boolean }
+  | {
+      kind: "combinationSticker";
+      items: Array<{ packageId: string; stickerId: string; x?: number; y?: number; size?: number }>;
+    }
   | { kind: "emoji"; packageId: string; sticonId: string };
 
 export type Member = {

--- a/Vyline/apps/desktop/src/lib/store-types.ts
+++ b/Vyline/apps/desktop/src/lib/store-types.ts
@@ -125,6 +125,8 @@ export type Message = {
     contentType: string;
     updatedTime: number;
   }>;
+  /** 取り消し前のメッセージ本体スナップショット */
+  revokedSnapshot?: MessageSnapshot;
   linkPreview?: LinkPreview;
   /** 失敗時の再送に使う送信意図（楽観メッセージに保持） */
   retry?: RetryIntent;
@@ -138,6 +140,8 @@ export type Message = {
     longitude?: number;
   };
 };
+
+export type MessageSnapshot = Omit<Message, "history" | "revokedSnapshot">;
 
 export type RetryIntent =
   | {
@@ -220,8 +224,18 @@ export type SelfProfile = {
   avatar: string;
   avatarUrl?: string;
   status: string;
+  phoneticName?: string;
+  pictureStatus?: string;
   musicProfile?: string;
   birthday?: string;
   backgroundUrl?: string;
   mid?: string;
+  profileId?: string;
+  premium?: {
+    active: boolean;
+    planType?: string | number;
+    validUntil?: number;
+    onFreeTrial?: boolean;
+    willExpire?: boolean;
+  };
 };

--- a/Vyline/apps/desktop/src/lib/store-types.ts
+++ b/Vyline/apps/desktop/src/lib/store-types.ts
@@ -71,6 +71,8 @@ export type LinkPreview = {
   site: string;
 };
 
+export type MessageState = "normal" | "edited" | "revoked-by-other" | "revoked-by-self";
+
 export type Message = {
   id: string;
   chatId: string;
@@ -100,7 +102,7 @@ export type Message = {
   read: boolean;
   readBy?: string[];
   readCount?: number;
-  revoked?: boolean;
+  messageState: MessageState;
   replyToId?: string;
   /** 絵文字リアクション（type は MessageReactionType 数値） */
   reactions?: MessageReaction[];
@@ -116,6 +118,13 @@ export type Message = {
   originalText?: string;
   /** 編集前の元テキストを表示中かどうか */
   showOriginal?: boolean;
+  /** 状態変更履歴 */
+  history?: Array<{
+    state: MessageState;
+    text: string | null;
+    contentType: string;
+    updatedTime: number;
+  }>;
   linkPreview?: LinkPreview;
   /** 失敗時の再送に使う送信意図（楽観メッセージに保持） */
   retry?: RetryIntent;

--- a/Vyline/apps/desktop/src/lib/store.ts
+++ b/Vyline/apps/desktop/src/lib/store.ts
@@ -27,8 +27,18 @@ import { parseMentions, type MentionDraft } from "../utils/mention.js";
 import { compressImageFile } from "../utils/compressImage.js";
 import { setHiddenForAccount } from "../hooks/useHiddenChats.js";
 import { invalidateMessage } from "./reactionCache.js";
+import type { MessageState } from "./store-types.js";
 
-export type { Chat, ChatSort, Message, Member, VyTheme, Settings, Screen } from "./store-types.js";
+export type {
+  Chat,
+  ChatSort,
+  Message,
+  Member,
+  VyTheme,
+  Settings,
+  Screen,
+  MessageState,
+} from "./store-types.js";
 
 /** chatId → 送信済み lastMessageId（既読 API の重複抑止） */
 const readReceiptSent = new Map<string, string>();
@@ -151,7 +161,15 @@ function applyReadWatermarkLocal(
 }
 
 function messagePreview(m: Message): string {
-  if (m.revoked) return "メッセージの送信を取り消しました";
+  if (m.messageState.startsWith("revoked")) {
+    if (m.messageState === "revoked-by-self" && m.history?.length) {
+      const last = [...m.history]
+        .reverse()
+        .find((h) => h.state === "normal" || h.state === "edited");
+      if (last?.text) return last.text;
+    }
+    return "メッセージの送信を取り消しました";
+  }
   switch (m.kind) {
     case "sticker":
       return m.altText || "スタンプ";
@@ -332,8 +350,11 @@ type State = {
     opts?: { silent?: boolean },
   ) => void;
   applyRevoked: (chatId: string, messageId: string) => void;
+  /** 取消し済みメッセージを履歴から復元 */
+  restoreRevokedMessage: (chatId: string, messageId: string) => Promise<void>;
   /** 楽観リアクション更新（UNDO は自分の全リアクション除去） */
   setMessageReaction: (messageId: string, reaction: "UNDO" | string, myMid: string) => void;
+  fetchMessageHistory: (chatId: string, messageId: string) => Promise<Message["history"]>;
   backfillChat: (chatId: string) => Promise<void>;
   pollMessagesDelta: (chatId: string) => Promise<void>;
   pollIncoming: () => Promise<void>;
@@ -752,6 +773,7 @@ export const useStore = create<State>()(
           createdAt: Date.now(),
           status: "sending",
           read: false,
+          messageState: "normal",
           replyToId: relatedMessageId,
           retry: {
             kind: "text",
@@ -834,6 +856,7 @@ export const useStore = create<State>()(
           createdAt: Date.now(),
           status: "sending",
           read: false,
+          messageState: "normal",
           retry: { kind: "sticker", packageId, stickerId, isPremium },
         };
         set((st) => ({ messages: [...st.messages, optimistic] }));
@@ -922,6 +945,7 @@ export const useStore = create<State>()(
           createdAt: Date.now(),
           status: "sending",
           read: false,
+          messageState: "normal",
           retry: { kind: "emoji", packageId, sticonId },
         };
         set((st) => ({ messages: [...st.messages, optimistic] }));
@@ -976,6 +1000,7 @@ export const useStore = create<State>()(
           createdAt: Date.now(),
           status: "sending",
           read: false,
+          messageState: "normal",
         };
         set((st) => ({ messages: [...st.messages, optimistic] }));
         void (async () => {
@@ -1078,11 +1103,22 @@ export const useStore = create<State>()(
           window.alert("送信が完了してから取り消しできます");
           return;
         }
+        const prevState = msg.messageState ?? "normal";
+        const historyEntry = {
+          state: prevState,
+          text: msg.text ?? null,
+          contentType: msg.kind,
+          updatedTime: Date.now(),
+        };
+        set((st) => ({
+          messages: st.messages.map((m) =>
+            m.id === id ? { ...m, history: [...(m.history ?? []), historyEntry] } : m,
+          ),
+        }));
         const res = await api.line.unsend(accountId, id);
         if (res.ok && activeChatId) await get().refreshMessages(activeChatId, { force: true });
         else if (!res.ok) {
           const errText = res.error ?? "";
-          // 送信取り消し可能な時間を過ぎた（MESSAGE_NOT_DESTRUCTIBLE / message too old）
           if (
             errText.includes("MESSAGE_NOT_DESTRUCTIBLE") ||
             errText.includes("message too old") ||
@@ -1158,7 +1194,14 @@ export const useStore = create<State>()(
       retryMessage: async (id) => {
         const accountId = get().accountId;
         const msg = get().messages.find((m) => m.id === id);
-        if (!accountId || !msg || msg.status !== "failed" || msg.revoked || !msg.retry) return;
+        if (
+          !accountId ||
+          !msg ||
+          msg.status !== "failed" ||
+          msg.messageState.startsWith("revoked") ||
+          !msg.retry
+        )
+          return;
         const chatId = msg.chatId;
         const intent = msg.retry;
         set((st) => ({
@@ -1240,6 +1283,10 @@ export const useStore = create<State>()(
         const { accountId, messages, settings, readDisabledMids } = get();
         set((st) => ({
           chats: st.chats.map((c) => (c.id === id ? { ...c, unread: 0 } : c)),
+          messages: st.messages.map((m) => {
+            if (m.chatId !== id) return m;
+            return { ...m, read: true, status: "read" };
+          }),
         }));
         // 全体無効（設定）または個別無効（右クリック）なら送信しない
         if (!accountId || !settings.readReceipts || readDisabledMids[id]) return;
@@ -1475,9 +1522,21 @@ export const useStore = create<State>()(
                     readBy: m.readBy?.length ? m.readBy : prev.readBy,
                     readCount: m.readCount ?? prev.readCount,
                   };
-                } else if (prev?.readBy?.length && !m.readBy?.length) {
+                } else if (prev?.readBy?.length && (!m.readBy?.length || !m.read)) {
                   mapped[i] = {
                     ...m,
+                    read: true,
+                    readBy: prev.readBy,
+                    readCount: m.readCount ?? prev.readCount,
+                  };
+                } else if (
+                  prev?.readBy?.length &&
+                  m.readBy?.length &&
+                  prev.readBy.length > m.readBy.length
+                ) {
+                  mapped[i] = {
+                    ...m,
+                    read: true,
                     readBy: prev.readBy,
                     readCount: m.readCount ?? prev.readCount,
                   };
@@ -1596,7 +1655,7 @@ export const useStore = create<State>()(
                 m.authorId === "me" &&
                 m.id &&
                 !m.id.startsWith("pending_") &&
-                !m.revoked,
+                !m.messageState.startsWith("revoked"),
             )
             .map((m) => m.id)
             .slice(-50);
@@ -1700,17 +1759,20 @@ export const useStore = create<State>()(
               const patch = res.receipts![m.id];
               if (!patch) return m;
               const readBy = patch.readBy ?? [];
+              const alreadyRead = m.read;
               const read =
                 patch.seen === true ||
                 Boolean((patch as { read?: boolean }).read) ||
                 (patch.readCount != null && patch.readCount > 0) ||
                 readBy.length > 0;
+              // 既読フラグが一度立っている場合は立てたままにする（未読にしない）
+              const finalRead = alreadyRead ? true : read;
               return {
                 ...m,
-                read,
-                readBy: readBy.length ? readBy : m.readBy,
-                readCount: patch.readCount ?? m.readCount,
-                status: read ? ("read" as const) : m.status === "read" ? "sent" : m.status,
+                read: finalRead,
+                readBy: finalRead ? (readBy.length ? readBy : m.readBy) : m.readBy,
+                readCount: finalRead ? (patch.readCount ?? m.readCount) : m.readCount,
+                status: finalRead ? ("read" as const) : m.status === "read" ? "sent" : m.status,
               };
             }),
           }));
@@ -1833,14 +1895,76 @@ export const useStore = create<State>()(
 
       applyRevoked: (chatId, messageId) => {
         set((st) => {
-          const msgs = st.messages.map((m) =>
-            m.chatId === chatId && m.id === messageId ? { ...m, revoked: true } : m,
-          );
-          // キャッシュからも削除
+          const msgs = st.messages.map((m) => {
+            if (m.chatId !== chatId || m.id !== messageId) return m;
+            const prevState = m.messageState ?? "normal";
+            const history = [
+              ...(m.history ?? []),
+              {
+                state: prevState,
+                text: m.text ?? null,
+                contentType: m.kind,
+                updatedTime: Date.now(),
+              },
+            ];
+            return {
+              ...m,
+              messageState: (m.authorId === "me"
+                ? "revoked-by-self"
+                : "revoked-by-other") as MessageState,
+              history,
+              text: undefined,
+            };
+          });
           invalidateMessage(messageReactionCache, messageId);
           if (msgs.every((m, i) => m === st.messages[i])) return st;
           return { messages: msgs };
         });
+      },
+
+      fetchMessageHistory: async (chatId, messageId) => {
+        const accountId = get().accountId;
+        if (!accountId) return [];
+        const res = await api.line.messageHistory(accountId, chatId, messageId);
+        if (res.ok) return res.history ?? [];
+        return [];
+      },
+
+      restoreRevokedMessage: async (_chatId, messageId) => {
+        const accountId = get().accountId;
+        if (!accountId) return;
+        const msg = get().messages.find((m) => m.id === messageId);
+        if (!msg || msg.messageState !== "revoked-by-self") return;
+        const lastNormal = [...(msg.history ?? [])]
+          .reverse()
+          .find((h) => h.state === "normal" || h.state === "edited");
+        if (!lastNormal) {
+          window.alert("復元できる元のメッセージがありません");
+          return;
+        }
+        const historyEntry = {
+          state: "normal" as const,
+          text: msg.text ?? null,
+          contentType: msg.kind,
+          updatedTime: Date.now(),
+        };
+        set((st) => ({
+          messages: st.messages.map((m) =>
+            m.id === messageId
+              ? {
+                  ...m,
+                  messageState: "normal" as MessageState,
+                  history: [...(m.history ?? []), historyEntry],
+                  text: lastNormal.text ?? undefined,
+                }
+              : m,
+          ),
+        }));
+        try {
+          await api.line.restoreRevokedMessage(accountId, _chatId, messageId);
+        } catch {
+          /* local update already applied */
+        }
       },
 
       setMessageReaction: (messageId, reaction, myMid) => {

--- a/Vyline/apps/desktop/src/lib/store.ts
+++ b/Vyline/apps/desktop/src/lib/store.ts
@@ -1551,10 +1551,12 @@ export const useStore = create<State>()(
                   mapped[i] = { ...m, messageState: prev.messageState };
                 }
                 // メッセージステートが undefined の場合もローカルの取り消し状態を優先
+                // （サーバが取り消し未処理の場合の fallback）
                 if (
                   prev?.messageState === "revoked-by-self" &&
-                  !m.messageState?.startsWith("revoked") &&
-                  m.messageState !== "revoked-by-self"
+                  m.messageState !== "revoked-by-self" &&
+                  // undefined や normal になっている場合はローカル状態を優先
+                  (m.messageState === undefined || m.messageState === "normal")
                 ) {
                   mapped[i] = { ...m, messageState: "revoked-by-self" as MessageState };
                 }

--- a/Vyline/apps/desktop/src/lib/store.ts
+++ b/Vyline/apps/desktop/src/lib/store.ts
@@ -23,6 +23,11 @@ import {
   type ContactInfo,
 } from "./mappers.js";
 import { lineStickerUrl } from "../utils/lineMedia.js";
+import {
+  renderCombinationStickerPreview,
+  setCombinationStickerPreview,
+  type CombinationStickerPlacement,
+} from "../utils/combinationStickers.js";
 import { getDismissedChatMids } from "../utils/dismissedChats.js";
 import { parseMentions, type MentionDraft } from "../utils/mention.js";
 import { compressImageFile } from "../utils/compressImage.js";
@@ -167,7 +172,16 @@ function applyReadWatermarkLocal(
 }
 
 function messagePreview(m: Message): string {
-  if (m.messageState.startsWith("revoked")) {
+  const isRevoked =
+    m.messageState.startsWith("revoked") ||
+    Boolean(m.revokedSnapshot) ||
+    Boolean(
+      m.history?.length &&
+        m.history.some(
+          (h) => h.state === "normal" || h.state === "edited" || h.contentType === "UNSENT",
+        ),
+    );
+  if (isRevoked) {
     if (m.revokedSnapshot) return `取り消し済み: ${messagePreview(m.revokedSnapshot)}`;
     const last = m.history
       ? [...m.history].reverse().find((h) => h.state === "normal" || h.state === "edited")
@@ -312,6 +326,10 @@ type State = {
     packageId: string,
     stickerId: string,
     isPremium?: boolean,
+  ) => Promise<void>;
+  sendCombinationSticker: (
+    chatId: string,
+    items: Array<{ packageId: string; stickerId: string; x?: number; y?: number; size?: number }>,
   ) => Promise<void>;
   sendLineEmoji: (chatId: string, packageId: string, sticonId: string) => Promise<void>;
   sendImageFile: (chatId: string, file: File) => Promise<void>;
@@ -935,6 +953,97 @@ export const useStore = create<State>()(
         })();
       },
 
+      sendCombinationSticker: async (chatId, items) => {
+        const { accountId, blockedMids } = get();
+        if (!accountId || !items.length) return;
+        if (chatId.startsWith("u") && blockedMids.includes(chatId)) return;
+        const placements: CombinationStickerPlacement[] = items.map((item, index) => ({
+          packageId: item.packageId,
+          stickerId: item.stickerId,
+          url: lineStickerUrl(item.stickerId),
+          name: item.stickerId,
+          x: item.x ?? Math.max(0, 40 + index * 18),
+          y: item.y ?? Math.max(0, 40 + index * 18),
+          size: item.size ?? 76,
+        }));
+        const tempId = `pending_cstk_${Date.now()}`;
+        const optimistic: Message = {
+          id: tempId,
+          chatId,
+          authorId: "me",
+          kind: "sticker",
+          sticker: lineStickerUrl(items[0]!.stickerId),
+          createdAt: Date.now(),
+          status: "sending",
+          read: false,
+          messageState: "normal",
+          retry: { kind: "combinationSticker", items: items.map((item) => ({ ...item })) },
+        };
+        set((st) => ({ messages: [...st.messages, optimistic] }));
+
+        void (async () => {
+          try {
+            const res = await api.line.sendCombinationSticker(accountId!, chatId, items);
+            if (!res.ok) {
+              set((st) => ({
+                messages: st.messages.map((m) =>
+                  m.id === tempId ? { ...m, status: "failed" } : m,
+                ),
+              }));
+              return;
+            }
+            if (res.message) {
+              const contactCache = buildContactCache(get().chats);
+              const mapped = mapMessage(res.message, chatId, accountId!, contactCache);
+              let preview = mapped.sticker ?? "";
+              try {
+                const dataUrl = await renderCombinationStickerPreview(placements);
+                if (dataUrl) {
+                  preview = dataUrl;
+                  setCombinationStickerPreview(accountId!, mapped.id, dataUrl);
+                }
+              } catch {
+                if (!preview) preview = lineStickerUrl(items[0]!.stickerId);
+              }
+              const finalMsg: Message = {
+                ...mapped,
+                kind: "sticker",
+                sticker: preview || mapped.sticker || "🎴",
+              };
+              set((st) => ({
+                messages: st.messages.map((m) => (m.id === tempId ? finalMsg : m)),
+                chats: st.chats.map((c) =>
+                  c.id === chatId
+                    ? {
+                        ...c,
+                        lastMessagePreview: "スタンプ",
+                        lastMessageTime: Math.max(c.lastMessageTime ?? 0, finalMsg.createdAt),
+                      }
+                    : c,
+                ),
+              }));
+            } else {
+              set((st) => ({
+                messages: st.messages.map((m) => (m.id === tempId ? { ...m, status: "sent" } : m)),
+              }));
+            }
+            const existing = refreshDebounce.get(chatId);
+            if (existing) clearTimeout(existing);
+            refreshDebounce.set(
+              chatId,
+              setTimeout(() => {
+                refreshDebounce.delete(chatId);
+                void get().refreshMessages(chatId, { force: true });
+              }, 800),
+            );
+          } catch {
+            set((st) => ({
+              messages: st.messages.map((m) => (m.id === tempId ? { ...m, status: "failed" } : m)),
+            }));
+          }
+        })();
+      },
+
       sendLineEmoji: async (chatId, packageId, sticonId) => {
         const { accountId, blockedMids } = get();
         if (!accountId || !packageId || !sticonId) return;
@@ -1259,6 +1368,10 @@ export const useStore = create<State>()(
               sticonId: intent.sticonId,
             });
             ok = res.ok;
+          } else if (intent.kind === "combinationSticker") {
+            const res = await api.line.sendCombinationSticker(accountId, chatId, intent.items);
+            ok = res.ok;
+            confirmed = res.ok ? (res.message ?? null) : null;
           }
           if (!ok) {
             markFailed();
@@ -1538,6 +1651,18 @@ export const useStore = create<State>()(
               for (let i = 0; i < mapped.length; i++) {
                 const m = mapped[i]!;
                 const prev = prevById.get(m.id);
+                const prevRevoked = Boolean(
+                  prev &&
+                    (prev.messageState.startsWith("revoked") ||
+                      prev.revokedSnapshot ||
+                      (prev.history?.length &&
+                        prev.history.some(
+                          (h) =>
+                            h.state === "normal" ||
+                            h.state === "edited" ||
+                            h.contentType === "UNSENT",
+                        ))),
+                );
                 if (m.authorId === "me" && prev?.read && !m.read) {
                   mapped[i] = {
                     ...m,
@@ -1591,6 +1716,20 @@ export const useStore = create<State>()(
                 }
                 if (prev?.revokedSnapshot && !m.revokedSnapshot) {
                   mapped[i] = { ...m, revokedSnapshot: prev.revokedSnapshot };
+                }
+                if (prevRevoked && !m.messageState?.startsWith("revoked")) {
+                  const last = prev?.history
+                    ? [...prev.history]
+                        .reverse()
+                        .find((h) => h.state === "normal" || h.state === "edited")
+                    : undefined;
+                  mapped[i] = {
+                    ...m,
+                    messageState: prev?.messageState ?? "revoked-by-self",
+                    history: prev?.history?.length ? prev.history : m.history,
+                    revokedSnapshot: prev?.revokedSnapshot ?? m.revokedSnapshot,
+                    text: prev?.revokedSnapshot?.text ?? last?.text ?? prev?.text ?? m.text,
+                  };
                 }
               }
               // pending / 送信直後の確定メッセージをサーバ欠落時も残す
@@ -1891,6 +2030,18 @@ export const useStore = create<State>()(
                 if (m.chatId !== chatId) return m;
                 const upd = incomingById.get(m.id);
                 if (!upd) return m;
+                const wasRevoked =
+                  m.messageState.startsWith("revoked") ||
+                  Boolean(m.revokedSnapshot) ||
+                  Boolean(
+                    m.history?.length &&
+                      m.history.some(
+                        (h) =>
+                          h.state === "normal" ||
+                          h.state === "edited" ||
+                          h.contentType === "UNSENT",
+                      ),
+                  );
                 const reactionChanged =
                   JSON.stringify(upd.reactions) !== JSON.stringify(m.reactions);
                 const revokedChanged =
@@ -1904,6 +2055,12 @@ export const useStore = create<State>()(
                     messageReactionCache.delete(m.id);
                   }
                   updated.reactions = upd.reactions;
+                  if (wasRevoked) {
+                    updated.messageState = m.messageState;
+                    updated.history = m.history;
+                    if (m.revokedSnapshot) updated.revokedSnapshot = m.revokedSnapshot;
+                    if (m.text !== undefined) updated.text = m.text;
+                  }
                 }
                 if (revokedChanged) {
                   updated.messageState = upd.messageState;

--- a/Vyline/apps/desktop/src/lib/store.ts
+++ b/Vyline/apps/desktop/src/lib/store.ts
@@ -162,12 +162,10 @@ function applyReadWatermarkLocal(
 
 function messagePreview(m: Message): string {
   if (m.messageState.startsWith("revoked")) {
-    if (m.messageState === "revoked-by-self" && m.history?.length) {
-      const last = [...m.history]
-        .reverse()
-        .find((h) => h.state === "normal" || h.state === "edited");
-      if (last?.text) return last.text;
-    }
+    const last = m.history
+      ? [...m.history].reverse().find((h) => h.state === "normal" || h.state === "edited")
+      : undefined;
+    if (last?.text) return last.text;
     return "メッセージの送信を取り消しました";
   }
   switch (m.kind) {
@@ -1540,6 +1538,9 @@ export const useStore = create<State>()(
                     readBy: prev.readBy,
                     readCount: m.readCount ?? prev.readCount,
                   };
+                }
+                if (prev?.history?.length && !m.history?.length) {
+                  mapped[i] = { ...m, history: prev.history };
                 }
               }
               // pending / 送信直後の確定メッセージをサーバ欠落時も残す

--- a/Vyline/apps/desktop/src/lib/store.ts
+++ b/Vyline/apps/desktop/src/lib/store.ts
@@ -24,6 +24,9 @@ import {
 } from "./mappers.js";
 import { lineStickerUrl } from "../utils/lineMedia.js";
 import {
+  COMBO_EDITOR_SIZE,
+  COMBO_ITEM_MAX_SIZE,
+  COMBO_ITEM_MIN_SIZE,
   renderCombinationStickerPreview,
   setCombinationStickerPreview,
   type CombinationStickerPlacement,
@@ -91,6 +94,71 @@ function buildContactCache(chats: Chat[]): Map<string, ContactInfo> {
 function snapshotFromMessage(m: Message): MessageSnapshot {
   const { history: _history, revokedSnapshot: _revokedSnapshot, ...snapshot } = m;
   return snapshot;
+}
+
+function isDataUrl(value?: string): boolean {
+  return typeof value === "string" && value.startsWith("data:");
+}
+
+function mergePreservingComboStickerPreview(existing: Message, incoming: Message): Message {
+  if (existing.kind !== "sticker" || incoming.kind !== "sticker") return incoming;
+  if (!isDataUrl(existing.sticker)) return incoming;
+  if (isDataUrl(incoming.sticker)) return incoming;
+  // ローカル合成プレビューはサーバ再取得結果（🧩 や無効 URL）より常に優先
+  return {
+    ...incoming,
+    sticker: existing.sticker,
+  };
+}
+
+function combinationPlacementsFromItems(
+  items: Array<{ packageId: string; stickerId: string; x?: number; y?: number; size?: number }>,
+): CombinationStickerPlacement[] {
+  return items.map((item, index) => {
+    const size = Math.round(
+      Math.max(
+        COMBO_ITEM_MIN_SIZE,
+        Math.min(COMBO_ITEM_MAX_SIZE, item.size ?? COMBO_ITEM_MAX_SIZE / 2),
+      ),
+    );
+    const fallback = Math.max(
+      0,
+      COMBO_EDITOR_SIZE / 2 - size / 2 + (index % 3) * 16 + Math.floor(index / 3) * 16,
+    );
+    return {
+      packageId: item.packageId,
+      stickerId: item.stickerId,
+      url: lineStickerUrl(item.stickerId),
+      name: item.stickerId,
+      x: item.x ?? fallback,
+      y: item.y ?? fallback,
+      size,
+    };
+  });
+}
+
+/** 送信済みコンビネーションのローカル合成プレビューを CSSTKID とメッセージIDの両方に保存 */
+async function persistCombinationStickerPreview(
+  accountId: string,
+  message: LineMessage | null,
+  placements: CombinationStickerPlacement[],
+): Promise<string | null> {
+  if (!message) return null;
+  try {
+    const dataUrl = await renderCombinationStickerPreview(placements);
+    if (!dataUrl) return null;
+    const meta = (message.contentMetadata ?? null) as Record<string, unknown> | null;
+    const comboId =
+      typeof meta?.CSSTKID === "string" && meta.CSSTKID.trim() ? meta.CSSTKID.trim() : null;
+    if (comboId) setCombinationStickerPreview(accountId, comboId, dataUrl);
+    const messageId = message.id != null ? String(message.id) : "";
+    if (messageId && messageId !== comboId) {
+      setCombinationStickerPreview(accountId, messageId, dataUrl);
+    }
+    return dataUrl;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -172,16 +240,7 @@ function applyReadWatermarkLocal(
 }
 
 function messagePreview(m: Message): string {
-  const isRevoked =
-    m.messageState.startsWith("revoked") ||
-    Boolean(m.revokedSnapshot) ||
-    Boolean(
-      m.history?.length &&
-        m.history.some(
-          (h) => h.state === "normal" || h.state === "edited" || h.contentType === "UNSENT",
-        ),
-    );
-  if (isRevoked) {
+  if (m.messageState.startsWith("revoked")) {
     if (m.revokedSnapshot) return `取り消し済み: ${messagePreview(m.revokedSnapshot)}`;
     const last = m.history
       ? [...m.history].reverse().find((h) => h.state === "normal" || h.state === "edited")
@@ -957,16 +1016,8 @@ export const useStore = create<State>()(
         const { accountId, blockedMids } = get();
         if (!accountId || !items.length) return;
         if (chatId.startsWith("u") && blockedMids.includes(chatId)) return;
-        const placements: CombinationStickerPlacement[] = items.map((item, index) => ({
-          packageId: item.packageId,
-          stickerId: item.stickerId,
-          url: lineStickerUrl(item.stickerId),
-          name: item.stickerId,
-          x: item.x ?? Math.max(0, 40 + index * 18),
-          y: item.y ?? Math.max(0, 40 + index * 18),
-          size: item.size ?? 76,
-        }));
-        const tempId = `pending_cstk_${Date.now()}`;
+        const placements = combinationPlacementsFromItems(items);
+        const tempId = `pending_combo_${Date.now()}`;
         const optimistic: Message = {
           id: tempId,
           chatId,
@@ -993,22 +1044,32 @@ export const useStore = create<State>()(
               return;
             }
             if (res.message) {
+              // 送信レスポンスの実証用ログ（ID・キー名のみ。トークン等は出さない）
+              try {
+                const meta = (res.message.contentMetadata ?? null) as Record<
+                  string,
+                  unknown
+                > | null;
+                console.debug("[vyline] combination sticker sent", {
+                  messageId: res.message.id,
+                  metaKeys: meta ? Object.keys(meta) : null,
+                  csstkId: typeof meta?.CSSTKID === "string" ? meta.CSSTKID : null,
+                });
+              } catch {
+                /* ignore */
+              }
               const contactCache = buildContactCache(get().chats);
               const mapped = mapMessage(res.message, chatId, accountId!, contactCache);
-              let preview = mapped.sticker ?? "";
-              try {
-                const dataUrl = await renderCombinationStickerPreview(placements);
-                if (dataUrl) {
-                  preview = dataUrl;
-                  setCombinationStickerPreview(accountId!, mapped.id, dataUrl);
-                }
-              } catch {
-                if (!preview) preview = lineStickerUrl(items[0]!.stickerId);
-              }
+              // 履歴表示は CSSTKID / メッセージID のどちらでもプレビューを引けるよう両方保存
+              const preview = await persistCombinationStickerPreview(
+                accountId!,
+                res.message,
+                placements,
+              );
               const finalMsg: Message = {
                 ...mapped,
                 kind: "sticker",
-                sticker: preview || mapped.sticker || "🎴",
+                sticker: preview || mapped.sticker || "🧩",
               };
               set((st) => ({
                 messages: st.messages.map((m) => (m.id === tempId ? finalMsg : m)),
@@ -1373,6 +1434,14 @@ export const useStore = create<State>()(
             ok = res.ok;
             confirmed = res.ok ? (res.message ?? null) : null;
           }
+          if (ok && confirmed && intent.kind === "combinationSticker") {
+            // 再送でも送信時と同じくローカルプレビューを保存（mapMessage が CSSTKID/メッセージIDで引ける）
+            await persistCombinationStickerPreview(
+              accountId,
+              confirmed,
+              combinationPlacementsFromItems(intent.items),
+            );
+          }
           if (!ok) {
             markFailed();
             return;
@@ -1651,18 +1720,6 @@ export const useStore = create<State>()(
               for (let i = 0; i < mapped.length; i++) {
                 const m = mapped[i]!;
                 const prev = prevById.get(m.id);
-                const prevRevoked = Boolean(
-                  prev &&
-                    (prev.messageState.startsWith("revoked") ||
-                      prev.revokedSnapshot ||
-                      (prev.history?.length &&
-                        prev.history.some(
-                          (h) =>
-                            h.state === "normal" ||
-                            h.state === "edited" ||
-                            h.contentType === "UNSENT",
-                        ))),
-                );
                 if (m.authorId === "me" && prev?.read && !m.read) {
                   mapped[i] = {
                     ...m,
@@ -1717,19 +1774,8 @@ export const useStore = create<State>()(
                 if (prev?.revokedSnapshot && !m.revokedSnapshot) {
                   mapped[i] = { ...m, revokedSnapshot: prev.revokedSnapshot };
                 }
-                if (prevRevoked && !m.messageState?.startsWith("revoked")) {
-                  const last = prev?.history
-                    ? [...prev.history]
-                        .reverse()
-                        .find((h) => h.state === "normal" || h.state === "edited")
-                    : undefined;
-                  mapped[i] = {
-                    ...m,
-                    messageState: prev?.messageState ?? "revoked-by-self",
-                    history: prev?.history?.length ? prev.history : m.history,
-                    revokedSnapshot: prev?.revokedSnapshot ?? m.revokedSnapshot,
-                    text: prev?.revokedSnapshot?.text ?? last?.text ?? prev?.text ?? m.text,
-                  };
+                if (prev && mapped[i]) {
+                  mapped[i] = mergePreservingComboStickerPreview(prev, mapped[i]);
                 }
               }
               // pending / 送信直後の確定メッセージをサーバ欠落時も残す
@@ -2030,18 +2076,6 @@ export const useStore = create<State>()(
                 if (m.chatId !== chatId) return m;
                 const upd = incomingById.get(m.id);
                 if (!upd) return m;
-                const wasRevoked =
-                  m.messageState.startsWith("revoked") ||
-                  Boolean(m.revokedSnapshot) ||
-                  Boolean(
-                    m.history?.length &&
-                      m.history.some(
-                        (h) =>
-                          h.state === "normal" ||
-                          h.state === "edited" ||
-                          h.contentType === "UNSENT",
-                      ),
-                  );
                 const reactionChanged =
                   JSON.stringify(upd.reactions) !== JSON.stringify(m.reactions);
                 const revokedChanged =
@@ -2055,12 +2089,6 @@ export const useStore = create<State>()(
                     messageReactionCache.delete(m.id);
                   }
                   updated.reactions = upd.reactions;
-                  if (wasRevoked) {
-                    updated.messageState = m.messageState;
-                    updated.history = m.history;
-                    if (m.revokedSnapshot) updated.revokedSnapshot = m.revokedSnapshot;
-                    if (m.text !== undefined) updated.text = m.text;
-                  }
                 }
                 if (revokedChanged) {
                   updated.messageState = upd.messageState;
@@ -2078,7 +2106,7 @@ export const useStore = create<State>()(
                   ];
                   updated.text = undefined;
                 }
-                return updated;
+                return mergePreservingComboStickerPreview(m, updated);
               })
             : st.messages;
           const merged = [...withUpdates, ...fresh].sort((a, b) => a.createdAt - b.createdAt);

--- a/Vyline/apps/desktop/src/lib/store.ts
+++ b/Vyline/apps/desktop/src/lib/store.ts
@@ -8,6 +8,7 @@ import type {
   ChatSort,
   Message,
   MessageReaction,
+  MessageSnapshot,
   VyTheme,
   Settings,
   Screen,
@@ -80,6 +81,11 @@ function buildContactCache(chats: Chat[]): Map<string, ContactInfo> {
     }
   }
   return contactCache;
+}
+
+function snapshotFromMessage(m: Message): MessageSnapshot {
+  const { history: _history, revokedSnapshot: _revokedSnapshot, ...snapshot } = m;
+  return snapshot;
 }
 
 /**
@@ -162,11 +168,12 @@ function applyReadWatermarkLocal(
 
 function messagePreview(m: Message): string {
   if (m.messageState.startsWith("revoked")) {
+    if (m.revokedSnapshot) return `取り消し済み: ${messagePreview(m.revokedSnapshot)}`;
     const last = m.history
       ? [...m.history].reverse().find((h) => h.state === "normal" || h.state === "edited")
       : undefined;
-    if (last?.text) return last.text;
-    return "メッセージの送信を取り消しました";
+    if (last?.text) return `取り消し済み: ${last.text}`;
+    return "取り消し済みのメッセージ";
   }
   switch (m.kind) {
     case "sticker":
@@ -273,9 +280,19 @@ type State = {
       displayName: string;
       statusMessage: string;
       thumbnailUrl?: string;
+      phoneticName?: string;
+      pictureStatus?: string;
       musicProfile?: string;
       birthday?: { display?: string } | null;
       backgroundUrl?: string;
+      profileId?: string;
+      premium?: {
+        active: boolean;
+        planType?: string | number;
+        validUntil?: number;
+        onFreeTrial?: boolean;
+        willExpire?: boolean;
+      } | null;
     } | null;
     chats: LineChat[];
     messages: LineMessage[];
@@ -579,10 +596,14 @@ export const useStore = create<State>()(
                 avatar: initial(profile.displayName),
                 avatarUrl: profile.thumbnailUrl || st.self.avatarUrl,
                 status: profile.statusMessage || "",
+                phoneticName: profile.phoneticName || st.self.phoneticName,
+                pictureStatus: profile.pictureStatus || st.self.pictureStatus,
                 musicProfile: profile.musicProfile || st.self.musicProfile,
                 birthday: profile.birthday?.display || st.self.birthday,
                 backgroundUrl: profile.backgroundUrl || st.self.backgroundUrl,
                 mid: profile.mid || st.self.mid,
+                profileId: profile.profileId || st.self.profileId,
+                premium: profile.premium ?? st.self.premium,
               },
             }));
           }
@@ -693,10 +714,14 @@ export const useStore = create<State>()(
                 avatar: initial(profile.displayName),
                 avatarUrl: profile.thumbnailUrl || st.self.avatarUrl,
                 status: profile.statusMessage || "",
+                phoneticName: profile.phoneticName || st.self.phoneticName,
+                pictureStatus: profile.pictureStatus || st.self.pictureStatus,
                 musicProfile: profile.musicProfile || st.self.musicProfile,
                 birthday: profile.birthday?.display || st.self.birthday,
                 backgroundUrl: profile.backgroundUrl || st.self.backgroundUrl,
                 mid: profile.mid || st.self.mid,
+                profileId: profile.profileId || st.self.profileId,
+                premium: profile.premium ?? st.self.premium,
               }
             : st.self,
         }));
@@ -992,55 +1017,53 @@ export const useStore = create<State>()(
           messageState: "normal",
         };
         set((st) => ({ messages: [...st.messages, optimistic] }));
-        void (async () => {
-          try {
-            const highQuality = get().settings.highQualityImages;
-            const { blob, mime } = highQuality
-              ? { blob: file, mime: file.type || "application/octet-stream" }
-              : await compressImageFile(file);
-            if (blob.size > 11_000_000) {
-              window.alert(
-                blob === file
-                  ? "ファイルが大きすぎます（11MB まで）"
-                  : "画像が大きすぎます（圧縮後も 11MB 超）",
-              );
-              set((st) => ({ messages: st.messages.filter((m) => m.id !== tempId) }));
-              return;
-            }
-            const buf = await blob.arrayBuffer();
-            const bytes = new Uint8Array(buf);
-            let binary = "";
-            const chunk = 0x8000;
-            for (let i = 0; i < bytes.length; i += chunk) {
-              binary += String.fromCharCode(...bytes.subarray(i, i + chunk));
-            }
-            const dataBase64 = btoa(binary);
-            const res = await api.line.sendMedia(accountId!, chatId, dataBase64, {
-              mimeType: mime,
-              filename: file.name || (isVideo ? "video.mp4" : "image.jpg"),
-              mediaType: isVideo ? "video" : "image",
-            });
-            if (res.ok) {
-              const existing = refreshDebounce.get(chatId);
-              if (existing) clearTimeout(existing);
-              refreshDebounce.set(
-                chatId,
-                setTimeout(() => {
-                  refreshDebounce.delete(chatId);
-                  void get().refreshMessages(chatId, { force: true });
-                }, 800),
-              );
-            } else {
-              // 画像は再送 UI を持たないので失敗時は楽観表示を除去
-              set((st) => ({ messages: st.messages.filter((m) => m.id !== tempId) }));
-            }
-          } catch {
+        try {
+          const highQuality = get().settings.highQualityImages;
+          const { blob, mime } = highQuality
+            ? { blob: file, mime: file.type || "application/octet-stream" }
+            : await compressImageFile(file);
+          if (blob.size > 11_000_000) {
+            window.alert(
+              blob === file
+                ? "ファイルが大きすぎます（11MB まで）"
+                : "画像が大きすぎます（圧縮後も 11MB 超）",
+            );
             set((st) => ({ messages: st.messages.filter((m) => m.id !== tempId) }));
-          } finally {
-            // 送信完了後にローカルURLを解放（60s 後でも安全な間隔）
-            setTimeout(() => URL.revokeObjectURL(localUrl), 60_000);
+            return;
           }
-        })();
+          const buf = await blob.arrayBuffer();
+          const bytes = new Uint8Array(buf);
+          let binary = "";
+          const chunk = 0x8000;
+          for (let i = 0; i < bytes.length; i += chunk) {
+            binary += String.fromCharCode(...bytes.subarray(i, i + chunk));
+          }
+          const dataBase64 = btoa(binary);
+          const res = await api.line.sendMedia(accountId!, chatId, dataBase64, {
+            mimeType: mime,
+            filename: file.name || (isVideo ? "video.mp4" : "image.jpg"),
+            mediaType: isVideo ? "video" : "image",
+          });
+          if (res.ok) {
+            const existing = refreshDebounce.get(chatId);
+            if (existing) clearTimeout(existing);
+            refreshDebounce.set(
+              chatId,
+              setTimeout(() => {
+                refreshDebounce.delete(chatId);
+                void get().refreshMessages(chatId, { force: true });
+              }, 800),
+            );
+          } else {
+            // 画像は再送 UI を持たないので失敗時は楽観表示を除去
+            set((st) => ({ messages: st.messages.filter((m) => m.id !== tempId) }));
+          }
+        } catch {
+          set((st) => ({ messages: st.messages.filter((m) => m.id !== tempId) }));
+        } finally {
+          // 送信完了後にローカルURLを解放（60s 後でも安全な間隔）
+          setTimeout(() => URL.revokeObjectURL(localUrl), 60_000);
+        }
       },
 
       sendAudio: async (chatId, seconds, blob) => {
@@ -1092,6 +1115,10 @@ export const useStore = create<State>()(
           window.alert("送信が完了してから取り消しできます");
           return;
         }
+        if (msg.messageState.startsWith("revoked") || msg.revokedSnapshot) {
+          get().showNotice("一度取り消したメッセージは再度取り消せません");
+          return;
+        }
         const prevState = msg.messageState ?? "normal";
         const historyEntry = {
           state: prevState,
@@ -1105,7 +1132,9 @@ export const useStore = create<State>()(
               ? {
                   ...m,
                   history: [...(m.history ?? []), historyEntry],
+                  revokedSnapshot: m.revokedSnapshot ?? snapshotFromMessage(m),
                   messageState: "revoked-by-self" as MessageState,
+                  text: undefined,
                 }
               : m,
           ),
@@ -1560,6 +1589,9 @@ export const useStore = create<State>()(
                 ) {
                   mapped[i] = { ...m, messageState: "revoked-by-self" as MessageState };
                 }
+                if (prev?.revokedSnapshot && !m.revokedSnapshot) {
+                  mapped[i] = { ...m, revokedSnapshot: prev.revokedSnapshot };
+                }
               }
               // pending / 送信直後の確定メッセージをサーバ欠落時も残す
               const keep = existingChat.filter((m) => {
@@ -1875,6 +1907,8 @@ export const useStore = create<State>()(
                 }
                 if (revokedChanged) {
                   updated.messageState = upd.messageState;
+                  updated.revokedSnapshot =
+                    m.revokedSnapshot ?? upd.revokedSnapshot ?? snapshotFromMessage(m);
                   const prevState = m.messageState ?? "normal";
                   updated.history = [
                     ...(m.history ?? []),
@@ -1967,6 +2001,7 @@ export const useStore = create<State>()(
                 ? "revoked-by-self"
                 : "revoked-by-other") as MessageState,
               history,
+              revokedSnapshot: m.revokedSnapshot ?? snapshotFromMessage(m),
               text: undefined,
             };
           });
@@ -1989,10 +2024,11 @@ export const useStore = create<State>()(
         if (!accountId) return;
         const msg = get().messages.find((m) => m.id === messageId);
         if (!msg || msg.messageState !== "revoked-by-self") return;
+        const snapshot = msg.revokedSnapshot;
         const lastNormal = [...(msg.history ?? [])]
           .reverse()
           .find((h) => h.state === "normal" || h.state === "edited");
-        if (!lastNormal) {
+        if (!snapshot && !lastNormal) {
           window.alert("復元できる元のメッセージがありません");
           return;
         }
@@ -2007,9 +2043,16 @@ export const useStore = create<State>()(
             m.id === messageId
               ? {
                   ...m,
-                  messageState: "normal" as MessageState,
+                  ...snapshot,
+                  messageState: (snapshot?.messageState ??
+                    (lastNormal?.state === "edited" ? "edited" : "normal")) as MessageState,
                   history: [...(m.history ?? []), historyEntry],
-                  text: lastNormal.text ?? undefined,
+                  ...(snapshot
+                    ? { revokedSnapshot: snapshot }
+                    : m.revokedSnapshot
+                      ? { revokedSnapshot: m.revokedSnapshot }
+                      : {}),
+                  text: snapshot?.text ?? lastNormal?.text ?? undefined,
                 }
               : m,
           ),

--- a/Vyline/apps/desktop/src/lib/store.ts
+++ b/Vyline/apps/desktop/src/lib/store.ts
@@ -727,15 +727,6 @@ export const useStore = create<State>()(
             ),
           }));
         }
-
-        // 自動選択チャットも「開いた」扱いにし、既読を送信する
-        if (chatId && !sessionOpenedChats.has(chatId)) {
-          sessionOpenedChats.add(chatId);
-          const { accountId, settings, readDisabledMids } = get();
-          if (accountId && settings.readReceipts && !readDisabledMids[chatId]) {
-            void get().markChatRead(chatId);
-          }
-        }
       },
 
       sendMessage: async (chatId, text, opts) => {
@@ -1110,7 +1101,13 @@ export const useStore = create<State>()(
         };
         set((st) => ({
           messages: st.messages.map((m) =>
-            m.id === id ? { ...m, history: [...(m.history ?? []), historyEntry] } : m,
+            m.id === id
+              ? {
+                  ...m,
+                  history: [...(m.history ?? []), historyEntry],
+                  messageState: "revoked-by-self" as MessageState,
+                }
+              : m,
           ),
         }));
         const res = await api.line.unsend(accountId, id);
@@ -1512,7 +1509,7 @@ export const useStore = create<State>()(
               for (let i = 0; i < mapped.length; i++) {
                 const m = mapped[i]!;
                 const prev = prevById.get(m.id);
-                if (prev?.read && !m.read) {
+                if (m.authorId === "me" && prev?.read && !m.read) {
                   mapped[i] = {
                     ...m,
                     read: true,
@@ -1520,7 +1517,11 @@ export const useStore = create<State>()(
                     readBy: m.readBy?.length ? m.readBy : prev.readBy,
                     readCount: m.readCount ?? prev.readCount,
                   };
-                } else if (prev?.readBy?.length && (!m.readBy?.length || !m.read)) {
+                } else if (
+                  m.authorId === "me" &&
+                  prev?.readBy?.length &&
+                  (!m.readBy?.length || !m.read)
+                ) {
                   mapped[i] = {
                     ...m,
                     read: true,
@@ -1528,6 +1529,7 @@ export const useStore = create<State>()(
                     readCount: m.readCount ?? prev.readCount,
                   };
                 } else if (
+                  m.authorId === "me" &&
                   prev?.readBy?.length &&
                   m.readBy?.length &&
                   prev.readBy.length > m.readBy.length
@@ -1541,6 +1543,20 @@ export const useStore = create<State>()(
                 }
                 if (prev?.history?.length && !m.history?.length) {
                   mapped[i] = { ...m, history: prev.history };
+                }
+                if (
+                  prev?.messageState?.startsWith("revoked") &&
+                  !m.messageState?.startsWith("revoked")
+                ) {
+                  mapped[i] = { ...m, messageState: prev.messageState };
+                }
+                // メッセージステートが undefined の場合もローカルの取り消し状態を優先
+                if (
+                  prev?.messageState === "revoked-by-self" &&
+                  !m.messageState?.startsWith("revoked") &&
+                  m.messageState !== "revoked-by-self"
+                ) {
+                  mapped[i] = { ...m, messageState: "revoked-by-self" as MessageState };
                 }
               }
               // pending / 送信直後の確定メッセージをサーバ欠落時も残す
@@ -1799,10 +1815,23 @@ export const useStore = create<State>()(
         const existingIds = new Set(messages.filter((m) => m.chatId === chatId).map((m) => m.id));
         const fresh = mapped.filter((m) => !existingIds.has(m.id));
 
-        // 既存メッセージにもリアクション等の更新を反映（同期で re-fetch された場合）
-        const hasUpdates = [...incomingById.values()].some(
-          (m) => existingIds.has(m.id) && m.reactions && m.reactions.length > 0,
-        );
+        // 既存メッセージにもリアクションや状態の更新を反映（同期で re-fetch された場合）
+        const hasUpdates = [...incomingById.values()].some((m) => {
+          if (!existingIds.has(m.id)) return false;
+          const existing = messages.find((x) => x.id === m.id);
+          if (!existing) return false;
+          if (
+            m.reactions?.length &&
+            JSON.stringify(m.reactions) !== JSON.stringify(existing.reactions)
+          )
+            return true;
+          if (
+            m.messageState?.startsWith("revoked") &&
+            !existing.messageState?.startsWith("revoked")
+          )
+            return true;
+          return false;
+        });
         if (fresh.length === 0 && !hasUpdates) return;
 
         // キャッシュ済み既読ウォーターマークを新着にも即適用（RPC なしで既読化）
@@ -1828,13 +1857,35 @@ export const useStore = create<State>()(
                 if (m.chatId !== chatId) return m;
                 const upd = incomingById.get(m.id);
                 if (!upd) return m;
-                if (JSON.stringify(upd.reactions) === JSON.stringify(m.reactions)) return m;
-                if (upd.reactions?.length) {
-                  messageReactionCache.set(m.id, upd.reactions);
-                } else {
-                  messageReactionCache.delete(m.id);
+                const reactionChanged =
+                  JSON.stringify(upd.reactions) !== JSON.stringify(m.reactions);
+                const revokedChanged =
+                  upd.messageState?.startsWith("revoked") && !m.messageState?.startsWith("revoked");
+                if (!reactionChanged && !revokedChanged) return m;
+                const updated = { ...m };
+                if (reactionChanged) {
+                  if (upd.reactions?.length) {
+                    messageReactionCache.set(m.id, upd.reactions);
+                  } else {
+                    messageReactionCache.delete(m.id);
+                  }
+                  updated.reactions = upd.reactions;
                 }
-                return { ...m, reactions: upd.reactions };
+                if (revokedChanged) {
+                  updated.messageState = upd.messageState;
+                  const prevState = m.messageState ?? "normal";
+                  updated.history = [
+                    ...(m.history ?? []),
+                    {
+                      state: prevState,
+                      text: m.text ?? null,
+                      contentType: m.kind,
+                      updatedTime: Date.now(),
+                    },
+                  ];
+                  updated.text = undefined;
+                }
+                return updated;
               })
             : st.messages;
           const merged = [...withUpdates, ...fresh].sort((a, b) => a.createdAt - b.createdAt);

--- a/Vyline/apps/desktop/src/utils/combinationStickers.ts
+++ b/Vyline/apps/desktop/src/utils/combinationStickers.ts
@@ -11,6 +11,18 @@ export type CombinationStickerPlacement = CombinationStickerItem & {
   size: number;
 };
 
+/**
+ * コンボエディタの正規座標空間 (240x240)。
+ * backend buildCombinationStickerLayouts が scale = 512 / 240 で
+ * LINE の 512x512 キャンバスへ変換する前提値と同期している。
+ * エディタの表示枠もこのサイズで固定すること。
+ */
+export const COMBO_EDITOR_SIZE = 240;
+
+/** エディタ上でのスタンプ1枚のサイズ範囲 (正規座標系) */
+export const COMBO_ITEM_MIN_SIZE = 48;
+export const COMBO_ITEM_MAX_SIZE = 168;
+
 const STORAGE_KEY = (accountId: string) => `vyline:combinationStickerPreviews:${accountId}`;
 
 function loadPreviewStore(accountId: string): Record<string, string> {
@@ -60,16 +72,28 @@ function loadImage(src: string): Promise<HTMLImageElement> {
 
 export async function renderCombinationStickerPreview(
   items: CombinationStickerPlacement[],
-  canvasSize = 512,
+  targetSize = 360,
 ): Promise<string> {
+  if (items.length === 0) return "";
+  // COMBO_EDITOR_SIZE (240x240) 空間の配置をバウンディングボックスでクロップする。
+  // クロップにより気泡表示 (128px object-contain) でもクラスタが枠を満たし、
+  // 相対的な配置比率は LINE 側のレンダリングと一致する。
+  const minX = Math.min(...items.map((i) => i.x));
+  const minY = Math.min(...items.map((i) => i.y));
+  const maxX = Math.max(...items.map((i) => i.x + i.size));
+  const maxY = Math.max(...items.map((i) => i.y + i.size));
+  const pad = Math.max(8, Math.round(Math.max(maxX - minX, maxY - minY) * 0.08));
+  const w = maxX - minX + pad * 2;
+  const h = maxY - minY + pad * 2;
+  const scale = Math.min(3, Math.max(1, targetSize / Math.max(w, h)));
+
   const canvas = document.createElement("canvas");
-  canvas.width = canvasSize;
-  canvas.height = canvasSize;
+  canvas.width = Math.round(w * scale);
+  canvas.height = Math.round(h * scale);
   const ctx = canvas.getContext("2d");
   if (!ctx) return "";
-  ctx.clearRect(0, 0, canvasSize, canvasSize);
-  ctx.fillStyle = "rgba(0,0,0,0)";
-  ctx.fillRect(0, 0, canvasSize, canvasSize);
+  ctx.scale(scale, scale);
+  ctx.translate(pad - minX, pad - minY);
 
   const loaded = await Promise.all(
     items.map(async (item) => {
@@ -88,12 +112,12 @@ export async function renderCombinationStickerPreview(
     const box = item.size;
     const x = item.x;
     const y = item.y;
-    const scale = Math.min(box / img.naturalWidth, box / img.naturalHeight, 1);
-    const w = img.naturalWidth * scale;
-    const h = img.naturalHeight * scale;
-    const dx = x + (box - w) / 2;
-    const dy = y + (box - h) / 2;
-    ctx.drawImage(img, dx, dy, w, h);
+    const fit = Math.min(box / img.naturalWidth, box / img.naturalHeight, 1);
+    const dw = img.naturalWidth * fit;
+    const dh = img.naturalHeight * fit;
+    const dx = x + (box - dw) / 2;
+    const dy = y + (box - dh) / 2;
+    ctx.drawImage(img, dx, dy, dw, dh);
   }
 
   return canvas.toDataURL("image/png");

--- a/Vyline/apps/desktop/src/utils/combinationStickers.ts
+++ b/Vyline/apps/desktop/src/utils/combinationStickers.ts
@@ -1,0 +1,100 @@
+export type CombinationStickerItem = {
+  packageId: string;
+  stickerId: string;
+  url: string;
+  name?: string;
+};
+
+export type CombinationStickerPlacement = CombinationStickerItem & {
+  x: number;
+  y: number;
+  size: number;
+};
+
+const STORAGE_KEY = (accountId: string) => `vyline:combinationStickerPreviews:${accountId}`;
+
+function loadPreviewStore(accountId: string): Record<string, string> {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY(accountId));
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? (parsed as Record<string, string>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function savePreviewStore(accountId: string, store: Record<string, string>): void {
+  try {
+    localStorage.setItem(STORAGE_KEY(accountId), JSON.stringify(store));
+  } catch {
+    /* ignore quota/private mode */
+  }
+}
+
+export function getCombinationStickerPreview(accountId: string, comboId: string): string | null {
+  const store = loadPreviewStore(accountId);
+  return store[comboId] ?? null;
+}
+
+export function setCombinationStickerPreview(
+  accountId: string,
+  comboId: string,
+  dataUrl: string,
+): void {
+  const store = loadPreviewStore(accountId);
+  store[comboId] = dataUrl;
+  savePreviewStore(accountId, store);
+}
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.decoding = "async";
+    img.crossOrigin = "anonymous";
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error(`failed to load image: ${src}`));
+    img.src = src.startsWith("http") ? `/api/cdn/line?u=${encodeURIComponent(src)}` : src;
+  });
+}
+
+export async function renderCombinationStickerPreview(
+  items: CombinationStickerPlacement[],
+  canvasSize = 512,
+): Promise<string> {
+  const canvas = document.createElement("canvas");
+  canvas.width = canvasSize;
+  canvas.height = canvasSize;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return "";
+  ctx.clearRect(0, 0, canvasSize, canvasSize);
+  ctx.fillStyle = "rgba(0,0,0,0)";
+  ctx.fillRect(0, 0, canvasSize, canvasSize);
+
+  const loaded = await Promise.all(
+    items.map(async (item) => {
+      try {
+        const img = await loadImage(item.url);
+        return { item, img };
+      } catch {
+        return null;
+      }
+    }),
+  );
+
+  for (const entry of loaded) {
+    if (!entry) continue;
+    const { item, img } = entry;
+    const box = item.size;
+    const x = item.x;
+    const y = item.y;
+    const scale = Math.min(box / img.naturalWidth, box / img.naturalHeight, 1);
+    const w = img.naturalWidth * scale;
+    const h = img.naturalHeight * scale;
+    const dx = x + (box - w) / 2;
+    const dy = y + (box - h) / 2;
+    ctx.drawImage(img, dx, dy, w, h);
+  }
+
+  return canvas.toDataURL("image/png");
+}

--- a/Vyline/apps/desktop/src/utils/lineMedia.ts
+++ b/Vyline/apps/desktop/src/utils/lineMedia.ts
@@ -48,7 +48,7 @@ export function extractStickerId(
   meta: Record<string, string | undefined> | null | undefined,
 ): string | null {
   if (!meta) return null;
-  const id = meta.STKID ?? meta.STICKER_ID ?? meta.stickerId ?? meta.STK_ID;
+  const id = meta.CSSTKID ?? meta.STKID ?? meta.STICKER_ID ?? meta.stickerId ?? meta.STK_ID;
   return id && String(id).length > 0 ? String(id) : null;
 }
 

--- a/Vyline/backend/src/api/line.ts
+++ b/Vyline/backend/src/api/line.ts
@@ -75,6 +75,8 @@ import {
   listDirectCalls,
   CallNotAllowedError,
   NotLoggedInError,
+  restoreRevokedMessage,
+  getMessageHistory,
 } from "../service/lineService.js";
 import {
   LiffNotLoggedInError,
@@ -571,6 +573,43 @@ lineRouter.post("/:accountId/unsend", async (c) => {
   try {
     await unsendMessage(accountId, body.messageId);
     return c.json({ ok: true });
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+// ─── POST /line/:accountId/restore ─────────────
+
+lineRouter.post("/:accountId/restore", async (c) => {
+  const accountId = c.req.param("accountId");
+  const body = await c.req.json<{ messageId?: string }>();
+
+  if (!body.messageId) {
+    return c.json({ ok: false, error: "messageId required" }, 400);
+  }
+
+  try {
+    const chatMid = c.req.query("chatMid") ?? "";
+    const restored = await restoreRevokedMessage(accountId, chatMid, body.messageId);
+    if (!restored) {
+      return c.json({ ok: false, error: "no history to restore" }, 400);
+    }
+    return c.json({ ok: true, text: restored.text, contentType: restored.contentType });
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+// ─── GET /line/:accountId/messages/:chatMid/:messageId/history ──
+
+lineRouter.get("/:accountId/messages/:chatMid/:messageId/history", async (c) => {
+  const accountId = c.req.param("accountId");
+  const chatMid = c.req.param("chatMid");
+  const messageId = c.req.param("messageId");
+
+  try {
+    const history = await getMessageHistory(accountId, chatMid, messageId);
+    return c.json({ ok: true, history });
   } catch (err) {
     return handleError(err, c);
   }
@@ -1624,6 +1663,52 @@ lineRouter.get("/:accountId/log", async (c) => {
   const limit = Math.min(Number(c.req.query("limit") ?? 200) || 200, 2000);
   try {
     return c.json({ ok: true, data: await readRecentMessageLog(accountId, limit) });
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+// ─── Vyline Storage ────────────────────────────────────────
+
+lineRouter.get("/:accountId/vyline/storage", async (c) => {
+  const accountId = c.req.param("accountId");
+  try {
+    const { getVylineStorageInfo } = await import("../storage/vylineStorageInfo.js");
+    const info = await getVylineStorageInfo();
+    return c.json(info);
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+lineRouter.delete("/:accountId/vyline/cache", async (c) => {
+  const accountId = c.req.param("accountId");
+  try {
+    const { clearCdnCache } = await import("../storage/cdnAssetCache.js");
+    const removed = await clearCdnCache();
+    return c.json({ ok: true, removed });
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+lineRouter.delete("/:accountId/vyline/saved-media", async (c) => {
+  const accountId = c.req.param("accountId");
+  try {
+    const { clearMediaCache } = await import("../storage/mediaCache.js");
+    const removed = await clearMediaCache();
+    return c.json({ ok: true, removed });
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+lineRouter.delete("/:accountId/vyline/icons", async (c) => {
+  const accountId = c.req.param("accountId");
+  try {
+    const { clearCdnCache } = await import("../storage/cdnAssetCache.js");
+    const removed = await clearCdnCache();
+    return c.json({ ok: true, removed });
   } catch (err) {
     return handleError(err, c);
   }

--- a/Vyline/backend/src/api/line.ts
+++ b/Vyline/backend/src/api/line.ts
@@ -1692,12 +1692,50 @@ lineRouter.delete("/:accountId/vyline/cache", async (c) => {
   }
 });
 
+lineRouter.delete("/:accountId/vyline/cache/cdn", async (c) => {
+  const accountId = c.req.param("accountId");
+  try {
+    const { clearCdnCache } = await import("../storage/cdnAssetCache.js");
+    const removed = await clearCdnCache();
+    return c.json({ ok: true, removed });
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+lineRouter.delete("/:accountId/vyline/cache/icons", async (c) => {
+  const accountId = c.req.param("accountId");
+  try {
+    const { clearIconCache } = await import("../storage/cdnAssetCache.js");
+    const removed = await clearIconCache();
+    return c.json({ ok: true, removed });
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
 lineRouter.delete("/:accountId/vyline/saved-media", async (c) => {
   const accountId = c.req.param("accountId");
   try {
     const { clearMediaCache } = await import("../storage/mediaCache.js");
     const removed = await clearMediaCache();
     return c.json({ ok: true, removed });
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+lineRouter.delete("/:accountId/vyline/saved-media/:type", async (c) => {
+  const accountId = c.req.param("accountId");
+  const type = c.req.param("type");
+  const validTypes = new Set(["image", "video", "audio", "file"]);
+  if (!validTypes.has(type)) {
+    return c.json({ ok: false, error: "invalid media type" }, 400);
+  }
+  try {
+    const { clearMediaCacheType } = await import("../storage/mediaCache.js");
+    const removed = await clearMediaCacheType(type as "image" | "video" | "audio" | "file");
+    return c.json({ ok: true, removed, type });
   } catch (err) {
     return handleError(err, c);
   }

--- a/Vyline/backend/src/api/line.ts
+++ b/Vyline/backend/src/api/line.ts
@@ -39,6 +39,7 @@ import {
   fetchMessageMedia,
   sendMessage,
   sendMedia,
+  sendMediaBatch,
   sendSticker,
   canCreateCombinationSticker,
   createCombinationSticker,
@@ -689,23 +690,34 @@ lineRouter.post("/:accountId/send-media-batch", async (c) => {
   }
 
   try {
-    let count = 0;
-    for (const item of body.items) {
-      if (!item?.dataBase64) continue;
+    const items = body.items
+      .filter((item): item is NonNullable<typeof item> & { dataBase64: string } =>
+        Boolean(item?.dataBase64),
+      )
+      .map((item) => {
+        const opts: {
+          dataBase64: string;
+          mimeType?: string;
+          filename?: string;
+          mediaType?: "image" | "video" | "audio" | "file" | "gif";
+        } = { dataBase64: item.dataBase64 };
+        if (item.mimeType) opts.mimeType = item.mimeType;
+        if (item.filename) opts.filename = item.filename;
+        if (item.mediaType) opts.mediaType = item.mediaType;
+        return opts;
+      });
+
+    if (items.length === 0) {
+      return c.json({ ok: false, error: "items required" }, 400);
+    }
+
+    for (const item of items) {
       if (item.dataBase64.length > 12_000_000) {
         return c.json({ ok: false, error: "file too large" }, 413);
       }
-      const opts: {
-        mimeType?: string;
-        filename?: string;
-        mediaType?: "image" | "video" | "audio" | "file" | "gif";
-      } = {};
-      if (item.mimeType) opts.mimeType = item.mimeType;
-      if (item.filename) opts.filename = item.filename;
-      if (item.mediaType) opts.mediaType = item.mediaType;
-      await sendMedia(accountId, body.chatMid, item.dataBase64, opts);
-      count++;
     }
+
+    const count = await sendMediaBatch(accountId, body.chatMid, items);
     return c.json({ ok: true, count });
   } catch (err) {
     return handleError(err, c);

--- a/Vyline/backend/src/api/line.ts
+++ b/Vyline/backend/src/api/line.ts
@@ -1702,14 +1702,3 @@ lineRouter.delete("/:accountId/vyline/saved-media", async (c) => {
     return handleError(err, c);
   }
 });
-
-lineRouter.delete("/:accountId/vyline/icons", async (c) => {
-  const accountId = c.req.param("accountId");
-  try {
-    const { clearCdnCache } = await import("../storage/cdnAssetCache.js");
-    const removed = await clearCdnCache();
-    return c.json({ ok: true, removed });
-  } catch (err) {
-    return handleError(err, c);
-  }
-});

--- a/Vyline/backend/src/api/line.ts
+++ b/Vyline/backend/src/api/line.ts
@@ -40,8 +40,12 @@ import {
   sendMessage,
   sendMedia,
   sendSticker,
+  canCreateCombinationSticker,
+  createCombinationSticker,
+  isStickerAvailableForCombinationSticker,
   fetchStickersCatalog,
   sendLineEmoji,
+  sendCombinationSticker,
   unsendMessage,
   editMessage,
   getMessageEditNotice,
@@ -167,6 +171,19 @@ function handleError(err: unknown, c: Context<any, any, any>) {
         ok: false,
         error: "MESSAGE_NOT_DESTRUCTIBLE: message too old",
         code: "MESSAGE_NOT_DESTRUCTIBLE",
+      },
+      400,
+    );
+  }
+  if (
+    code === "MESSAGE_ALREADY_REVOKED" ||
+    message.toUpperCase().includes("MESSAGE_ALREADY_REVOKED")
+  ) {
+    return c.json(
+      {
+        ok: false,
+        error: "このメッセージはすでに送信取り消し済みです。もう一度取り消すことはできません。",
+        code: "MESSAGE_ALREADY_REVOKED",
       },
       400,
     );
@@ -500,6 +517,99 @@ lineRouter.get("/:accountId/stickers", async (c) => {
   }
 });
 
+// ─── POST /line/:accountId/combination-stickers/can-create ───────
+// { packageIds: string[] }
+
+lineRouter.post("/:accountId/combination-stickers/can-create", async (c) => {
+  const accountId = c.req.param("accountId");
+  const body = await c.req.json<{ packageIds?: string[] }>();
+  if (!body.packageIds?.length) {
+    return c.json({ ok: false, error: "packageIds required" }, 400);
+  }
+  try {
+    const result = await canCreateCombinationSticker(accountId, body.packageIds);
+    return c.json({ ok: true, ...result });
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+// ─── POST /line/:accountId/combination-stickers/available ───────
+// { packageId: string }
+
+lineRouter.post("/:accountId/combination-stickers/available", async (c) => {
+  const accountId = c.req.param("accountId");
+  const body = await c.req.json<{ packageId?: string }>();
+  if (!body.packageId) {
+    return c.json({ ok: false, error: "packageId required" }, 400);
+  }
+  try {
+    const result = await isStickerAvailableForCombinationSticker(accountId, body.packageId);
+    return c.json({ ok: true, ...result });
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+// ─── POST /line/:accountId/combination-stickers ───────
+// { items: [{ packageId, stickerId }], idOfPreviousVersionOfCombinationSticker? }
+
+lineRouter.post("/:accountId/combination-stickers", async (c) => {
+  const accountId = c.req.param("accountId");
+  const body = await c.req.json<{
+    items?: Array<{ packageId: string; stickerId: string; x?: number; y?: number; size?: number }>;
+    idOfPreviousVersionOfCombinationSticker?: string;
+  }>();
+  if (!body.items?.length) {
+    return c.json({ ok: false, error: "items required" }, 400);
+  }
+  try {
+    const result =
+      body.idOfPreviousVersionOfCombinationSticker != null
+        ? await createCombinationSticker(accountId, body.items, {
+            idOfPreviousVersionOfCombinationSticker: body.idOfPreviousVersionOfCombinationSticker,
+          })
+        : await createCombinationSticker(accountId, body.items);
+    return c.json({ ok: true, ...result });
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+// ─── POST /line/:accountId/send-combination-sticker ───────
+// { chatMid, items: [{ packageId, stickerId }], idOfPreviousVersionOfCombinationSticker? }
+
+lineRouter.post("/:accountId/send-combination-sticker", async (c) => {
+  const accountId = c.req.param("accountId");
+  const body = await c.req.json<{
+    chatMid?: string;
+    items?: Array<{ packageId: string; stickerId: string; x?: number; y?: number; size?: number }>;
+    idOfPreviousVersionOfCombinationSticker?: string;
+  }>();
+  if (!body.chatMid) {
+    return c.json({ ok: false, error: "chatMid required" }, 400);
+  }
+  if (!body.items?.length) {
+    return c.json({ ok: false, error: "items required" }, 400);
+  }
+  try {
+    const message = await sendCombinationSticker(
+      accountId,
+      body.chatMid,
+      body.items,
+      body.idOfPreviousVersionOfCombinationSticker != null
+        ? {
+            idOfPreviousVersionOfCombinationSticker:
+              body.idOfPreviousVersionOfCombinationSticker,
+          }
+        : undefined,
+    );
+    return c.json({ ok: true, message: message ?? undefined });
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
 // ─── POST /line/:accountId/send-emoji ─────────
 // { chatMid, packageId, sticonId }
 
@@ -555,6 +665,49 @@ lineRouter.post("/:accountId/send-media", async (c) => {
     if (body.mediaType) opts.mediaType = body.mediaType;
     await sendMedia(accountId, body.chatMid, body.dataBase64, opts);
     return c.json({ ok: true });
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+// ─── POST /line/:accountId/send-media-batch ───────
+// { chatMid, items: [{ dataBase64, mimeType?, filename?, mediaType? }] }
+
+lineRouter.post("/:accountId/send-media-batch", async (c) => {
+  const accountId = c.req.param("accountId");
+  const body = await c.req.json<{
+    chatMid?: string;
+    items?: Array<{
+      dataBase64?: string;
+      mimeType?: string;
+      filename?: string;
+      mediaType?: "image" | "video" | "audio" | "file" | "gif";
+    }>;
+  }>();
+
+  if (!body.chatMid || !Array.isArray(body.items) || body.items.length === 0) {
+    return c.json({ ok: false, error: "chatMid and items required" }, 400);
+  }
+
+  try {
+    let count = 0;
+    for (const item of body.items) {
+      if (!item?.dataBase64) continue;
+      if (item.dataBase64.length > 12_000_000) {
+        return c.json({ ok: false, error: "file too large" }, 413);
+      }
+      const opts: {
+        mimeType?: string;
+        filename?: string;
+        mediaType?: "image" | "video" | "audio" | "file" | "gif";
+      } = {};
+      if (item.mimeType) opts.mimeType = item.mimeType;
+      if (item.filename) opts.filename = item.filename;
+      if (item.mediaType) opts.mediaType = item.mediaType;
+      await sendMedia(accountId, body.chatMid, item.dataBase64, opts);
+      count++;
+    }
+    return c.json({ ok: true, count });
   } catch (err) {
     return handleError(err, c);
   }
@@ -744,14 +897,6 @@ lineRouter.patch("/:accountId/profile", async (c) => {
     allowSearchByUserid?: boolean;
     allowSearchByEmail?: boolean;
     hiddenFromList?: boolean;
-    birthday?: {
-      year?: string;
-      day: string;
-      yearEnabled?: boolean;
-      dayEnabled?: boolean;
-      yearPrivacy?: "PUBLIC" | "PRIVATE";
-      dayPrivacy?: "PUBLIC" | "PRIVATE";
-    };
   }>();
   try {
     const profile = await updateMyProfile(accountId, body);

--- a/Vyline/backend/src/api/line.ts
+++ b/Vyline/backend/src/api/line.ts
@@ -599,8 +599,7 @@ lineRouter.post("/:accountId/send-combination-sticker", async (c) => {
       body.items,
       body.idOfPreviousVersionOfCombinationSticker != null
         ? {
-            idOfPreviousVersionOfCombinationSticker:
-              body.idOfPreviousVersionOfCombinationSticker,
+            idOfPreviousVersionOfCombinationSticker: body.idOfPreviousVersionOfCombinationSticker,
           }
         : undefined,
     );

--- a/Vyline/backend/src/line/clientManager.ts
+++ b/Vyline/backend/src/line/clientManager.ts
@@ -215,6 +215,7 @@ function startFetchOpsLoop(client: VylineClient, accountId: string): void {
     opsRevision.get(accountId) ?? { revision: 0, globalRev: 0, individualRev: 0 };
 
   async function loop(): Promise<void> {
+    let errorStreak = 0;
     while (!abort.signal.aborted && client.base.authToken) {
       try {
         const cursor = getCursor();
@@ -266,6 +267,7 @@ function startFetchOpsLoop(client: VylineClient, accountId: string): void {
             { once: true },
           );
         });
+        errorStreak = 0;
       } catch (err) {
         if (abort.signal.aborted) break;
         const msg = err instanceof Error ? err.message : String(err);
@@ -275,11 +277,16 @@ function startFetchOpsLoop(client: VylineClient, accountId: string): void {
         if (isTimeout) {
           // /SYNC4 は長ポール。新着がないままクライアント側の
           // 期限を迎えるのは通常の待機終了なので、警告にしない。
+          errorStreak = 0;
           log.debug({ accountId, msg }, "ops long poll timed out, retrying in 5s");
+          await new Promise<void>((resolve) => setTimeout(resolve, 5_000));
         } else {
-          log.warn({ accountId, msg }, "ops loop error, retrying in 5s");
+          // 連続エラー時は指数バックオフ（5s → 10s → 20s ... 最大60s）でサーバ負荷を避ける
+          errorStreak++;
+          const retryMs = Math.min(5_000 * 2 ** (errorStreak - 1), 60_000);
+          log.warn({ accountId, msg }, `ops loop error, retrying in ${retryMs / 1000}s`);
+          await new Promise<void>((resolve) => setTimeout(resolve, retryMs));
         }
-        await new Promise<void>((resolve) => setTimeout(resolve, 5_000));
       }
     }
     opsAbortByAccount.delete(accountId);
@@ -385,9 +392,10 @@ function watchAuthToken(client: VylineClient, accountId: string): void {
     },
     5 * 60 * 1000,
   );
-
-  process.on("exit", () => clearInterval(interval));
+  tokenWatchIntervals.set(accountId, interval);
 }
+
+const tokenWatchIntervals = new Map<string, ReturnType<typeof setInterval>>();
 
 export async function loginWithEmail(
   accountId: string,
@@ -642,6 +650,11 @@ export function getLoggedInAt(accountId: string): number | null {
 export function removeClient(accountId: string): void {
   stopFetchOpsLoop(accountId);
   detachFetchOps(accountId);
+  const tokenWatch = tokenWatchIntervals.get(accountId);
+  if (tokenWatch) {
+    clearInterval(tokenWatch);
+    tokenWatchIntervals.delete(accountId);
+  }
   clients.delete(accountId);
   log.info({ accountId }, "client removed");
 }

--- a/Vyline/backend/src/line/clientManager.ts
+++ b/Vyline/backend/src/line/clientManager.ts
@@ -93,12 +93,21 @@ const sendQueue = new Map<string, Promise<unknown>>();
 const SEND_TIMEOUT_MS = 15_000;
 
 function withSendTimeout<T>(p: Promise<T>, timeoutMs: number): Promise<T> {
-  return Promise.race([
-    p,
-    new Promise<T>((_, reject) => {
-      setTimeout(() => reject(new Error(`send timed out after ${timeoutMs}ms`)), timeoutMs);
-    }),
-  ]);
+  return new Promise<T>((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      reject(new Error(`send timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    p.then(
+      (value) => {
+        clearTimeout(timeoutId);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timeoutId);
+        reject(error);
+      },
+    );
+  });
 }
 
 export function runSendRpc<T>(

--- a/Vyline/backend/src/service/lineService.ts
+++ b/Vyline/backend/src/service/lineService.ts
@@ -810,12 +810,21 @@ function invalidateBoxCursorCache(accountId: string, chatMid?: string): void {
 }
 
 function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
-  return Promise.race([
-    promise,
-    new Promise<T>((_, reject) => {
-      setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
-    }),
-  ]);
+  return new Promise<T>((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      reject(new Error(`${label} timed out after ${ms}ms`));
+    }, ms);
+    promise.then(
+      (value) => {
+        clearTimeout(timeoutId);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timeoutId);
+        reject(error);
+      },
+    );
+  });
 }
 
 async function resolveMyMid(
@@ -1739,9 +1748,10 @@ export async function fetchContactProfile(
   })();
 
   contactProfileInflight.set(cacheKey, task);
-  void task.finally(() => {
+  const cleanup = () => {
     contactProfileInflight.delete(cacheKey);
-  });
+  };
+  task.then(cleanup, cleanup);
   return task;
 }
 

--- a/Vyline/backend/src/service/lineService.ts
+++ b/Vyline/backend/src/service/lineService.ts
@@ -85,6 +85,7 @@ import {
 export { restoreRevokedMessage, getMessageHistory } from "../storage/chatStore.js";
 import { CallNotAllowedError, callAllowlistHint, isAllowedCallTarget } from "../call/allowlist.js";
 import { appendMessageLog, type MessageLogEntry } from "../storage/messageLog.js";
+import { writeMediaCache } from "../storage/mediaCache.js";
 
 export { CallNotAllowedError, callAllowlistHint };
 export type { CallSessionSnapshot } from "../call/callManager.js";
@@ -4366,6 +4367,50 @@ export async function sendMediaBatch(
       }
 
       if (plainMode) {
+        // Desktop 準拠: OBS /r/talk/m/reqseq に連番 reqseq でアップロードし、
+        // サーバ側にメッセージを生成させる（HAR 実績と同じ経路）。
+        // thrift sendMessage を併用すると flow=1 チャットでは履歴に載らない。
+        try {
+          const uploaded = await client.base.obs.uploadObjTalkBatch(
+            chatMid,
+            items.map((item, idx) => ({
+              type: (batchMediaTypes[idx] ?? "image") as Parameters<
+                typeof client.base.obs.uploadObjTalk
+              >[1],
+              data: new Blob([Uint8Array.from(atob(item.dataBase64), (c) => c.charCodeAt(0))], {
+                type: item.mimeType ?? "image/png",
+              }),
+              filename:
+                item.filename ??
+                ((item.mediaType ?? "image") === "image" ? "screenshot.png" : "file.bin"),
+            })),
+          );
+          // reqseq 生成メッセージは OBS から OID が取れないため、
+          // アップロード応答の objId（== 生成メッセージID の実測）をキーに
+          // 送信バイトをローカル media cache に置く（自クライアントの即表示用）
+          for (let i = 0; i < uploaded.length; i++) {
+            const objId = uploaded[i]?.objId;
+            if (!objId) continue;
+            const binary = Uint8Array.from(atob(items[i]!.dataBase64), (c) => c.charCodeAt(0));
+            void writeMediaCache(
+              accountId,
+              chatMid,
+              objId,
+              binary,
+              items[i]!.mimeType ?? "image/png",
+            );
+          }
+          log.info(
+            { accountId, chatMid, count: uploaded.length, batch: true, plain: true, reqseq: true },
+            "media batch sent via OBS reqseq",
+          );
+          return items.length;
+        } catch (err) {
+          log.warn(
+            { accountId, chatMid, err: err instanceof Error ? err.message : String(err) },
+            "OBS reqseq batch failed — falling back to sendMessage path",
+          );
+        }
         let previousMessageId: string | undefined;
         let count = 0;
         for (let i = 0; i < items.length; i++) {

--- a/Vyline/backend/src/service/lineService.ts
+++ b/Vyline/backend/src/service/lineService.ts
@@ -175,9 +175,18 @@ function extractBackgroundUrl(value: unknown, depth = 0): string | null {
   if (depth > 12 || value == null) return null;
   if (typeof value === "string") {
     const s = value.trim();
+    if (/^\/(?:myhome|mh|hm)\//i.test(s)) {
+      return `https://obs.line-scdn.net${s}`;
+    }
+    if (/^[a-z0-9_-]{8,}$/i.test(s) && !s.includes(" ")) {
+      const maybe = backgroundObjToUrl(s);
+      if (maybe) return maybe;
+    }
     if (
       /^https?:\/\//i.test(s) &&
-      (s.includes("myhome") || /\.(png|jpe?g|webp|gif)(\?|$)/i.test(s))
+      (s.includes("myhome") ||
+        s.includes("line-scdn.net") ||
+        /\.(png|jpe?g|webp|gif)(\?|$)/i.test(s))
     ) {
       return s;
     }
@@ -228,19 +237,24 @@ async function fetchHomeProfileBackgroundUrl(
   }
   try {
     const client = requireClient(accountId);
-    const res = await withTimeout(
-      (async () => {
-        const r = await client.voomRest<unknown>({
-          routing: "HOMEAPI",
-          path: `/api/v1/home/profile.json?homeId=${encodeURIComponent(targetMid)}`,
-        });
-        return r;
-      })(),
-      HOME_BACKGROUND_RPC_TIMEOUT_MS,
-      "homeProfile",
-    );
-    const result = (res as { result?: unknown })?.result;
-    const url = result ? extractBackgroundUrl(result) : null;
+    const fetchHomeBackground = async (path: string, label: string): Promise<string | null> => {
+      const res = await withTimeout(
+        (async () => {
+          const r = await client.voomRest<unknown>({
+            routing: "HOMEAPI",
+            path: `${path}?homeId=${encodeURIComponent(targetMid)}`,
+          });
+          return r;
+        })(),
+        HOME_BACKGROUND_RPC_TIMEOUT_MS,
+        label,
+      );
+      const result = (res as { result?: unknown })?.result;
+      return result ? extractBackgroundUrl(result) : null;
+    };
+    const url =
+      (await fetchHomeBackground("/api/v1/home/profile.json", "homeProfile")) ??
+      (await fetchHomeBackground("/api/v1/home/cover.json", "homeCover"));
     homeBackgroundCache.set(key, { at: Date.now(), url: url ?? "" });
     return url;
   } catch (err) {
@@ -988,7 +1002,8 @@ export async function fetchProfile(accountId: string): Promise<LineProfile> {
   const mem = myProfileCache.get(accountId);
   if (mem && now - mem.at < MY_PROFILE_CACHE_MS) {
     if (mem.profile.premium) return mem.profile;
-    const premium = premiumStatusCache.get(accountId)?.premium ?? (await fetchPremiumStatus(accountId));
+    const premium =
+      premiumStatusCache.get(accountId)?.premium ?? (await fetchPremiumStatus(accountId));
     const next = { ...mem.profile, premium };
     myProfileCache.set(accountId, { at: mem.at, profile: next });
     return next;
@@ -1048,8 +1063,8 @@ export async function fetchProfile(accountId: string): Promise<LineProfile> {
         statusMessage?: string;
         musicProfile?: string;
         videoProfile?: string;
-      profileId?: string;
-    }
+        profileId?: string;
+      }
     | undefined;
 
   const persistAndReturn = (out: LineProfile): LineProfile => {
@@ -1135,7 +1150,8 @@ export async function fetchProfile(accountId: string): Promise<LineProfile> {
     const profile = await vylineGetProfile(accountId, String(knownMid));
     if (profile?.displayName) {
       const mapped = lineProfileFromVyline(profile);
-      mapped.premium = premiumStatusCache.get(accountId)?.premium ?? (await fetchPremiumStatus(accountId));
+      mapped.premium =
+        premiumStatusCache.get(accountId)?.premium ?? (await fetchPremiumStatus(accountId));
       myProfileCache.set(accountId, { at: now, profile: mapped });
       refreshInBg();
       return mapped;
@@ -1785,6 +1801,19 @@ export async function fetchContactProfile(
 
   const cached = contactProfileCache.get(cacheKey);
   if (cached && now - cached.at < CONTACT_PROFILE_CACHE_MS) {
+    if (targetMid.startsWith("u") && !cached.profile.backgroundUrl) {
+      const next = { ...cached.profile };
+      try {
+        const bg = await fetchHomeProfileBackgroundUrl(accountId, targetMid);
+        if (bg) {
+          next.backgroundUrl = bg;
+          contactProfileCache.set(cacheKey, { at: Date.now(), profile: next });
+          return next;
+        }
+      } catch {
+        /* optional */
+      }
+    }
     return cached.profile;
   }
 
@@ -1803,6 +1832,14 @@ export async function fetchContactProfile(
     const vylineHit = await vylineGetProfile(accountId, targetMid);
     if (vylineHit && !vylineProfileNeedsRefresh(vylineHit)) {
       const profile = lineProfileFromVyline(vylineHit);
+      if (targetMid.startsWith("u") && !profile.backgroundUrl) {
+        try {
+          const bg = await fetchHomeProfileBackgroundUrl(accountId, targetMid);
+          if (bg) profile.backgroundUrl = bg;
+        } catch {
+          /* optional */
+        }
+      }
       contactProfileCache.set(cacheKey, { at: Date.now(), profile });
       return profile;
     }
@@ -4100,11 +4137,25 @@ export async function sendMedia(
 
       try {
         if (plainMode) {
-          // E2EE 鍵を整えられない相手は uploadMediaByE2EE の内部 plain フォールバックを使う
-          // （uploadObjTalk は talk メッセージを作らないため使わない）
-          await tryUpload();
+          // 平文チャットは E2EE メディアメッセージではなく raw OBS upload で送る。
+          // uploadObjTalk が talk 側のメッセージ作成まで面倒を見るため、sendMessage は呼ばない。
+          const { objId, objHash } = await client.base.obs.uploadObjTalk(
+            chatMid,
+            mediaType,
+            blob,
+            undefined,
+            filename,
+          );
           log.info(
-            { accountId, chatMid, mediaType, size: binary.byteLength, plain: true },
+            {
+              accountId,
+              chatMid,
+              mediaType,
+              size: binary.byteLength,
+              plain: true,
+              objId,
+              objHash,
+            },
             "media sent",
           );
           return;
@@ -4191,77 +4242,35 @@ export async function sendSticker(
       return null;
     }
   }
-  return runSendRpc(accountId, async () => {
-    const client = requireClient(accountId);
-    const myMid = await resolveMyMid(client, accountId);
-    const packageId = String(opts?.packageId ?? "11537");
-    const stickerId = String(opts?.stickerId ?? "52002734");
-    // Premium sticker: STKVER=100, 所持チェック不要
-    const premium = Boolean(opts?.isPremium);
-    const stkver = premium ? "100" : "1";
-    const contentMetadata: Record<string, string> = {
-      STKPKGID: packageId,
-      STKID: stickerId,
-      STKVER: stkver,
-      STKTXT: "[スタンプ]",
-    };
-    if (premium) {
-      contentMetadata.STKOPT = "A";
-    }
-
-    const sendPlain = async () =>
-      client.base.talk.sendMessage({
-        to: chatMid,
-        contentType: "STICKER",
-        contentMetadata,
-        e2ee: false,
-      });
-
-    let sent: unknown;
-    if (noE2eePeers.has(chatMid)) {
-      sent = await sendPlain();
-    } else {
-      try {
-        await ensureE2EEIdentityCached(client, accountId);
-        const envelope = await encryptLetterSealingMessage(client, {
-          to: chatMid,
-          from: myMid,
-          contentType: 7, // STICKER
-          payload: {},
-        });
-        sent = await client.base.talk.sendMessage({
-          to: chatMid,
-          contentType: "STICKER",
-          contentMetadata: { ...contentMetadata, ...envelope.contentMetadata },
-          chunks: envelope.chunks,
-          e2ee: true,
-        });
-      } catch (err) {
-        const errMsg = err instanceof Error ? err.message : String(err);
-        markNoE2eePeer(chatMid, errMsg);
-        log.warn({ accountId, chatMid, errMsg }, "e2ee sticker send failed, trying plain");
-        sent = await sendPlain();
+  return runSendRpc(accountId, async () =>
+    sendStickerMessage(accountId, chatMid, async () => {
+      const packageId = String(opts?.packageId ?? "11537");
+      const stickerId = String(opts?.stickerId ?? "52002734");
+      // Premium sticker: STKVER=100, 所持チェック不要
+      const premium = Boolean(opts?.isPremium);
+      const stkver = premium ? "100" : "1";
+      const contentMetadata: Record<string, string> = {
+        STKPKGID: packageId,
+        STKID: stickerId,
+        STKVER: stkver,
+        STKTXT: "[スタンプ]",
+      };
+      if (premium) {
+        contentMetadata.STKOPT = "A";
       }
-    }
-
-    invalidateMessageBoxesCache(accountId);
-    invalidateBoxCursorCache(accountId, chatMid);
-    // 送信結果に STK メタが無い場合もあるので補完してキャッシュ
-    if (sent && typeof sent === "object") {
-      const raw = sent as Record<string, unknown>;
-      const meta = (raw.contentMetadata ?? {}) as Record<string, string>;
-      raw.contentMetadata = { ...contentMetadata, ...meta };
-      raw.contentType = raw.contentType ?? "STICKER";
-    }
-    const remembered = await rememberSentRaw(accountId, chatMid, myMid, sent);
-    log.info({ accountId, chatMid, packageId, stickerId }, "sticker sent");
-    return remembered;
-  });
+      return {
+        contentMetadata,
+      };
+    }),
+  );
 }
 
 type CombinationStickerInput = {
   packageId: string;
   stickerId: string;
+  x?: number;
+  y?: number;
+  size?: number;
 };
 
 function buildCombinationStickerLayouts(items: CombinationStickerInput[]): {
@@ -4273,6 +4282,18 @@ function buildCombinationStickerLayouts(items: CombinationStickerInput[]): {
   const count = Math.max(1, items.length);
 
   const toLayoutInfo = (index: number): CombinationStickerLayoutInfo => {
+    const item = items[index];
+    if (item?.x != null && item?.y != null && item?.size != null) {
+      const scale = canvasWidth / 240;
+      const size = Math.max(40, Math.min(canvasWidth, Math.round(item.size * scale)));
+      return {
+        width: size,
+        height: size,
+        rotation: 0,
+        x: Math.max(0, Math.round(item.x * scale)),
+        y: Math.max(0, Math.round(item.y * scale)),
+      };
+    }
     switch (count) {
       case 1:
         return { width: 352, height: 352, rotation: 0, x: 80, y: 80 };
@@ -4393,16 +4414,113 @@ export async function createCombinationSticker(
     throw new Error("at least one sticker is required");
   }
   return await runSendRpc(accountId, async () => {
-    const client = requireClient(accountId);
-    const payload = buildCombinationStickerLayouts(items);
-    const result = await client.base.shop.createCombinationSticker({
-      request: {
-        ...payload,
-        idOfPreviousVersionOfCombinationSticker:
-          opts?.idOfPreviousVersionOfCombinationSticker ?? "",
-      },
+    return await createCombinationStickerCore(accountId, items, opts);
+  });
+}
+
+async function createCombinationStickerCore(
+  accountId: string,
+  items: CombinationStickerInput[],
+  opts?: { idOfPreviousVersionOfCombinationSticker?: string },
+): Promise<{ id: string }> {
+  const client = requireClient(accountId);
+  const payload = buildCombinationStickerLayouts(items);
+  const result = await client.base.shop.createCombinationSticker({
+    request: {
+      ...payload,
+      idOfPreviousVersionOfCombinationSticker: opts?.idOfPreviousVersionOfCombinationSticker ?? "",
+    },
+  });
+  return { id: String(result?.id ?? "") };
+}
+
+async function sendStickerMessage(
+  accountId: string,
+  chatMid: string,
+  build: (
+    client: ReturnType<typeof requireClient>,
+    myMid: string,
+  ) => Promise<{
+    contentMetadata: Record<string, string>;
+  }>,
+): Promise<Message | null> {
+  const client = requireClient(accountId);
+  const myMid = await resolveMyMid(client, accountId);
+  const built = await build(client, myMid);
+
+  const sendPlain = async () =>
+    client.base.talk.sendMessage({
+      to: chatMid,
+      contentType: "STICKER",
+      contentMetadata: built.contentMetadata,
+      e2ee: false,
     });
-    return { id: String(result?.id ?? "") };
+
+  let sent: unknown;
+  if (noE2eePeers.has(chatMid)) {
+    sent = await sendPlain();
+  } else {
+    try {
+      await ensureE2EEIdentityCached(client, accountId);
+      const envelope = await encryptLetterSealingMessage(client, {
+        to: chatMid,
+        from: myMid,
+        contentType: 7, // STICKER
+        payload: {},
+      });
+      sent = await client.base.talk.sendMessage({
+        to: chatMid,
+        contentType: "STICKER",
+        contentMetadata: { ...built.contentMetadata, ...envelope.contentMetadata },
+        chunks: envelope.chunks,
+        e2ee: true,
+      });
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      markNoE2eePeer(chatMid, errMsg);
+      log.warn({ accountId, chatMid, errMsg }, "e2ee sticker send failed, trying plain");
+      sent = await sendPlain();
+    }
+  }
+
+  invalidateMessageBoxesCache(accountId);
+  invalidateBoxCursorCache(accountId, chatMid);
+  if (sent && typeof sent === "object") {
+    const raw = sent as Record<string, unknown>;
+    const meta = (raw.contentMetadata ?? {}) as Record<string, string>;
+    raw.contentMetadata = { ...built.contentMetadata, ...meta };
+    raw.contentType = raw.contentType ?? "STICKER";
+  }
+  const remembered = await rememberSentRaw(accountId, chatMid, myMid, sent);
+  return remembered;
+}
+
+export async function sendCombinationSticker(
+  accountId: string,
+  chatMid: string,
+  items: CombinationStickerInput[],
+  opts?: { idOfPreviousVersionOfCombinationSticker?: string },
+): Promise<Message | null> {
+  if (chatMid.startsWith("u")) {
+    const blocked = await fetchBlockedContactIds(accountId);
+    if (blocked.includes(chatMid)) {
+      log.info({ accountId, chatMid }, "sendCombinationSticker blocked: user is blocked");
+      return null;
+    }
+  }
+  if (!items.length) {
+    throw new Error("at least one sticker is required");
+  }
+  return runSendRpc(accountId, async () => {
+    const created = await createCombinationStickerCore(accountId, items, opts);
+    const remembered = await sendStickerMessage(accountId, chatMid, async () => ({
+      contentMetadata: { CSSTKID: created.id },
+    }));
+    log.info(
+      { accountId, chatMid, combinationStickerId: created.id, count: items.length },
+      "combination sticker sent",
+    );
+    return remembered;
   });
 }
 

--- a/Vyline/backend/src/service/lineService.ts
+++ b/Vyline/backend/src/service/lineService.ts
@@ -76,7 +76,6 @@ import {
   markMessageRevoked,
   restoreRevokedMessage,
   getMessageHistory,
-  findStoredMessageById,
   warmAccountCache,
   saveBoxOrder,
   type BootstrapPayload,
@@ -4386,7 +4385,16 @@ export async function canCreateCombinationSticker(
   packageIds: string[],
 ): Promise<{ canCreate: boolean; usablePackageIds: string[] }> {
   const client = requireClient(accountId);
-  return await client.base.shop.canCreateCombinationSticker({
+  const shop = (
+    client.base as unknown as {
+      shop: {
+        canCreateCombinationSticker: (input: {
+          request: { packageIds: string[] };
+        }) => Promise<{ canCreate: boolean; usablePackageIds: string[] }>;
+      };
+    }
+  ).shop;
+  return await shop.canCreateCombinationSticker({
     request: {
       packageIds,
     },
@@ -4398,7 +4406,16 @@ export async function isStickerAvailableForCombinationSticker(
   packageId: string,
 ): Promise<{ availableForCombinationSticker: boolean }> {
   const client = requireClient(accountId);
-  return await client.base.shop.isStickerAvailableForCombinationSticker({
+  const shop = (
+    client.base as unknown as {
+      shop: {
+        isStickerAvailableForCombinationSticker: (input: {
+          request: { packageId: string };
+        }) => Promise<{ availableForCombinationSticker: boolean }>;
+      };
+    }
+  ).shop;
+  return await shop.isStickerAvailableForCombinationSticker({
     request: {
       packageId,
     },
@@ -4425,7 +4442,16 @@ async function createCombinationStickerCore(
 ): Promise<{ id: string }> {
   const client = requireClient(accountId);
   const payload = buildCombinationStickerLayouts(items);
-  const result = await client.base.shop.createCombinationSticker({
+  const shop = (
+    client.base as unknown as {
+      shop: {
+        createCombinationSticker: (input: {
+          request: typeof payload & { idOfPreviousVersionOfCombinationSticker: string };
+        }) => Promise<{ id: string | number | null | undefined }>;
+      };
+    }
+  ).shop;
+  const result = await shop.createCombinationSticker({
     request: {
       ...payload,
       idOfPreviousVersionOfCombinationSticker: opts?.idOfPreviousVersionOfCombinationSticker ?? "",
@@ -4597,7 +4623,7 @@ export async function sendLineEmoji(
 export async function unsendMessage(accountId: string, messageId: string): Promise<void> {
   // 送信と同じキューで直列化（送信中と同時に H2 セッションを使うと取り消しが落ちることがある）
   return runSendRpc(accountId, async () => {
-    const found = await findStoredMessageById(accountId, messageId);
+    const found = await findStoredMessageByIdLocal(accountId, messageId);
     if (found) {
       const stored = found.message;
       if (
@@ -4616,6 +4642,22 @@ export async function unsendMessage(accountId: string, messageId: string): Promi
     });
     log.info({ accountId, messageId }, "message unsent");
   });
+}
+
+async function findStoredMessageByIdLocal(
+  accountId: string,
+  messageId: string,
+): Promise<{
+  chatMid: string;
+  message: Awaited<ReturnType<typeof getStoredMessages>>[number];
+} | null> {
+  const chats = await getStoredChats(accountId);
+  for (const chat of chats) {
+    const messages = await getStoredMessages(accountId, chat.mid, Number.MAX_SAFE_INTEGER);
+    const message = messages.find((m) => m.id === messageId);
+    if (message) return { chatMid: chat.mid, message };
+  }
+  return null;
 }
 
 /** メッセージ編集（Desktop: editMessage） */

--- a/Vyline/backend/src/service/lineService.ts
+++ b/Vyline/backend/src/service/lineService.ts
@@ -44,6 +44,7 @@ import {
   vylinePutProfiles,
   vylineResolvedNameMap,
 } from "../storage/vylineCache.js";
+import { updateSessionMeta } from "../storage/tokenStore.js";
 import { VylineStorage } from "../storage/vylineStorage.js";
 import { banCreateGroup, isCreateGroupBanned } from "../storage/featureLocks.js";
 import {
@@ -75,6 +76,7 @@ import {
   markMessageRevoked,
   restoreRevokedMessage,
   getMessageHistory,
+  findStoredMessageById,
   warmAccountCache,
   saveBoxOrder,
   type BootstrapPayload,
@@ -89,6 +91,40 @@ export { CallNotAllowedError, callAllowlistHint };
 export type { CallSessionSnapshot } from "../call/callManager.js";
 
 const log = childLogger("service:line");
+
+type CombinationStickerLayoutInfo = {
+  width: number;
+  height: number;
+  rotation: number;
+  x: number;
+  y: number;
+};
+
+type CombinationStickerStickerInfo = {
+  stickerId: number;
+  productId: number;
+  stickerHash: string;
+  stickerOptions: string;
+  stickerVersion: number;
+};
+
+type CombinationStickerLayout = {
+  layoutInfo: CombinationStickerLayoutInfo;
+  stickerInfo: CombinationStickerStickerInfo;
+};
+
+type CombinationStickerMetadata = {
+  version: number;
+  canvasWidth: number;
+  canvasHeight: number;
+  stickerLayouts: CombinationStickerLayout[];
+};
+
+type CombinationStickerStickerData = {
+  packageId: string;
+  stickerId: string;
+  version: number;
+};
 
 // ─── helpers ──────────────────────────────────
 
@@ -301,8 +337,9 @@ async function ensureGroupE2EEKey(
         msg.includes("NOT_FOUND") ||
         msg.includes("no valid group key") ||
         msg.includes("there is no valid group key");
-      if (expectedMissing) {
+      if (expectedMissing || isRetryPlainError(msg)) {
         log.debug({ chatMid, err: msg }, "ensureGroupE2EEKey: no group key (skip)");
+        if (isRetryPlainError(msg)) noE2eePeers.add(chatMid);
       } else {
         log.warn(
           { chatMid, err: msg },
@@ -580,6 +617,15 @@ const CONTACT_PROFILE_MISS_MS = Number(process.env.VYLINE_CONTACT_MISS_CACHE_MS 
 const contactProfileMiss = new Map<string, number>();
 const myProfileCache = new Map<string, { at: number; profile: LineProfile }>();
 const myMidCache = new Map<string, string>();
+type PremiumStatus = {
+  active: boolean;
+  planType?: string | number;
+  validUntil?: number;
+  onFreeTrial?: boolean;
+  willExpire?: boolean;
+};
+const premiumStatusCache = new Map<string, { at: number; premium: PremiumStatus }>();
+const PREMIUM_STATUS_CACHE_MS = Number(process.env.VYLINE_PREMIUM_STATUS_CACHE_MS ?? 10 * 60_000);
 
 /** Desktop: 起動時に鍵検証済み — 毎リクエスト getE2EEPublicKeys を避ける */
 const e2eeIdentityEnsuredAt = new Map<string, number>();
@@ -890,6 +936,48 @@ function requireClient(accountId: string) {
   return client;
 }
 
+async function fetchPremiumStatus(accountId: string): Promise<PremiumStatus> {
+  const now = Date.now();
+  const cached = premiumStatusCache.get(accountId);
+  if (cached && now - cached.at < PREMIUM_STATUS_CACHE_MS) {
+    return cached.premium;
+  }
+
+  const client = requireClient(accountId);
+  let premium: PremiumStatus = { active: false };
+  try {
+    const status = (await client.base.request.request(
+      LINEStruct.getPremiumStatus_args({ req: {} as never }),
+      "getPremiumStatus",
+      4,
+      true,
+      "/EXT/line-premium/common/thrift/status",
+    )) as {
+      active?: boolean;
+      planType?: string | number;
+      validUntil?: number | bigint;
+      onFreeTrial?: boolean;
+      willExpire?: boolean;
+    };
+    premium = {
+      active: Boolean(status?.active),
+      onFreeTrial: Boolean(status?.onFreeTrial),
+      willExpire: Boolean(status?.willExpire),
+    };
+    if (status?.planType != null) premium.planType = status.planType;
+    if (status?.validUntil != null) premium.validUntil = Number(status.validUntil);
+  } catch (err) {
+    log.debug(
+      { accountId, err: err instanceof Error ? err.message : String(err) },
+      "getPremiumStatus failed",
+    );
+  }
+
+  premiumStatusCache.set(accountId, { at: Date.now(), premium });
+  void updateSessionMeta(accountId, { premium });
+  return premium;
+}
+
 /** 自分のプロフィール取得（メモリ / base.profile / Vyline 優先、RPC は短タイムアウト） */
 export async function fetchProfile(accountId: string): Promise<LineProfile> {
   // Refresh token before making profile requests to ensure it's valid
@@ -899,7 +987,11 @@ export async function fetchProfile(accountId: string): Promise<LineProfile> {
   const now = Date.now();
   const mem = myProfileCache.get(accountId);
   if (mem && now - mem.at < MY_PROFILE_CACHE_MS) {
-    return mem.profile;
+    if (mem.profile.premium) return mem.profile;
+    const premium = premiumStatusCache.get(accountId)?.premium ?? (await fetchPremiumStatus(accountId));
+    const next = { ...mem.profile, premium };
+    myProfileCache.set(accountId, { at: mem.at, profile: next });
+    return next;
   }
 
   const client = requireClient(accountId);
@@ -919,7 +1011,10 @@ export async function fetchProfile(accountId: string): Promise<LineProfile> {
       backgroundUrl?: string;
     },
     birthday: LineBirthday | null = null,
+    premium: PremiumStatus | null = null,
   ): LineProfile => {
+    // ふりがな / profileId / pictureStatus / birthday は backend で保持しておく。
+    // 現在の UI では出さないが、将来の再表示やデバッグ用にレスポンス形は残す。
     const pictureStatus = String(raw.pictureStatus ?? raw.picturePath ?? "");
     const thumbnailUrl = pictureStatusToUrl(pictureStatus) ?? "";
     const out: LineProfile = {
@@ -936,6 +1031,7 @@ export async function fetchProfile(accountId: string): Promise<LineProfile> {
       profileId: String(raw.profileId ?? ""),
       backgroundUrl: raw.backgroundUrl || undefined,
       birthday,
+      ...(premium ? { premium } : {}),
     };
     return out;
   };
@@ -952,8 +1048,8 @@ export async function fetchProfile(accountId: string): Promise<LineProfile> {
         statusMessage?: string;
         musicProfile?: string;
         videoProfile?: string;
-        profileId?: string;
-      }
+      profileId?: string;
+    }
     | undefined;
 
   const persistAndReturn = (out: LineProfile): LineProfile => {
@@ -980,6 +1076,7 @@ export async function fetchProfile(accountId: string): Promise<LineProfile> {
       if (out.birthday?.display) put.birthday = out.birthday.display;
       if (out.backgroundUrl) put.backgroundUrl = out.backgroundUrl;
       void vylinePutProfile(accountId, put);
+      if (out.premium) void updateSessionMeta(accountId, { premium: out.premium });
     }
     return out;
   };
@@ -993,6 +1090,7 @@ export async function fetchProfile(accountId: string): Promise<LineProfile> {
           MY_PROFILE_RPC_TIMEOUT_MS,
           "getProfile.bg",
         );
+        const premium = await fetchPremiumStatus(accountId);
         let birthday: LineBirthday | null = mem?.profile.birthday ?? null;
         try {
           const ext = await withTimeout(
@@ -1012,7 +1110,7 @@ export async function fetchProfile(accountId: string): Promise<LineProfile> {
         } catch {
           /* optional */
         }
-        persistAndReturn(mapRaw(profile as never, birthday));
+        persistAndReturn(mapRaw(profile as never, birthday, premium));
       } catch (err) {
         log.debug({ accountId, err }, "fetchProfile background refresh failed");
       }
@@ -1025,7 +1123,7 @@ export async function fetchProfile(accountId: string): Promise<LineProfile> {
   }
 
   if (baseProf?.mid && baseProf.displayName) {
-    const quick = mapRaw(baseProf, mem?.profile.birthday ?? null);
+    const quick = mapRaw(baseProf, mem?.profile.birthday ?? null, mem?.profile.premium ?? null);
     persistAndReturn(quick);
     refreshInBg();
     return quick;
@@ -1037,6 +1135,7 @@ export async function fetchProfile(accountId: string): Promise<LineProfile> {
     const profile = await vylineGetProfile(accountId, String(knownMid));
     if (profile?.displayName) {
       const mapped = lineProfileFromVyline(profile);
+      mapped.premium = premiumStatusCache.get(accountId)?.premium ?? (await fetchPremiumStatus(accountId));
       myProfileCache.set(accountId, { at: now, profile: mapped });
       refreshInBg();
       return mapped;
@@ -1049,6 +1148,7 @@ export async function fetchProfile(accountId: string): Promise<LineProfile> {
       MY_PROFILE_RPC_TIMEOUT_MS,
       "getProfile",
     );
+    const premium = await fetchPremiumStatus(accountId);
     let birthday: LineBirthday | null = null;
     try {
       const ext = await withTimeout(
@@ -1069,13 +1169,16 @@ export async function fetchProfile(accountId: string): Promise<LineProfile> {
       log.debug({ accountId, err }, "getExtendedProfile skipped");
     }
 
-    const out = persistAndReturn(mapRaw(profile as never, birthday));
+    const out = persistAndReturn(mapRaw(profile as never, birthday, premium));
     log.debug({ accountId, mid: out.mid, hasThumb: Boolean(out.thumbnailUrl) }, "profile fetched");
     return out;
   } catch (err) {
     log.debug({ accountId, err }, "fetchProfile timed out — fallback");
     if (mem) return mem.profile;
-    if (baseProf?.mid) return persistAndReturn(mapRaw(baseProf, null));
+    if (baseProf?.mid) {
+      const premium = await fetchPremiumStatus(accountId).catch(() => null);
+      return persistAndReturn(mapRaw(baseProf, null, premium));
+    }
     throw err;
   }
 }
@@ -3608,6 +3711,11 @@ function isMissingGroupKeyError(errMsg: string): boolean {
   );
 }
 
+function isRetryPlainError(errMsg: string): boolean {
+  const lower = errMsg.toLowerCase();
+  return errMsg.includes("E2EE_RETRY_PLAIN") || lower.includes("member settings off");
+}
+
 /**
  * グループ宛送信前: 最新共有鍵を用意。無ければ新規 register。
  * （uploadMediaByE2EE / Letter Sealing は鍵無しだと NOT_FOUND で落ちる）
@@ -3632,6 +3740,11 @@ async function ensureGroupKeyReadyForSend(
     return;
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
+    if (isRetryPlainError(msg)) {
+      noE2eePeers.add(chatMid);
+      log.debug({ accountId, chatMid, err: msg }, "ensureGroupKeyReadyForSend: retry plain");
+      return;
+    }
     if (!isMissingGroupKeyError(msg)) {
       log.warn({ accountId, chatMid, err: msg }, "ensureGroupKeyReadyForSend: getLast failed");
       throw err;
@@ -3952,6 +4065,7 @@ export async function sendMedia(
           );
           plainMode = true;
         }
+        plainMode = plainMode || noE2eePeers.has(chatMid);
       }
 
       const mime = opts?.mimeType ?? "image/png";
@@ -4145,6 +4259,153 @@ export async function sendSticker(
   });
 }
 
+type CombinationStickerInput = {
+  packageId: string;
+  stickerId: string;
+};
+
+function buildCombinationStickerLayouts(items: CombinationStickerInput[]): {
+  metadata: CombinationStickerMetadata;
+  stickers: CombinationStickerStickerData[];
+} {
+  const canvasWidth = 512;
+  const canvasHeight = 512;
+  const count = Math.max(1, items.length);
+
+  const toLayoutInfo = (index: number): CombinationStickerLayoutInfo => {
+    switch (count) {
+      case 1:
+        return { width: 352, height: 352, rotation: 0, x: 80, y: 80 };
+      case 2:
+        return {
+          width: 216,
+          height: 216,
+          rotation: 0,
+          x: index === 0 ? 40 : 256,
+          y: 148,
+        };
+      case 3:
+        return index === 0
+          ? { width: 240, height: 240, rotation: 0, x: 136, y: 20 }
+          : {
+              width: 200,
+              height: 200,
+              rotation: 0,
+              x: index === 1 ? 44 : 268,
+              y: 248,
+            };
+      case 4: {
+        const col = index % 2;
+        const row = Math.floor(index / 2);
+        return { width: 192, height: 192, rotation: 0, x: 48 + col * 224, y: 48 + row * 224 };
+      }
+      case 5:
+        if (index < 2) {
+          return { width: 176, height: 176, rotation: 0, x: 68 + index * 204, y: 56 };
+        }
+        return { width: 160, height: 160, rotation: 0, x: 48 + (index - 2) * 148, y: 292 };
+      case 6: {
+        const col = index % 3;
+        const row = Math.floor(index / 3);
+        return {
+          width: 140,
+          height: 140,
+          rotation: 0,
+          x: 38 + col * 158,
+          y: 86 + row * 168,
+        };
+      }
+      default: {
+        const cols = count <= 8 ? 3 : 4;
+        const rows = Math.ceil(count / cols);
+        const cellW = Math.floor((canvasWidth - 72) / cols);
+        const cellH = Math.floor((canvasHeight - 72) / rows);
+        const col = index % cols;
+        const row = Math.floor(index / cols);
+        const size = Math.min(cellW, cellH) - 10;
+        return {
+          width: size,
+          height: size,
+          rotation: 0,
+          x: 36 + col * cellW + Math.floor((cellW - size) / 2),
+          y: 36 + row * cellH + Math.floor((cellH - size) / 2),
+        };
+      }
+    }
+  };
+
+  const metadata: CombinationStickerMetadata = {
+    version: 1,
+    canvasWidth,
+    canvasHeight,
+    stickerLayouts: items.map((item, index) => ({
+      layoutInfo: toLayoutInfo(index),
+      stickerInfo: {
+        stickerId: Number(item.stickerId),
+        productId: Number(item.packageId),
+        stickerHash: "",
+        stickerOptions: "",
+        stickerVersion: 1,
+      },
+    })),
+  };
+
+  return {
+    metadata,
+    stickers: items.map((item) => ({
+      packageId: item.packageId,
+      stickerId: item.stickerId,
+      version: 1,
+    })),
+  };
+}
+
+export async function canCreateCombinationSticker(
+  accountId: string,
+  packageIds: string[],
+): Promise<{ canCreate: boolean; usablePackageIds: string[] }> {
+  const client = requireClient(accountId);
+  return await client.base.shop.canCreateCombinationSticker({
+    request: {
+      packageIds,
+    },
+  });
+}
+
+export async function isStickerAvailableForCombinationSticker(
+  accountId: string,
+  packageId: string,
+): Promise<{ availableForCombinationSticker: boolean }> {
+  const client = requireClient(accountId);
+  return await client.base.shop.isStickerAvailableForCombinationSticker({
+    request: {
+      packageId,
+    },
+  });
+}
+
+export async function createCombinationSticker(
+  accountId: string,
+  items: CombinationStickerInput[],
+  opts?: { idOfPreviousVersionOfCombinationSticker?: string },
+): Promise<{ id: string }> {
+  if (items.length === 0) {
+    throw new Error("at least one sticker is required");
+  }
+  return await runSendRpc(accountId, async () => {
+    const client = requireClient(accountId);
+    const payload = buildCombinationStickerLayouts(items);
+    const result = await client.base.shop.createCombinationSticker({
+      request: {
+        ...payload,
+        idOfPreviousVersionOfCombinationSticker:
+          opts?.idOfPreviousVersionOfCombinationSticker ?? "",
+      },
+    });
+    return { id: String(result?.id ?? "") };
+  });
+}
+
 /** LINE 絵文字 (sticon) 送信 */
 export async function sendLineEmoji(
   accountId: string,
@@ -4218,6 +4479,18 @@ export async function sendLineEmoji(
 export async function unsendMessage(accountId: string, messageId: string): Promise<void> {
   // 送信と同じキューで直列化（送信中と同時に H2 セッションを使うと取り消しが落ちることがある）
   return runSendRpc(accountId, async () => {
+    const found = await findStoredMessageById(accountId, messageId);
+    if (found) {
+      const stored = found.message;
+      if (
+        stored.revokedSnapshot ||
+        stored.messageState?.startsWith("revoked") ||
+        stored.contentType === "UNSENT" ||
+        stored.contentType === "UNSEND"
+      ) {
+        throw new Error("MESSAGE_ALREADY_REVOKED: this message was already unsent once");
+      }
+    }
     const client = requireClient(accountId);
     await client.base.talk.unsendMessage({
       seq: await client.base.getReqseq(),
@@ -4295,7 +4568,7 @@ export async function getMessageEditNotice(
 // ─── Profile / Chat admin / Contacts (domain facade) ───────────────────────
 // Desktop: TalkService_updateProfileAttributes / updateChat / updateContactSetting
 
-/** 自分プロフィール属性更新（表示名・ステメ・誕生日等） */
+/** 自分プロフィール属性更新（表示名・ステメ等） */
 export async function updateMyProfile(
   accountId: string,
   input: ProfileUpdateInput,
@@ -4305,7 +4578,7 @@ export async function updateMyProfile(
 
   // musicProfile は ANDROIDSECONDARY 等で "music profile update not allowed"
   // → 書き込みは行わずログのみ（取得・表示は fetchProfile 側）
-  const { musicProfile, birthday, ...attrs } = input;
+  const { musicProfile, ...attrs } = input;
   if (musicProfile !== undefined) {
     log.info({ accountId }, "musicProfile write skipped (server rejects on this device type)");
   }
@@ -4313,41 +4586,6 @@ export async function updateMyProfile(
   const attrInput: ProfileUpdateInput = { ...attrs };
   if (Object.keys(attrInput).length > 0) {
     await session.profile.update(attrInput);
-  }
-
-  if (birthday) {
-    try {
-      await session.profile.update({ birthday });
-    } catch (err1) {
-      log.debug({ accountId, err: err1 }, "birthday update attr 0 failed — retry attr 1");
-      try {
-        const day = birthday.day.replace(/[^0-9]/g, "").slice(0, 4);
-        const year = (birthday.year ?? "").replace(/[^0-9]/g, "").slice(0, 4);
-        await client.base.talk.updateExtendedProfileAttribute({
-          reqSeq: await client.base.getReqseq(),
-          attr: 1,
-          extendedProfile: {
-            birthday: {
-              year,
-              day,
-              yearEnabled: birthday.yearEnabled ?? Boolean(year),
-              dayEnabled: birthday.dayEnabled ?? true,
-              yearPrivacyLevelType: birthday.yearPrivacy ?? "PRIVATE",
-              dayPrivacyLevelType: birthday.dayPrivacy ?? "PUBLIC",
-            },
-          },
-        });
-      } catch (err2) {
-        // ANDROIDSECONDARY 等では x-lc:500 / 空ボディで失敗することがある
-        log.info(
-          {
-            accountId,
-            err: err2 instanceof Error ? err2.message : String(err2),
-          },
-          "birthday update skipped (not supported on this device)",
-        );
-      }
-    }
   }
 
   myMidCache.delete(accountId);
@@ -4370,14 +4608,6 @@ export async function updateMyProfile(
       musicProfile: musicProfile ?? "",
       videoProfile: "",
       profileId: "",
-      birthday: birthday
-        ? formatBirthdayDisplay({
-            day: birthday.day,
-            ...(birthday.year !== undefined ? { year: birthday.year } : {}),
-            ...(birthday.yearEnabled !== undefined ? { yearEnabled: birthday.yearEnabled } : {}),
-            ...(birthday.dayEnabled !== undefined ? { dayEnabled: birthday.dayEnabled } : {}),
-          })
-        : null,
     };
   }
 }
@@ -5563,34 +5793,7 @@ export async function fetchStickersCatalog(
 
   const client = requireClient(accountId);
 
-  let premium: StickersCatalog["premium"] = { active: false };
-  try {
-    const status = (await client.base.request.request(
-      LINEStruct.getPremiumStatus_args({ req: {} as never }),
-      "getPremiumStatus",
-      4,
-      true,
-      "/EXT/line-premium/common/thrift/status",
-    )) as {
-      active?: boolean;
-      planType?: string | number;
-      validUntil?: number | bigint;
-      onFreeTrial?: boolean;
-      willExpire?: boolean;
-    };
-    premium = {
-      active: Boolean(status?.active),
-      onFreeTrial: Boolean(status?.onFreeTrial),
-      willExpire: Boolean(status?.willExpire),
-    };
-    if (status?.planType != null) premium.planType = status.planType;
-    if (status?.validUntil != null) premium.validUntil = Number(status.validUntil);
-  } catch (err) {
-    log.debug(
-      { accountId, err: err instanceof Error ? err.message : String(err) },
-      "getPremiumStatus failed",
-    );
-  }
+  const premium = await fetchPremiumStatus(accountId);
 
   const stickerIds = [
     ...DEFAULT_STICKER_PACKS,

--- a/Vyline/backend/src/service/lineService.ts
+++ b/Vyline/backend/src/service/lineService.ts
@@ -151,7 +151,7 @@ export function backgroundObjToUrl(objId: string | undefined | null): string | n
   if (!objId || !String(objId).trim()) return null;
   const s = String(objId).trim();
   if (s.startsWith("https://") || s.startsWith("http://")) return s;
-  return `https://obs.line-scdn.net/myhome/h/${s}`;
+  return `https://obs.line-apps.com/r/myhome/h/${s}`;
 }
 
 // ─── プロフィール背景（他ユーザー）────────────────
@@ -221,7 +221,17 @@ const HOME_BACKGROUND_CACHE_MS = 30 * 60 * 1000; // 30 分
 const HOME_BACKGROUND_RPC_TIMEOUT_MS = 6_000;
 
 /**
- * VOOM ホームプロフィール API からユーザーのプロフィール背景 URL を取得する。
+ * 相手のプロフィール背景（カバー画像）URL を取得する。
+ *
+ * 実データは HOME チャネルの home/cover API が正解（live-verified 2026-08-21）:
+ *   GET gw.line.naver.jp/hm/api/v1/home/cover.json?homeId=<mid>
+ *   ヘッダ X-Line-ChannelToken = issueChannelToken(HOME).channelAccessToken
+ * レスポンス:
+ *   { code:0, result:{ coverObsInfo:{ objectId, obsNamespace:"c", serviceName:"myhome" }, isDefaultCover:false } }
+ * 画像 URL: https://obs.line-apps.com/r/myhome/<obsNamespace>/<objectId>
+ *
+ * 注: ルーティングは MYHOME_RENEWAL(/hm)。HOMEAPI(/ma) や MYHOME(/mh) は 401/404 になる。
+ * チャネルトークンは voom.call("HOME", ...) が自動で発行する(channelAccessToken を使用)。
  * 失敗時は null（タイムアウト・権限なし・未設定などは静かに握りつぶす）。
  */
 async function fetchHomeProfileBackgroundUrl(
@@ -232,32 +242,37 @@ async function fetchHomeProfileBackgroundUrl(
   const key = `${accountId}:${targetMid}`;
   const cached = homeBackgroundCache.get(key);
   if (cached && Date.now() - cached.at < HOME_BACKGROUND_CACHE_MS) {
-    return cached.url;
+    return cached.url || null;
   }
   try {
     const client = requireClient(accountId);
-    const fetchHomeBackground = async (path: string, label: string): Promise<string | null> => {
-      const res = await withTimeout(
-        (async () => {
-          const r = await client.voomRest<unknown>({
-            routing: "HOMEAPI",
-            path: `${path}?homeId=${encodeURIComponent(targetMid)}`,
-          });
-          return r;
-        })(),
-        HOME_BACKGROUND_RPC_TIMEOUT_MS,
-        label,
-      );
-      const result = (res as { result?: unknown })?.result;
-      return result ? extractBackgroundUrl(result) : null;
-    };
-    const url =
-      (await fetchHomeBackground("/api/v1/home/profile.json", "homeProfile")) ??
-      (await fetchHomeBackground("/api/v1/home/cover.json", "homeCover"));
-    homeBackgroundCache.set(key, { at: Date.now(), url: url ?? "" });
-    return url;
+    const res = await withTimeout(
+      client.voom.call("HOME", {
+        routing: "MYHOME_RENEWAL",
+        path: `/api/v1/home/cover.json?homeId=${encodeURIComponent(targetMid)}`,
+      }),
+      HOME_BACKGROUND_RPC_TIMEOUT_MS,
+      "homeCover",
+    );
+    const result = (res as { result?: unknown }).result as
+      | {
+          coverObsInfo?: { objectId?: string; obsNamespace?: string };
+          isDefaultCover?: boolean;
+        }
+      | null
+      | undefined;
+    const info = result?.coverObsInfo;
+    // isDefaultCover=true は LINE の既定カバー（未設定）とみなし表示しない
+    if (info?.objectId && result?.isDefaultCover !== true) {
+      const ns = info.obsNamespace || "c";
+      const url = `https://obs.line-apps.com/r/myhome/${ns}/${info.objectId}`;
+      homeBackgroundCache.set(key, { at: Date.now(), url });
+      return url;
+    }
+    homeBackgroundCache.set(key, { at: Date.now(), url: "" });
+    return null;
   } catch (err) {
-    log.debug({ accountId, targetMid, err }, "homeProfile background fetch failed");
+    log.debug({ accountId, targetMid, err }, "home cover background fetch failed");
     homeBackgroundCache.set(key, { at: Date.now(), url: "" });
     return null;
   }
@@ -1043,7 +1058,7 @@ export async function fetchProfile(accountId: string): Promise<LineProfile> {
       musicProfile: String(raw.musicProfile ?? ""),
       videoProfile: String(raw.videoProfile ?? ""),
       profileId: String(raw.profileId ?? ""),
-      backgroundUrl: raw.backgroundUrl || undefined,
+      backgroundUrl: raw.backgroundUrl || extractBackgroundUrl(raw) || undefined,
       birthday,
       ...(premium ? { premium } : {}),
     };
@@ -1908,7 +1923,11 @@ async function fetchContactProfileInner(
       const raw = await resolveUserContactV3Like(client, targetMid);
       if (!raw) return null;
       const profile = mapContactV3Like(raw, targetMid);
-      // プロフィール背景は homeProfile API から（別途・短タイムアウト・失敗許容）
+      // getProfile / contact raw に背景が入ることがあるのでまずそこを優先する。
+      const rawBackground = extractBackgroundUrl(raw);
+      if (rawBackground) profile.backgroundUrl = rawBackground;
+
+      // プロフィール背景は homeProfile API も別途試す（失敗許容の保険）
       try {
         const bg = await fetchHomeProfileBackgroundUrl(accountId, targetMid);
         if (bg) profile.backgroundUrl = bg;
@@ -4049,10 +4068,64 @@ export async function sendMessage(
 }
 
 export type MediaSendType = "image" | "video" | "audio" | "file" | "gif";
+export type MediaBatchItem = {
+  dataBase64: string;
+  mimeType?: string;
+  filename?: string;
+  mediaType?: MediaSendType;
+};
 
 /** スクショ／画像など E2EE メディア送信 */
 /** メディア送信は E2EE 鍵整備 + OBS アップロード + プレビューで時間がかかるため通常より長め */
 const MEDIA_SEND_TIMEOUT_MS = 90_000;
+const MEDIA_FLOW_REQSEQ = 1;
+const mediaFlowCache = new Map<string, { flowMap: Record<string, number>; expiresAt: number }>();
+
+function mediaContentTypeNumber(mediaType: MediaSendType): number {
+  if (mediaType === "video") return 2;
+  if (mediaType === "audio") return 3;
+  if (mediaType === "file") return 14;
+  return 1;
+}
+
+async function determinePlainMediaFlow(
+  client: ReturnType<typeof requireClient>,
+  accountId: string,
+  chatMid: string,
+  mediaTypes: MediaSendType[],
+): Promise<boolean> {
+  const now = Date.now();
+  const cached = mediaFlowCache.get(chatMid);
+  let flowMap = cached && cached.expiresAt > now ? cached.flowMap : undefined;
+  if (!flowMap) {
+    try {
+      const res = await client.base.talk.determineMediaMessageFlow({
+        request: { chatMid },
+      });
+      flowMap = Object.fromEntries(
+        Object.entries(res.flowMap ?? {}).map(([key, value]) => [String(key), Number(value)]),
+      );
+      const ttl =
+        typeof res.cacheTtlMillis === "bigint"
+          ? Number(res.cacheTtlMillis)
+          : Number(res.cacheTtlMillis ?? 0);
+      mediaFlowCache.set(chatMid, {
+        flowMap,
+        expiresAt: now + Math.max(60_000, Math.min(ttl || 0, 6 * 60 * 60 * 1000)),
+      });
+      log.info({ accountId, chatMid, flowMap }, "media message flow determined");
+    } catch (err) {
+      log.warn(
+        { accountId, chatMid, err: err instanceof Error ? err.message : String(err) },
+        "determineMediaMessageFlow failed",
+      );
+      return false;
+    }
+  }
+  return mediaTypes.every(
+    (type) => flowMap[String(mediaContentTypeNumber(type))] === MEDIA_FLOW_REQSEQ,
+  );
+}
 
 export async function sendMedia(
   accountId: string,
@@ -4083,27 +4156,6 @@ export async function sendMedia(
         log.warn({ accountId, err }, "E2EE ensure before media send failed");
       }
 
-      // グループは既存の共有鍵があれば E2EE、無ければ plain（uploadObjTalk）で送る。
-      // 鍵が無いのに勝手に新規登録すると本家クライアントと不整合になり画像が見えなくなるため、
-      // 新規 register はしない（テキストは plain フォールバックで問題ない）
-      let plainMode = noE2eePeers.has(chatMid);
-      if ((chatMid.startsWith("c") || chatMid.startsWith("r")) && !plainMode) {
-        try {
-          await ensureGroupE2EEKey(client, chatMid);
-          if (groupKeyWarmFailed.has(chatMid)) {
-            groupKeyWarmFailed.delete(chatMid);
-            await ensureGroupKeyReadyForSend(client, accountId, chatMid);
-          }
-        } catch (err) {
-          log.warn(
-            { accountId, chatMid, err: err instanceof Error ? err.message : String(err) },
-            "group E2EE key setup failed — sending media as plain",
-          );
-          plainMode = true;
-        }
-        plainMode = plainMode || noE2eePeers.has(chatMid);
-      }
-
       const mime = opts?.mimeType ?? "image/png";
       const mediaType: MediaSendType =
         opts?.mediaType ??
@@ -4124,6 +4176,32 @@ export async function sendMedia(
         (mediaType === "image" || mediaType === "gif"
           ? `screenshot.${mime.includes("jpeg") ? "jpg" : "png"}`
           : "file.bin");
+
+      // Desktop 準拠: REFRESH_MEDIA_FLOW を待たず、送信前にメディア flow を確認する。
+      // flow=1 は OBS /r/talk/m/reqseq でサーバー側に message を作らせる。
+      let plainMode =
+        noE2eePeers.has(chatMid) ||
+        (await determinePlainMediaFlow(client, accountId, chatMid, [mediaType]));
+
+      // グループは既存の共有鍵があれば E2EE、無ければ plain（uploadObjTalk）で送る。
+      // 鍵が無いのに勝手に新規登録すると本家クライアントと不整合になり画像が見えなくなるため、
+      // 新規 register はしない（テキストは plain フォールバックで問題ない）
+      if ((chatMid.startsWith("c") || chatMid.startsWith("r")) && !plainMode) {
+        try {
+          await ensureGroupE2EEKey(client, chatMid);
+          if (groupKeyWarmFailed.has(chatMid)) {
+            groupKeyWarmFailed.delete(chatMid);
+            await ensureGroupKeyReadyForSend(client, accountId, chatMid);
+          }
+        } catch (err) {
+          log.warn(
+            { accountId, chatMid, err: err instanceof Error ? err.message : String(err) },
+            "group E2EE key setup failed — sending media as plain",
+          );
+          plainMode = true;
+        }
+        plainMode = plainMode || noE2eePeers.has(chatMid);
+      }
 
       const tryUpload = async () => {
         await client.base.obs.uploadMediaByE2EE({
@@ -4228,6 +4306,231 @@ export async function sendMedia(
   );
 }
 
+export async function sendMediaBatch(
+  accountId: string,
+  chatMid: string,
+  items: MediaBatchItem[],
+): Promise<number> {
+  if (chatMid.startsWith("u")) {
+    const blocked = await fetchBlockedContactIds(accountId);
+    if (blocked.includes(chatMid)) {
+      log.info({ accountId, chatMid }, "sendMediaBatch blocked: user is blocked");
+      return 0;
+    }
+  }
+
+  return runSendRpc(
+    accountId,
+    async () => {
+      const client = requireClient(accountId);
+      await resolveMyMid(client, accountId);
+      try {
+        await ensureE2EEIdentityCached(client, accountId);
+      } catch (err) {
+        log.warn({ accountId, err }, "E2EE ensure before media batch send failed");
+      }
+
+      const batchMediaTypes = items.map((item) => {
+        const mime = item.mimeType ?? "image/png";
+        return (
+          item.mediaType ??
+          (mime.startsWith("video/")
+            ? "video"
+            : mime.startsWith("audio/")
+              ? "audio"
+              : mime === "image/gif"
+                ? "gif"
+                : mime.startsWith("image/")
+                  ? "image"
+                  : "file")
+        );
+      });
+      let plainMode =
+        noE2eePeers.has(chatMid) ||
+        (await determinePlainMediaFlow(client, accountId, chatMid, batchMediaTypes));
+      if ((chatMid.startsWith("c") || chatMid.startsWith("r")) && !plainMode) {
+        try {
+          await ensureGroupE2EEKey(client, chatMid);
+          if (groupKeyWarmFailed.has(chatMid)) {
+            groupKeyWarmFailed.delete(chatMid);
+            await ensureGroupKeyReadyForSend(client, accountId, chatMid);
+          }
+        } catch (err) {
+          log.warn(
+            { accountId, chatMid, err: err instanceof Error ? err.message : String(err) },
+            "group E2EE key setup failed — sending media batch as plain",
+          );
+          plainMode = true;
+        }
+        plainMode = plainMode || noE2eePeers.has(chatMid);
+      }
+
+      if (plainMode) {
+        let previousMessageId: string | undefined;
+        let count = 0;
+        for (let i = 0; i < items.length; i++) {
+          const item = items[i]!;
+          const mime = item.mimeType ?? "image/png";
+          const mediaType = batchMediaTypes[i] ?? "image";
+          const binary = Uint8Array.from(atob(item.dataBase64), (c) => c.charCodeAt(0));
+          const blob = new Blob([binary], { type: mime });
+          const filename =
+            item.filename ??
+            (mediaType === "image" || mediaType === "gif"
+              ? `screenshot.${mime.includes("jpeg") ? "jpg" : "png"}`
+              : "file.bin");
+          const message = await client.base.obs.uploadObjTalkMessage({
+            to: chatMid,
+            type: mediaType,
+            data: blob,
+            filename,
+            ...(previousMessageId
+              ? {
+                  relatedMessageId: previousMessageId,
+                  messageRelationType: "SUBORDINATE",
+                }
+              : {}),
+          });
+          previousMessageId = message.id;
+          count++;
+          log.info(
+            {
+              accountId,
+              chatMid,
+              mediaType,
+              size: binary.byteLength,
+              plain: true,
+              batch: true,
+              messageId: message.id,
+              relatedMessageId: message.relatedMessageId,
+              messageRelationType: message.messageRelationType,
+            },
+            "media batch item sent",
+          );
+        }
+        return count;
+      }
+
+      let count = 0;
+      let previousMessageId: string | undefined;
+      for (const item of items) {
+        const mime = item.mimeType ?? "image/png";
+        const mediaType: MediaSendType =
+          item.mediaType ??
+          (mime.startsWith("video/")
+            ? "video"
+            : mime.startsWith("audio/")
+              ? "audio"
+              : mime === "image/gif"
+                ? "gif"
+                : mime.startsWith("image/")
+                  ? "image"
+                  : "file");
+        const binary = Uint8Array.from(atob(item.dataBase64), (c) => c.charCodeAt(0));
+        const blob = new Blob([binary], { type: mime });
+        const filename =
+          item.filename ??
+          (mediaType === "image" || mediaType === "gif"
+            ? `screenshot.${mime.includes("jpeg") ? "jpg" : "png"}`
+            : "file.bin");
+
+        const tryUpload = async () => {
+          const message = await client.base.obs.uploadMediaByE2EE({
+            data: blob,
+            oType: mediaType,
+            to: chatMid,
+            filename,
+            ...(previousMessageId
+              ? {
+                  relatedMessageId: previousMessageId,
+                  messageRelationType: "SUBORDINATE",
+                }
+              : {}),
+          });
+          previousMessageId = message.id;
+          return message;
+        };
+
+        try {
+          const message = await tryUpload();
+          log.info(
+            {
+              accountId,
+              chatMid,
+              mediaType,
+              size: binary.byteLength,
+              batch: true,
+              messageId: message.id,
+              relatedMessageId: message.relatedMessageId,
+              messageRelationType: message.messageRelationType,
+            },
+            "media batch item sent",
+          );
+          count++;
+        } catch (err) {
+          let errMsg = err instanceof Error ? err.message : String(err);
+
+          if (isSenderKeyError(errMsg)) {
+            log.warn(
+              { accountId, chatMid, errMsg },
+              "media batch send: invalid sender key — rotating and retrying",
+            );
+            try {
+              await ensureValidE2EEIdentity(client, { forceNewSenderKey: true });
+              const message = await tryUpload();
+              previousMessageId = message.id;
+              count++;
+              continue;
+            } catch (retryErr) {
+              err = retryErr;
+              errMsg = retryErr instanceof Error ? retryErr.message : String(retryErr);
+            }
+          }
+
+          if (
+            (isGroupKeyRecreateError(errMsg) || isMissingGroupKeyError(errMsg)) &&
+            (chatMid.startsWith("c") || chatMid.startsWith("r"))
+          ) {
+            log.warn(
+              { accountId, chatMid, errMsg },
+              "media batch send: old/missing group key — recreating and retrying",
+            );
+            try {
+              await recreateE2EEGroupKey(client, chatMid);
+              groupKeyWarm.delete(chatMid);
+              groupKeyWarmFailed.delete(chatMid);
+              const message = await tryUpload();
+              previousMessageId = message.id;
+              count++;
+              continue;
+            } catch (retryErr) {
+              log.warn(
+                {
+                  accountId,
+                  chatMid,
+                  retryErr: retryErr instanceof Error ? retryErr.message : String(retryErr),
+                },
+                "media batch send after group-key recreate failed",
+              );
+              throw retryErr;
+            }
+          }
+
+          throw err;
+        }
+      }
+
+      return count;
+    },
+    {
+      timeoutMs: Math.min(
+        300_000,
+        Math.max(MEDIA_SEND_TIMEOUT_MS, MEDIA_SEND_TIMEOUT_MS * items.length),
+      ),
+    },
+  );
+}
+
 /** スタンプ送信（所持パック / Premium）。E2EE 非対応相手は最初から plain */
 export async function sendSticker(
   accountId: string,
@@ -4272,6 +4575,9 @@ type CombinationStickerInput = {
   size?: number;
 };
 
+/** frontend sticker-emoji-panel の正規座標空間 (COMBO_EDITOR_SIZE) と同期 */
+const COMBO_EDITOR_SPACE = 240;
+
 function buildCombinationStickerLayouts(items: CombinationStickerInput[]): {
   metadata: CombinationStickerMetadata;
   stickers: CombinationStickerStickerData[];
@@ -4283,14 +4589,14 @@ function buildCombinationStickerLayouts(items: CombinationStickerInput[]): {
   const toLayoutInfo = (index: number): CombinationStickerLayoutInfo => {
     const item = items[index];
     if (item?.x != null && item?.y != null && item?.size != null) {
-      const scale = canvasWidth / 240;
+      const scale = canvasWidth / COMBO_EDITOR_SPACE;
       const size = Math.max(40, Math.min(canvasWidth, Math.round(item.size * scale)));
       return {
         width: size,
         height: size,
         rotation: 0,
-        x: Math.max(0, Math.round(item.x * scale)),
-        y: Math.max(0, Math.round(item.y * scale)),
+        x: Math.max(0, Math.min(canvasWidth - size, Math.round(item.x * scale))),
+        y: Math.max(0, Math.min(canvasHeight - size, Math.round(item.y * scale))),
       };
     }
     switch (count) {
@@ -4542,8 +4848,16 @@ export async function sendCombinationSticker(
     const remembered = await sendStickerMessage(accountId, chatMid, async () => ({
       contentMetadata: { CSSTKID: created.id },
     }));
+    const sentMeta = (remembered?.contentMetadata ?? null) as Record<string, unknown> | null;
     log.info(
-      { accountId, chatMid, combinationStickerId: created.id, count: items.length },
+      {
+        accountId,
+        chatMid,
+        combinationStickerId: created.id,
+        count: items.length,
+        sentMetaKeys: sentMeta ? Object.keys(sentMeta) : null,
+        sentMetaHasCsstk: typeof sentMeta?.CSSTKID === "string" && sentMeta.CSSTKID.length > 0,
+      },
       "combination sticker sent",
     );
     return remembered;

--- a/Vyline/backend/src/service/lineService.ts
+++ b/Vyline/backend/src/service/lineService.ts
@@ -3545,7 +3545,11 @@ async function fetchMessagesInner(
   for (const m of merged) byId.set(m.id, m);
   for (const m of messages) {
     const prev = byId.get(m.id);
-    byId.set(m.id, prev ? { ...prev, ...m } : m);
+    const combined = prev ? { ...prev, ...m } : m;
+    if (prev?.history?.length && !combined.history?.length) {
+      combined.history = prev.history;
+    }
+    byId.set(m.id, combined);
   }
   const out = [...byId.values()].sort((a, b) => b.createdTime - a.createdTime).slice(0, limit);
 

--- a/Vyline/backend/src/service/lineService.ts
+++ b/Vyline/backend/src/service/lineService.ts
@@ -76,7 +76,6 @@ import {
   markMessageRevoked,
   restoreRevokedMessage,
   getMessageHistory,
-  findStoredMessageById,
   warmAccountCache,
   saveBoxOrder,
   type BootstrapPayload,
@@ -4386,7 +4385,16 @@ export async function canCreateCombinationSticker(
   packageIds: string[],
 ): Promise<{ canCreate: boolean; usablePackageIds: string[] }> {
   const client = requireClient(accountId);
-  return await client.base.shop.canCreateCombinationSticker({
+  const shop = (
+    client.base as unknown as {
+      shop: {
+        canCreateCombinationSticker: (input: {
+          request: { packageIds: string[] };
+        }) => Promise<{ canCreate: boolean; usablePackageIds: string[] }>;
+      };
+    }
+  ).shop;
+  return await shop.canCreateCombinationSticker({
     request: {
       packageIds,
     },
@@ -4398,7 +4406,16 @@ export async function isStickerAvailableForCombinationSticker(
   packageId: string,
 ): Promise<{ availableForCombinationSticker: boolean }> {
   const client = requireClient(accountId);
-  return await client.base.shop.isStickerAvailableForCombinationSticker({
+  const shop = (
+    client.base as unknown as {
+      shop: {
+        isStickerAvailableForCombinationSticker: (input: {
+          request: { packageId: string };
+        }) => Promise<{ availableForCombinationSticker: boolean }>;
+      };
+    }
+  ).shop;
+  return await shop.isStickerAvailableForCombinationSticker({
     request: {
       packageId,
     },
@@ -4425,7 +4442,16 @@ async function createCombinationStickerCore(
 ): Promise<{ id: string }> {
   const client = requireClient(accountId);
   const payload = buildCombinationStickerLayouts(items);
-  const result = await client.base.shop.createCombinationSticker({
+  const shop = (
+    client.base as unknown as {
+      shop: {
+        createCombinationSticker: (input: {
+          request: typeof payload & { idOfPreviousVersionOfCombinationSticker: string };
+        }) => Promise<{ id: string | number | null | undefined }>;
+      };
+    }
+  ).shop;
+  const result = await shop.createCombinationSticker({
     request: {
       ...payload,
       idOfPreviousVersionOfCombinationSticker: opts?.idOfPreviousVersionOfCombinationSticker ?? "",
@@ -4597,7 +4623,8 @@ export async function sendLineEmoji(
 export async function unsendMessage(accountId: string, messageId: string): Promise<void> {
   // 送信と同じキューで直列化（送信中と同時に H2 セッションを使うと取り消しが落ちることがある）
   return runSendRpc(accountId, async () => {
-    const found = await findStoredMessageById(accountId, messageId);
+    const found = await findStoredMessageByIdLocal(accountId, messageId);
+    const chatMid = found?.chatMid;
     if (found) {
       const stored = found.message;
       if (
@@ -4614,8 +4641,27 @@ export async function unsendMessage(accountId: string, messageId: string): Promi
       seq: await client.base.getReqseq(),
       messageId,
     });
+    if (chatMid) {
+      await markMessageRevoked(accountId, chatMid, messageId);
+    }
     log.info({ accountId, messageId }, "message unsent");
   });
+}
+
+async function findStoredMessageByIdLocal(
+  accountId: string,
+  messageId: string,
+): Promise<{
+  chatMid: string;
+  message: Awaited<ReturnType<typeof getStoredMessages>>[number];
+} | null> {
+  const chats = await getStoredChats(accountId);
+  for (const chat of chats) {
+    const messages = await getStoredMessages(accountId, chat.mid, Number.MAX_SAFE_INTEGER);
+    const message = messages.find((m) => m.id === messageId);
+    if (message) return { chatMid: chat.mid, message };
+  }
+  return null;
 }
 
 /** メッセージ編集（Desktop: editMessage） */

--- a/Vyline/backend/src/service/lineService.ts
+++ b/Vyline/backend/src/service/lineService.ts
@@ -73,11 +73,15 @@ import {
   upsertChats,
   upsertMessages,
   markMessageRevoked,
+  restoreRevokedMessage,
+  getMessageHistory,
   warmAccountCache,
   saveBoxOrder,
   type BootstrapPayload,
   type StoredChat,
 } from "../storage/chatStore.js";
+
+export { restoreRevokedMessage, getMessageHistory } from "../storage/chatStore.js";
 import { CallNotAllowedError, callAllowlistHint, isAllowedCallTarget } from "../call/allowlist.js";
 import { appendMessageLog, type MessageLogEntry } from "../storage/messageLog.js";
 

--- a/Vyline/backend/src/service/restoreDesktop.ts
+++ b/Vyline/backend/src/service/restoreDesktop.ts
@@ -37,6 +37,7 @@ function resolveDesktopKeysPath(): string | null {
     join(process.cwd(), "source", "desktop", "e2ee", "desktop-e2ee-keys.json"),
     join(process.cwd(), "Vyline", "backend", "data", "desktop-e2ee-keys.json"),
     join(process.cwd(), "data", "desktop-e2ee-keys.json"),
+    join(backendDataDir(), "desktop-e2ee-keys.json"),
   ];
   for (const p of candidates) {
     if (existsSync(p)) return p;

--- a/Vyline/backend/src/storage/cdnAssetCache.ts
+++ b/Vyline/backend/src/storage/cdnAssetCache.ts
@@ -6,6 +6,7 @@
  */
 
 import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
 import { mkdir, readFile, readdir, writeFile, stat } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -21,7 +22,18 @@ const ALLOWED_HOSTS = new Set([
 ]);
 
 const _dir = dirname(fileURLToPath(import.meta.url));
-const CACHE_ROOT = process.env.VYLINE_CDN_CACHE_DIR ?? join(_dir, "../../data/cdn-cache");
+const LEGACY_ROOT = join(_dir, "../../data/cdn-cache");
+const CACHE_ROOT = process.env.VYLINE_CDN_CACHE_DIR ?? join(_dir, "../../storage/cache/cdn-cache");
+
+try {
+  if (!existsSync(CACHE_ROOT) && existsSync(LEGACY_ROOT)) {
+    const { rename } = await import("node:fs/promises");
+    await mkdir(dirname(CACHE_ROOT), { recursive: true });
+    await rename(LEGACY_ROOT, CACHE_ROOT);
+  }
+} catch {
+  /* ignore */
+}
 
 const memory = new Map<string, { buf: Uint8Array; contentType: string; at: number }>();
 const MEMORY_MAX = 80;
@@ -225,4 +237,65 @@ export async function ensureCdnCacheDir(): Promise<void> {
   } catch {
     /* ignore */
   }
+}
+
+export async function getCdnCacheSize(): Promise<number> {
+  let total = 0;
+  try {
+    const { readdir, stat } = await import("node:fs/promises");
+    await mkdir(CACHE_ROOT, { recursive: true });
+    const entries = await readdir(CACHE_ROOT, { withFileTypes: true });
+    for (const e of entries) {
+      const p = join(CACHE_ROOT, e.name);
+      if (e.isDirectory()) {
+        const files = await readdir(p);
+        for (const f of files) {
+          try {
+            const s = await stat(join(p, f));
+            total += s.size;
+          } catch {
+            /* ignore */
+          }
+        }
+      } else {
+        try {
+          const s = await stat(p);
+          total += s.size;
+        } catch {
+          /* ignore */
+        }
+      }
+    }
+  } catch (err) {
+    log.debug({ err }, "cdn cache size check failed");
+  }
+  return total;
+}
+
+export async function clearCdnCache(): Promise<number> {
+  memory.clear();
+  let removed = 0;
+  try {
+    const { readdir, rm, stat } = await import("node:fs/promises");
+    await mkdir(CACHE_ROOT, { recursive: true });
+    const entries = await readdir(CACHE_ROOT, { withFileTypes: true });
+    for (const e of entries) {
+      const p = join(CACHE_ROOT, e.name);
+      if (e.isDirectory()) {
+        const files = await readdir(p);
+        for (const f of files) {
+          await rm(join(p, f), { force: true });
+          removed++;
+        }
+      } else {
+        await rm(p, { force: true });
+        removed++;
+      }
+    }
+    const { logger } = await import("../logger.js");
+    logger.info({ removed }, "cdn cache cleared");
+  } catch (err) {
+    log.debug({ err }, "cdn cache clear failed");
+  }
+  return removed;
 }

--- a/Vyline/backend/src/storage/cdnAssetCache.ts
+++ b/Vyline/backend/src/storage/cdnAssetCache.ts
@@ -7,12 +7,36 @@
 
 import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
-import { mkdir, readFile, readdir, writeFile, stat } from "node:fs/promises";
+import { mkdir, readFile, readdir, stat, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { childLogger } from "../logger.js";
 
 const log = childLogger("cdn-cache");
+
+async function dirSize(target: string): Promise<number> {
+  if (!existsSync(target)) return 0;
+  let total = 0;
+  try {
+    const entries = await readdir(target, { withFileTypes: true });
+    for (const e of entries) {
+      const p = join(target, e.name);
+      if (e.isDirectory()) {
+        total += await dirSize(p);
+      } else {
+        try {
+          const s = await stat(p);
+          total += s.size;
+        } catch {
+          /* ignore */
+        }
+      }
+    }
+  } catch (err) {
+    log.debug({ err, target }, "dirSize failed");
+  }
+  return total;
+}
 
 const ALLOWED_HOSTS = new Set([
   "stickershop.line-scdn.net",
@@ -21,9 +45,17 @@ const ALLOWED_HOSTS = new Set([
   "profile.line-scdn.net",
 ]);
 
+const ICON_HOSTS = new Set(["profile.line-scdn.net"]);
+const CDN_HOSTS = new Set([
+  "stickershop.line-scdn.net",
+  "shop.line-scdn.net",
+  "static.line-scdn.net",
+]);
+
 const _dir = dirname(fileURLToPath(import.meta.url));
 const LEGACY_ROOT = join(_dir, "../../data/cdn-cache");
 const CACHE_ROOT = process.env.VYLINE_CDN_CACHE_DIR ?? join(_dir, "../../storage/cache/cdn-cache");
+const ICON_ROOT = process.env.VYLINE_ICON_CACHE_DIR ?? join(_dir, "../../storage/cache/icons");
 
 try {
   if (!existsSync(CACHE_ROOT) && existsSync(LEGACY_ROOT)) {
@@ -31,6 +63,8 @@ try {
     await mkdir(dirname(CACHE_ROOT), { recursive: true });
     await rename(LEGACY_ROOT, CACHE_ROOT);
   }
+  await mkdir(CACHE_ROOT, { recursive: true });
+  await mkdir(ICON_ROOT, { recursive: true });
 } catch {
   /* ignore */
 }
@@ -107,6 +141,16 @@ function extFromContentType(ct: string, url: string): string {
   return m ? `.${m[1]!.toLowerCase()}` : ".bin";
 }
 
+function cacheRootForUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    if (ICON_HOSTS.has(u.hostname)) return ICON_ROOT;
+  } catch {
+    /* ignore */
+  }
+  return CACHE_ROOT;
+}
+
 export function isAllowedLineCdnUrl(raw: string): boolean {
   try {
     const u = new URL(raw);
@@ -120,12 +164,14 @@ export function isAllowedLineCdnUrl(raw: string): boolean {
 function diskPath(url: string, contentType?: string): string {
   const h = hashKey(url);
   const ext = contentType ? extFromContentType(contentType, url) : "";
-  return join(CACHE_ROOT, h.slice(0, 2), `${h}${ext || ""}`);
+  const root = cacheRootForUrl(url);
+  return join(root, h.slice(0, 2), `${h}${ext || ""}`);
 }
 
 async function readDisk(url: string): Promise<{ buf: Uint8Array; contentType: string } | null> {
   const h = hashKey(url);
-  const dir = join(CACHE_ROOT, h.slice(0, 2));
+  const root = cacheRootForUrl(url);
+  const dir = join(root, h.slice(0, 2));
   try {
     const files = await readdir(dir);
     const hit = files.find((f) => f.startsWith(h));
@@ -152,6 +198,7 @@ async function readDisk(url: string): Promise<{ buf: Uint8Array; contentType: st
 
 async function writeDisk(url: string, buf: Uint8Array, contentType: string): Promise<void> {
   const path = diskPath(url, contentType);
+  const root = cacheRootForUrl(url);
   await mkdir(dirname(path), { recursive: true });
   await writeFile(path, buf);
 }
@@ -240,47 +287,30 @@ export async function ensureCdnCacheDir(): Promise<void> {
 }
 
 export async function getCdnCacheSize(): Promise<number> {
-  let total = 0;
-  try {
-    const { readdir, stat } = await import("node:fs/promises");
-    await mkdir(CACHE_ROOT, { recursive: true });
-    const entries = await readdir(CACHE_ROOT, { withFileTypes: true });
-    for (const e of entries) {
-      const p = join(CACHE_ROOT, e.name);
-      if (e.isDirectory()) {
-        const files = await readdir(p);
-        for (const f of files) {
-          try {
-            const s = await stat(join(p, f));
-            total += s.size;
-          } catch {
-            /* ignore */
-          }
-        }
-      } else {
-        try {
-          const s = await stat(p);
-          total += s.size;
-        } catch {
-          /* ignore */
-        }
-      }
-    }
-  } catch (err) {
-    log.debug({ err }, "cdn cache size check failed");
-  }
-  return total;
+  return dirSize(CACHE_ROOT);
+}
+
+export async function getIconCacheSize(): Promise<number> {
+  return dirSize(ICON_ROOT);
 }
 
 export async function clearCdnCache(): Promise<number> {
   memory.clear();
+  return clearDir(CACHE_ROOT);
+}
+
+export async function clearIconCache(): Promise<number> {
+  return clearDir(ICON_ROOT);
+}
+
+async function clearDir(root: string): Promise<number> {
   let removed = 0;
   try {
     const { readdir, rm, stat } = await import("node:fs/promises");
-    await mkdir(CACHE_ROOT, { recursive: true });
-    const entries = await readdir(CACHE_ROOT, { withFileTypes: true });
+    await mkdir(root, { recursive: true });
+    const entries = await readdir(root, { withFileTypes: true });
     for (const e of entries) {
-      const p = join(CACHE_ROOT, e.name);
+      const p = join(root, e.name);
       if (e.isDirectory()) {
         const files = await readdir(p);
         for (const f of files) {
@@ -293,9 +323,9 @@ export async function clearCdnCache(): Promise<number> {
       }
     }
     const { logger } = await import("../logger.js");
-    logger.info({ removed }, "cdn cache cleared");
+    logger.info({ removed, root }, "cdn dir cleared");
   } catch (err) {
-    log.debug({ err }, "cdn cache clear failed");
+    log.debug({ err, root }, "cdn dir clear failed");
   }
   return removed;
 }

--- a/Vyline/backend/src/storage/chatStore.ts
+++ b/Vyline/backend/src/storage/chatStore.ts
@@ -52,6 +52,8 @@ export interface StoredMessage {
   stickerSticky?: boolean;
   reactions?: MessageReaction[];
   savedAt: string;
+  messageState?: Message["messageState"];
+  history?: Message["history"];
 }
 
 interface ChatDbMeta {
@@ -168,7 +170,11 @@ export async function upsertMessages(
   const db = await getDb(accountId);
   const byChat = db.messages[chatMid] ?? {};
   for (const message of messages) {
-    byChat[message.id] = message;
+    const prev = byChat[message.id];
+    byChat[message.id] = {
+      ...message,
+      history: prev?.history?.length ? prev.history : message.history,
+    };
   }
   db.messages[chatMid] = byChat;
   db.meta.messagesSyncedAt = db.meta.messagesSyncedAt ?? {};
@@ -185,9 +191,55 @@ export async function markMessageRevoked(
   const db = await getDb(accountId);
   const stored = db.messages[chatMid]?.[messageId];
   if (!stored) return;
+  const prevState = stored.messageState ?? "normal";
+  const entry = {
+    state: prevState,
+    text: stored.text,
+    contentType: stored.contentType,
+    updatedTime: Date.now(),
+  };
+  stored.messageState = stored.isMyMessage ? "revoked-by-self" : "revoked-by-other";
+  stored.history = [...(stored.history ?? []), entry];
   stored.contentType = "UNSENT";
   stored.text = null;
   scheduleSave(accountId);
+}
+
+/** 取消し済みメッセージを元に戻す（ローカル永続化）。LINE サーバー側は元に戻せないため chatStore のみ更新 */
+export async function restoreRevokedMessage(
+  accountId: string,
+  chatMid: string,
+  messageId: string,
+): Promise<{ text: string | null; contentType: string } | null> {
+  const db = await getDb(accountId);
+  const stored = db.messages[chatMid]?.[messageId];
+  if (!stored || !stored.history?.length) return null;
+  const lastNormal = [...stored.history]
+    .reverse()
+    .find((h) => h.state === "normal" || h.state === "edited");
+  if (!lastNormal) return null;
+  const entry = {
+    state: "normal" as const,
+    text: stored.text,
+    contentType: stored.contentType,
+    updatedTime: Date.now(),
+  };
+  stored.messageState = "normal";
+  stored.history = [...stored.history, entry];
+  stored.text = lastNormal.text;
+  stored.contentType = lastNormal.contentType;
+  scheduleSave(accountId);
+  return { text: lastNormal.text, contentType: lastNormal.contentType };
+}
+
+export async function getMessageHistory(
+  accountId: string,
+  chatMid: string,
+  messageId: string,
+): Promise<Message["history"]> {
+  const db = await getDb(accountId);
+  const stored = db.messages[chatMid]?.[messageId];
+  return stored?.history ?? [];
 }
 
 export async function getMessages(
@@ -229,7 +281,9 @@ function storedMessageToMessage(stored: StoredMessage): Message {
     createdTime: stored.createdTime,
     isMyMessage: stored.isMyMessage,
     contentMetadata: stored.contentMetadata ?? null,
+    messageState: stored.messageState ?? "normal",
   };
+  if (stored.history) msg.history = stored.history;
   if (stored.readCount != null) msg.readCount = stored.readCount;
   if (stored.readBy) msg.readBy = stored.readBy;
   if (stored.seen != null) msg.seen = stored.seen;

--- a/Vyline/backend/src/storage/chatStore.ts
+++ b/Vyline/backend/src/storage/chatStore.ts
@@ -25,6 +25,8 @@ const DATA_DIR = process.env.VYLINE_DATA_DIR ?? join(_dir, "..", "..", "data");
 const SAVE_DEBOUNCE_MS = Number(process.env.VYLINE_CHATDB_SAVE_MS ?? 400);
 const BOOTSTRAP_TOP_CHATS = Number(process.env.VYLINE_BOOTSTRAP_TOP_CHATS ?? 12);
 const BOOTSTRAP_MSG_LIMIT = Number(process.env.VYLINE_BOOTSTRAP_MSG_LIMIT ?? 40);
+/** チャットあたりの保持上限。無制限保存はメモリ・ディスク・全体書き込みを肥大させるため抑止 */
+const MAX_MESSAGES_PER_CHAT_DB = Number(process.env.VYLINE_CHATDB_MAX_MSGS_PER_CHAT ?? 500);
 
 export interface StoredChat {
   mid: string;
@@ -197,6 +199,14 @@ export async function upsertMessages(
     byChat[message.id] = next;
   }
   db.messages[chatMid] = byChat;
+  // 上限を超えたら古いものから落とす（全ファイル書き換えコストの抑止）
+  const ids = Object.keys(byChat);
+  if (ids.length > MAX_MESSAGES_PER_CHAT_DB) {
+    const drop = ids
+      .sort((a, b) => (byChat[a]?.createdTime ?? 0) - (byChat[b]?.createdTime ?? 0))
+      .slice(0, ids.length - MAX_MESSAGES_PER_CHAT_DB);
+    for (const id of drop) delete byChat[id];
+  }
   db.meta.messagesSyncedAt = db.meta.messagesSyncedAt ?? {};
   db.meta.messagesSyncedAt[chatMid] = new Date().toISOString();
   scheduleSave(accountId);
@@ -410,13 +420,22 @@ export async function saveBoxOrder(accountId: string, boxOrder: string[]): Promi
   scheduleSave(accountId);
 }
 
-/** VylineBackup: 全チャット・メッセージのディープコピーを返す */
+/** VylineBackup: コンテナだけコピーした参照スナップショットを返す。
+ * 個々のメッセージオブジェクトは不変扱いのため clone しない
+ * （全件 deep copy は DB サイズ分のメモリを一時的に 2〜3 重で消費していた） */
 export async function exportChatDb(accountId: string): Promise<ChatDb> {
   const db = await getDb(accountId);
+  const messages: ChatDb["messages"] = {};
+  for (const [chatMid, byChat] of Object.entries(db.messages)) {
+    messages[chatMid] = { ...byChat };
+  }
   return {
-    meta: JSON.parse(JSON.stringify(db.meta)) as ChatDbMeta,
-    chats: JSON.parse(JSON.stringify(db.chats)) as ChatDb["chats"],
-    messages: JSON.parse(JSON.stringify(db.messages)) as ChatDb["messages"],
+    meta: {
+      ...db.meta,
+      ...(db.meta.messagesSyncedAt ? { messagesSyncedAt: { ...db.meta.messagesSyncedAt } } : {}),
+    },
+    chats: { ...db.chats },
+    messages,
   };
 }
 

--- a/Vyline/backend/src/storage/chatStore.ts
+++ b/Vyline/backend/src/storage/chatStore.ts
@@ -9,7 +9,13 @@ import { existsSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import type { Chat, Message, MessageContentMeta, MessageReaction } from "@vyline/types";
+import type {
+  Chat,
+  Message,
+  MessageContentMeta,
+  MessageReaction,
+  MessageSnapshot,
+} from "@vyline/types";
 import { childLogger } from "../logger.js";
 
 const log = childLogger("chatStore");
@@ -54,6 +60,7 @@ export interface StoredMessage {
   savedAt: string;
   messageState?: Message["messageState"];
   history?: Message["history"];
+  revokedSnapshot?: MessageSnapshot;
 }
 
 interface ChatDbMeta {
@@ -171,10 +178,23 @@ export async function upsertMessages(
   const byChat = db.messages[chatMid] ?? {};
   for (const message of messages) {
     const prev = byChat[message.id];
-    byChat[message.id] = {
+    const prevRevoked =
+      Boolean(prev?.revokedSnapshot) || Boolean(prev?.messageState?.startsWith("revoked"));
+    const incomingRevoked =
+      Boolean(message.revokedSnapshot) || Boolean(message.messageState?.startsWith("revoked"));
+    const next: StoredMessage = {
       ...message,
       history: prev?.history?.length ? prev.history : message.history,
     };
+    const revokedSnapshot = prev?.revokedSnapshot ?? message.revokedSnapshot;
+    if (revokedSnapshot) next.revokedSnapshot = revokedSnapshot;
+    if (prevRevoked && !incomingRevoked) {
+      next.messageState =
+        prev?.messageState ?? (prev?.isMyMessage ? "revoked-by-self" : "revoked-by-other");
+      next.contentType = prev ? prev.contentType : message.contentType;
+      next.text = prev ? prev.text : message.text;
+    }
+    byChat[message.id] = next;
   }
   db.messages[chatMid] = byChat;
   db.meta.messagesSyncedAt = db.meta.messagesSyncedAt ?? {};
@@ -198,6 +218,7 @@ export async function markMessageRevoked(
     contentType: stored.contentType,
     updatedTime: Date.now(),
   };
+  stored.revokedSnapshot = stored.revokedSnapshot ?? snapshotFromStoredMessage(stored);
   stored.messageState = stored.isMyMessage ? "revoked-by-self" : "revoked-by-other";
   stored.history = [...(stored.history ?? []), entry];
   stored.contentType = "UNSENT";
@@ -284,6 +305,7 @@ function storedMessageToMessage(stored: StoredMessage): Message {
     messageState: stored.messageState ?? "normal",
   };
   if (stored.history) msg.history = stored.history;
+  if (stored.revokedSnapshot) msg.revokedSnapshot = stored.revokedSnapshot;
   if (stored.readCount != null) msg.readCount = stored.readCount;
   if (stored.readBy) msg.readBy = stored.readBy;
   if (stored.seen != null) msg.seen = stored.seen;
@@ -292,6 +314,15 @@ function storedMessageToMessage(stored: StoredMessage): Message {
   if (stored.stickerSticky) msg.stickerSticky = true;
   if (stored.reactions?.length) msg.reactions = stored.reactions;
   return msg;
+}
+
+function snapshotFromStoredMessage(stored: StoredMessage): MessageSnapshot {
+  const {
+    history: _history,
+    revokedSnapshot: _revokedSnapshot,
+    ...snapshot
+  } = storedMessageToMessage(stored);
+  return snapshot;
 }
 
 /** Desktop 準拠: boxOrder 順、無ければ lastMessageTime 降順 */

--- a/Vyline/backend/src/storage/chatStore.ts
+++ b/Vyline/backend/src/storage/chatStore.ts
@@ -9,7 +9,13 @@ import { existsSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import type { Chat, Message, MessageContentMeta, MessageReaction } from "@vyline/types";
+import type {
+  Chat,
+  Message,
+  MessageContentMeta,
+  MessageReaction,
+  MessageSnapshot,
+} from "@vyline/types";
 import { childLogger } from "../logger.js";
 
 const log = childLogger("chatStore");
@@ -54,6 +60,7 @@ export interface StoredMessage {
   savedAt: string;
   messageState?: Message["messageState"];
   history?: Message["history"];
+  revokedSnapshot?: MessageSnapshot;
 }
 
 interface ChatDbMeta {
@@ -116,6 +123,20 @@ async function getDb(accountId: string): Promise<ChatDb> {
   return db;
 }
 
+function snapshotFromStoredMessage(stored: StoredMessage): MessageSnapshot {
+  const {
+    savedAt: _savedAt,
+    history: _history,
+    revokedSnapshot: _revokedSnapshot,
+    messageState,
+    ...snapshot
+  } = stored;
+  return {
+    ...snapshot,
+    ...(messageState != null ? { messageState } : {}),
+  };
+}
+
 function scheduleSave(accountId: string): void {
   dirty.add(accountId);
   const prev = saveTimers.get(accountId);
@@ -171,8 +192,10 @@ export async function upsertMessages(
   const byChat = db.messages[chatMid] ?? {};
   for (const message of messages) {
     const prev = byChat[message.id];
+    const revokedSnapshot = prev?.revokedSnapshot ?? message.revokedSnapshot;
     byChat[message.id] = {
       ...message,
+      ...(revokedSnapshot ? { revokedSnapshot } : {}),
       history: prev?.history?.length ? prev.history : message.history,
     };
   }
@@ -191,6 +214,7 @@ export async function markMessageRevoked(
   const db = await getDb(accountId);
   const stored = db.messages[chatMid]?.[messageId];
   if (!stored) return;
+  stored.revokedSnapshot = stored.revokedSnapshot ?? snapshotFromStoredMessage(stored);
   const prevState = stored.messageState ?? "normal";
   const entry = {
     state: prevState,
@@ -213,23 +237,42 @@ export async function restoreRevokedMessage(
 ): Promise<{ text: string | null; contentType: string } | null> {
   const db = await getDb(accountId);
   const stored = db.messages[chatMid]?.[messageId];
-  if (!stored || !stored.history?.length) return null;
-  const lastNormal = [...stored.history]
-    .reverse()
-    .find((h) => h.state === "normal" || h.state === "edited");
-  if (!lastNormal) return null;
+  if (!stored) return null;
+  const snapshot = stored.revokedSnapshot;
+  const lastNormal = stored.history?.length
+    ? [...stored.history].reverse().find((h) => h.state === "normal" || h.state === "edited")
+    : undefined;
+  if (!snapshot && !lastNormal) return null;
+  const restoredText = snapshot?.text ?? lastNormal?.text ?? null;
+  const restoredContentType =
+    snapshot?.contentType ?? lastNormal?.contentType ?? stored.contentType;
   const entry = {
     state: "normal" as const,
     text: stored.text,
     contentType: stored.contentType,
     updatedTime: Date.now(),
   };
-  stored.messageState = "normal";
-  stored.history = [...stored.history, entry];
-  stored.text = lastNormal.text;
-  stored.contentType = lastNormal.contentType;
+  stored.messageState = (snapshot?.messageState ??
+    lastNormal?.state ??
+    "normal") as Message["messageState"];
+  stored.history = [...(stored.history ?? []), entry];
+  if (snapshot) stored.revokedSnapshot = snapshot;
+  stored.text = restoredText;
+  stored.contentType = restoredContentType;
+  if (snapshot) {
+    if (snapshot.contentMetadata !== undefined) stored.contentMetadata = snapshot.contentMetadata;
+    if (snapshot.readCount !== undefined) stored.readCount = snapshot.readCount;
+    if (snapshot.readBy !== undefined) stored.readBy = snapshot.readBy;
+    if (snapshot.seen !== undefined) stored.seen = snapshot.seen;
+    if (snapshot.relatedMessageId !== undefined) {
+      stored.relatedMessageId = snapshot.relatedMessageId;
+    }
+    if (snapshot.stickerAnimated !== undefined) stored.stickerAnimated = snapshot.stickerAnimated;
+    if (snapshot.stickerSticky !== undefined) stored.stickerSticky = snapshot.stickerSticky;
+    if (snapshot.reactions !== undefined) stored.reactions = snapshot.reactions;
+  }
   scheduleSave(accountId);
-  return { text: lastNormal.text, contentType: lastNormal.contentType };
+  return { text: restoredText, contentType: restoredContentType };
 }
 
 export async function getMessageHistory(
@@ -253,6 +296,18 @@ export async function getMessages(
   return Object.values(byChat)
     .sort((a, b) => b.createdTime - a.createdTime)
     .slice(0, limit);
+}
+
+export async function findStoredMessageById(
+  accountId: string,
+  messageId: string,
+): Promise<{ chatMid: string; message: StoredMessage } | null> {
+  const db = await getDb(accountId);
+  for (const [chatMid, messages] of Object.entries(db.messages)) {
+    const message = messages[messageId];
+    if (message) return { chatMid, message };
+  }
+  return null;
 }
 
 function storedChatToChat(stored: StoredChat): Chat {
@@ -284,6 +339,7 @@ function storedMessageToMessage(stored: StoredMessage): Message {
     messageState: stored.messageState ?? "normal",
   };
   if (stored.history) msg.history = stored.history;
+  if (stored.revokedSnapshot) msg.revokedSnapshot = stored.revokedSnapshot;
   if (stored.readCount != null) msg.readCount = stored.readCount;
   if (stored.readBy) msg.readBy = stored.readBy;
   if (stored.seen != null) msg.seen = stored.seen;

--- a/Vyline/backend/src/storage/mediaCache.ts
+++ b/Vyline/backend/src/storage/mediaCache.ts
@@ -11,22 +11,57 @@
 
 import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, readdir, stat, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { childLogger } from "../logger.js";
 
 const log = childLogger("media-cache");
 
+async function dirSize(target: string): Promise<number> {
+  if (!existsSync(target)) return 0;
+  let total = 0;
+  try {
+    const entries = await readdir(target, { withFileTypes: true });
+    for (const e of entries) {
+      const p = join(target, e.name);
+      if (e.isDirectory()) {
+        total += await dirSize(p);
+      } else {
+        try {
+          const s = await stat(p);
+          total += s.size;
+        } catch {
+          /* ignore */
+        }
+      }
+    }
+  } catch (err) {
+    log.debug({ err, target }, "dirSize failed");
+  }
+  return total;
+}
+
 const _dir = dirname(fileURLToPath(import.meta.url));
 const LEGACY_ROOT = join(_dir, "../../data/media-cache");
 const CACHE_ROOT = process.env.VYLINE_MEDIA_CACHE_DIR ?? join(_dir, "../../storage/saved-media");
+
+const TYPE_ROOTS = {
+  image: join(CACHE_ROOT, "images"),
+  video: join(CACHE_ROOT, "videos"),
+  audio: join(CACHE_ROOT, "audio"),
+  file: join(CACHE_ROOT, "files"),
+} as const;
 
 try {
   if (!existsSync(CACHE_ROOT) && existsSync(LEGACY_ROOT)) {
     const { rename } = await import("node:fs/promises");
     await mkdir(dirname(CACHE_ROOT), { recursive: true });
     await rename(LEGACY_ROOT, CACHE_ROOT);
+  }
+  await mkdir(CACHE_ROOT, { recursive: true });
+  for (const dir of Object.values(TYPE_ROOTS)) {
+    await mkdir(dir, { recursive: true });
   }
 } catch {
   /* ignore */
@@ -51,9 +86,30 @@ function extFromContentType(ct: string): string {
   return ".bin";
 }
 
+function contentTypeFromFilename(name: string): string {
+  if (name.endsWith(".jpg") || name.endsWith(".jpeg")) return "image/jpeg";
+  if (name.endsWith(".png")) return "image/png";
+  if (name.endsWith(".webp")) return "image/webp";
+  if (name.endsWith(".gif")) return "image/gif";
+  if (name.endsWith(".mp4")) return "video/mp4";
+  if (name.endsWith(".m4a")) return "audio/m4a";
+  if (name.endsWith(".pdf")) return "application/pdf";
+  return "application/octet-stream";
+}
+
+function typeRootForContentType(ct: string): string {
+  const lower = ct.toLowerCase();
+  if (lower.startsWith("image/")) return TYPE_ROOTS.image;
+  if (lower.startsWith("video/")) return TYPE_ROOTS.video;
+  if (lower.startsWith("audio/")) return TYPE_ROOTS.audio;
+  return TYPE_ROOTS.file;
+}
+
 function diskPath(accountId: string, chatMid: string, messageId: string, ct: string): string {
   const h = key(accountId, chatMid, messageId);
-  return join(CACHE_ROOT, h.slice(0, 2), `${h}${extFromContentType(ct)}`);
+  const root = typeRootForContentType(ct);
+  const ext = extFromContentType(ct);
+  return join(root, h.slice(0, 2), `${h}${ext}`);
 }
 
 export async function readMediaCache(
@@ -67,33 +123,23 @@ export async function readMediaCache(
     return { buf: mem.buf, contentType: mem.contentType };
   }
   const h = key(accountId, chatMid, messageId);
-  const dir = join(CACHE_ROOT, h.slice(0, 2));
-  try {
-    const { readdir } = await import("node:fs/promises");
-    const files = await readdir(dir);
-    const hit = files.find((f) => f.startsWith(h));
-    if (!hit) return null;
-    const buf = new Uint8Array(await readFile(join(dir, hit)));
-    const contentType = hit.endsWith(".jpg")
-      ? "image/jpeg"
-      : hit.endsWith(".png")
-        ? "image/png"
-        : hit.endsWith(".webp")
-          ? "image/webp"
-          : hit.endsWith(".gif")
-            ? "image/gif"
-            : hit.endsWith(".mp4")
-              ? "video/mp4"
-              : hit.endsWith(".m4a")
-                ? "audio/m4a"
-                : hit.endsWith(".pdf")
-                  ? "application/pdf"
-                  : "application/octet-stream";
-    remember(memKey, buf, contentType);
-    return { buf, contentType };
-  } catch {
-    return null;
+
+  const searchRoots = [CACHE_ROOT, LEGACY_ROOT, ...Object.values(TYPE_ROOTS)];
+  for (const root of searchRoots) {
+    if (root === LEGACY_ROOT && existsSync(root) === false) continue;
+    const dir = join(root, h.slice(0, 2));
+    try {
+      const { readdir } = await import("node:fs/promises");
+      const files = await readdir(dir);
+      const hit = files.find((f) => f.startsWith(h));
+      if (!hit) continue;
+      const buf = new Uint8Array(await readFile(join(dir, hit)));
+      const contentType = contentTypeFromFilename(hit);
+      remember(memKey, buf, contentType);
+      return { buf, contentType };
+    } catch {}
   }
+  return null;
 }
 
 function remember(memKey: string, buf: Uint8Array, contentType: string): void {
@@ -127,13 +173,44 @@ export async function ensureMediaCacheDir(): Promise<void> {
 
 export async function clearMediaCache(): Promise<number> {
   memory.clear();
+  return clearDir(CACHE_ROOT);
+}
+
+export async function clearMediaCacheType(
+  type: "image" | "video" | "audio" | "file",
+): Promise<number> {
+  const root = TYPE_ROOTS[type];
+  if (!root) return 0;
+  return clearDir(root);
+}
+
+export async function getMediaCacheSize(): Promise<number> {
+  return dirSize(CACHE_ROOT);
+}
+
+export async function getMediaCacheSizeByType(): Promise<{
+  image: number;
+  video: number;
+  audio: number;
+  file: number;
+}> {
+  const [image, video, audio, file] = await Promise.all([
+    dirSize(TYPE_ROOTS.image),
+    dirSize(TYPE_ROOTS.video),
+    dirSize(TYPE_ROOTS.audio),
+    dirSize(TYPE_ROOTS.file),
+  ]);
+  return { image, video, audio, file };
+}
+
+async function clearDir(root: string): Promise<number> {
   let removed = 0;
   try {
-    const { readdir, rm, stat } = await import("node:fs/promises");
-    await mkdir(CACHE_ROOT, { recursive: true });
-    const entries = await readdir(CACHE_ROOT, { withFileTypes: true });
+    const { readdir, rm } = await import("node:fs/promises");
+    await mkdir(root, { recursive: true });
+    const entries = await readdir(root, { withFileTypes: true });
     for (const e of entries) {
-      const p = join(CACHE_ROOT, e.name);
+      const p = join(root, e.name);
       if (e.isDirectory()) {
         const files = await readdir(p);
         for (const f of files) {
@@ -146,42 +223,9 @@ export async function clearMediaCache(): Promise<number> {
       }
     }
     const { logger } = await import("../logger.js");
-    logger.info({ removed }, "media cache cleared");
+    logger.info({ removed, root }, "media cache cleared");
   } catch (err) {
-    log.debug({ err }, "media cache clear failed");
+    log.debug({ err, root }, "media cache clear failed");
   }
   return removed;
-}
-
-export async function getMediaCacheSize(): Promise<number> {
-  let total = 0;
-  try {
-    const { readdir, stat } = await import("node:fs/promises");
-    await mkdir(CACHE_ROOT, { recursive: true });
-    const entries = await readdir(CACHE_ROOT, { withFileTypes: true });
-    for (const e of entries) {
-      const p = join(CACHE_ROOT, e.name);
-      if (e.isDirectory()) {
-        const files = await readdir(p);
-        for (const f of files) {
-          try {
-            const s = await stat(join(p, f));
-            total += s.size;
-          } catch {
-            /* ignore */
-          }
-        }
-      } else {
-        try {
-          const s = await stat(p);
-          total += s.size;
-        } catch {
-          /* ignore */
-        }
-      }
-    }
-  } catch (err) {
-    log.debug({ err }, "media cache size check failed");
-  }
-  return total;
 }

--- a/Vyline/backend/src/storage/mediaCache.ts
+++ b/Vyline/backend/src/storage/mediaCache.ts
@@ -10,6 +10,7 @@
  */
 
 import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -18,7 +19,18 @@ import { childLogger } from "../logger.js";
 const log = childLogger("media-cache");
 
 const _dir = dirname(fileURLToPath(import.meta.url));
-const CACHE_ROOT = process.env.VYLINE_MEDIA_CACHE_DIR ?? join(_dir, "../../data/media-cache");
+const LEGACY_ROOT = join(_dir, "../../data/media-cache");
+const CACHE_ROOT = process.env.VYLINE_MEDIA_CACHE_DIR ?? join(_dir, "../../storage/saved-media");
+
+try {
+  if (!existsSync(CACHE_ROOT) && existsSync(LEGACY_ROOT)) {
+    const { rename } = await import("node:fs/promises");
+    await mkdir(dirname(CACHE_ROOT), { recursive: true });
+    await rename(LEGACY_ROOT, CACHE_ROOT);
+  }
+} catch {
+  /* ignore */
+}
 
 const memory = new Map<string, { buf: Uint8Array; contentType: string; at: number }>();
 const MEMORY_MAX = 40;
@@ -139,4 +151,37 @@ export async function clearMediaCache(): Promise<number> {
     log.debug({ err }, "media cache clear failed");
   }
   return removed;
+}
+
+export async function getMediaCacheSize(): Promise<number> {
+  let total = 0;
+  try {
+    const { readdir, stat } = await import("node:fs/promises");
+    await mkdir(CACHE_ROOT, { recursive: true });
+    const entries = await readdir(CACHE_ROOT, { withFileTypes: true });
+    for (const e of entries) {
+      const p = join(CACHE_ROOT, e.name);
+      if (e.isDirectory()) {
+        const files = await readdir(p);
+        for (const f of files) {
+          try {
+            const s = await stat(join(p, f));
+            total += s.size;
+          } catch {
+            /* ignore */
+          }
+        }
+      } else {
+        try {
+          const s = await stat(p);
+          total += s.size;
+        } catch {
+          /* ignore */
+        }
+      }
+    }
+  } catch (err) {
+    log.debug({ err }, "media cache size check failed");
+  }
+  return total;
 }

--- a/Vyline/backend/src/storage/messageLog.ts
+++ b/Vyline/backend/src/storage/messageLog.ts
@@ -48,6 +48,8 @@ export interface MessageLogEntry {
 
 const streams = new Map<string, WriteStream>();
 const rotatedBytes = new Map<string, number>();
+/** 追記バイト数カウンタ（毎回 stat() するコストを避ける） */
+const writtenBytes = new Map<string, number>();
 
 function logPath(accountId: string): string {
   return join(LOG_DIR, `message-log-${accountId}.jsonl`);
@@ -62,6 +64,10 @@ function streamFor(accountId: string): WriteStream {
   mkdirSync(LOG_DIR, { recursive: true });
   const stream = createWriteStream(logPath(accountId), { flags: "a", encoding: "utf8" });
   streams.set(accountId, stream);
+  // カウンタ初期化: 既存サイズは1回だけ取得
+  stat(logPath(accountId))
+    .then((s) => writtenBytes.set(accountId, s.size))
+    .catch(() => writtenBytes.set(accountId, 0));
   stream.on("error", (err) => {
     if (streams.get(accountId) === stream) streams.delete(accountId);
     log.debug({ accountId, err }, "message log stream error");
@@ -70,14 +76,9 @@ function streamFor(accountId: string): WriteStream {
 }
 
 async function maybeRotate(accountId: string): Promise<void> {
-  const p = logPath(accountId);
-  let size = 0;
-  try {
-    size = (await stat(p)).size;
-  } catch {
-    return;
-  }
+  const size = writtenBytes.get(accountId) ?? 0;
   if (size < ROTATE_BYTES) return;
+  const p = logPath(accountId);
   const last = rotatedBytes.get(accountId);
   if (last != null && size - last < ROTATE_BYTES) return; // 直前ローテ直後
   rotatedBytes.set(accountId, size);
@@ -85,6 +86,7 @@ async function maybeRotate(accountId: string): Promise<void> {
     const s = streams.get(accountId);
     s?.end();
     streams.delete(accountId);
+    writtenBytes.set(accountId, 0);
     const prev = `${p}.2`;
     if (existsSync(prev))
       await import("node:fs/promises").then(({ unlink }) => unlink(prev)).catch(() => undefined);
@@ -99,7 +101,10 @@ async function maybeRotate(accountId: string): Promise<void> {
 export function appendMessageLog(entry: MessageLogEntry): void {
   try {
     const s = streamFor(entry.accountId);
-    s.write(`${JSON.stringify(entry)}\n`);
+    const line = `${JSON.stringify(entry)}\n`;
+    s.write(line);
+    // stat() の代わりに書き込みバイト数で追跡
+    writtenBytes.set(entry.accountId, (writtenBytes.get(entry.accountId) ?? 0) + line.length);
     void maybeRotate(entry.accountId).catch(() => undefined);
   } catch (err) {
     log.debug({ err }, "message log append failed");

--- a/Vyline/backend/src/storage/tokenStore.ts
+++ b/Vyline/backend/src/storage/tokenStore.ts
@@ -39,6 +39,13 @@ export interface TokenEntry {
   displayName?: string;
   picturePath?: string;
   statusMessage?: string;
+  premium?: {
+    active: boolean;
+    planType?: string | number;
+    validUntil?: number;
+    onFreeTrial?: boolean;
+    willExpire?: boolean;
+  };
 }
 
 export type TokenMap = Record<string, TokenEntry>;
@@ -48,6 +55,13 @@ export type SessionMeta = {
   displayName?: string;
   picturePath?: string;
   statusMessage?: string;
+  premium?: {
+    active: boolean;
+    planType?: string | number;
+    validUntil?: number;
+    onFreeTrial?: boolean;
+    willExpire?: boolean;
+  };
 };
 
 async function ensureDataDir(): Promise<void> {
@@ -113,10 +127,12 @@ export async function saveToken(
   const displayName = meta?.displayName ?? existing?.displayName;
   const picturePath = meta?.picturePath ?? existing?.picturePath;
   const statusMessage = meta?.statusMessage ?? existing?.statusMessage;
+  const premium = meta?.premium ?? existing?.premium;
   if (mid) entry.mid = mid;
   if (displayName) entry.displayName = displayName;
   if (picturePath) entry.picturePath = picturePath;
   if (statusMessage) entry.statusMessage = statusMessage;
+  if (premium) entry.premium = premium;
   tokens[accountId] = entry;
 
   await writeFile(TOKENS_FILE, JSON.stringify(tokens, null, 2), "utf-8");
@@ -131,6 +147,7 @@ export async function updateSessionMeta(accountId: string, meta: SessionMeta): P
   if (meta.displayName != null) existing.displayName = meta.displayName;
   if (meta.picturePath != null) existing.picturePath = meta.picturePath;
   if (meta.statusMessage != null) existing.statusMessage = meta.statusMessage;
+  if (meta.premium != null) existing.premium = meta.premium;
   existing.savedAt = new Date().toISOString();
   tokens[accountId] = existing;
   await writeFile(TOKENS_FILE, JSON.stringify(tokens, null, 2), "utf-8");
@@ -170,6 +187,7 @@ export async function listSavedSessions(): Promise<
         displayName?: string;
         picturePath?: string;
         statusMessage?: string;
+        premium?: TokenEntry["premium"];
         hasToken: boolean;
       } = {
         accountId,
@@ -180,6 +198,7 @@ export async function listSavedSessions(): Promise<
       if (entry.displayName) row.displayName = entry.displayName;
       if (entry.picturePath) row.picturePath = entry.picturePath;
       if (entry.statusMessage) row.statusMessage = entry.statusMessage;
+      if (entry.premium) row.premium = entry.premium;
       return row;
     })
     .sort((a, b) => (a.savedAt < b.savedAt ? 1 : -1));

--- a/Vyline/backend/src/storage/vylineStorageInfo.ts
+++ b/Vyline/backend/src/storage/vylineStorageInfo.ts
@@ -1,0 +1,112 @@
+/**
+ * storage/vylineStorageInfo.ts
+ *
+ * Vyline のストレージ使用量とディスク情報を集計する。
+ */
+
+import { existsSync } from "node:fs";
+import { mkdir, readdir, stat } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { childLogger } from "../logger.js";
+
+const log = childLogger("vyline-storage");
+const _dir = dirname(fileURLToPath(import.meta.url));
+
+async function streamToText(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value) chunks.push(value);
+  }
+  return Buffer.concat(chunks).toString("utf-8");
+}
+
+export const VYLINE_DATA_DIR = process.env.VYLINE_DATA_DIR ?? join(_dir, "..", "..", "data");
+export const VYLINE_STORAGE_DIR =
+  process.env.VYLINE_STORAGE_DIR ?? join(_dir, "..", "..", "storage");
+export const VYLINE_CACHE_DIR = join(VYLINE_STORAGE_DIR, "cache");
+export const VYLINE_SAVED_MEDIA_DIR = join(VYLINE_STORAGE_DIR, "saved-media");
+
+const CDN_CACHE_DIR = join(VYLINE_CACHE_DIR, "cdn-cache");
+const LEGACY_CDN_CACHE_DIR = join(VYLINE_DATA_DIR, "cdn-cache");
+const LEGACY_MEDIA_CACHE_DIR = join(VYLINE_DATA_DIR, "media-cache");
+
+async function dirSize(target: string): Promise<number> {
+  if (!existsSync(target)) return 0;
+  let total = 0;
+  try {
+    const entries = await readdir(target, { withFileTypes: true });
+    for (const e of entries) {
+      const p = join(target, e.name);
+      if (e.isDirectory()) {
+        total += await dirSize(p);
+      } else {
+        try {
+          const s = await stat(p);
+          total += s.size;
+        } catch {
+          /* ignore */
+        }
+      }
+    }
+  } catch (err) {
+    log.debug({ err, target }, "dirSize failed");
+  }
+  return total;
+}
+
+function extractDriveLetter(path: string): string {
+  const m = /^([a-zA-Z]:)/.exec(path);
+  return m?.[1]?.toUpperCase() ?? "";
+}
+
+async function getDiskInfo(
+  driveLetter: string,
+): Promise<{ totalBytes: number; freeBytes: number; usedBytes: number } | null> {
+  try {
+    if (!driveLetter) return null;
+    const name = driveLetter.replace(":", "");
+    const ps = `[pscustomobject]@{ Total = (Get-PSDrive ${name}).Used + (Get-PSDrive ${name}).Free; Free = (Get-PSDrive ${name}).Free; Used = (Get-PSDrive ${name}).Used } | ConvertTo-Json`;
+    const proc = Bun.spawn(["powershell", "-NoProfile", "-Command", ps], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [code, stdout, stderr] = await Promise.all([
+      proc.exited,
+      streamToText(proc.stdout),
+      streamToText(proc.stderr),
+    ]);
+    if (typeof code === "number" && code === 0 && stdout.trim()) {
+      const data = JSON.parse(stdout.trim());
+      if (data && typeof data.Total === "number") {
+        return { totalBytes: data.Total, freeBytes: data.Free, usedBytes: data.Used };
+      }
+    }
+  } catch {
+    /* ignore */
+  }
+  return null;
+}
+
+export async function getVylineStorageInfo() {
+  const driveLetter = extractDriveLetter(VYLINE_STORAGE_DIR);
+  const [cacheSize, savedMediaSize] = await Promise.all([
+    dirSize(VYLINE_CACHE_DIR),
+    dirSize(VYLINE_SAVED_MEDIA_DIR),
+  ]);
+
+  const vylineTotal = cacheSize + savedMediaSize;
+  const disk = await getDiskInfo(driveLetter);
+
+  return {
+    ok: true,
+    driveLetter,
+    disk,
+    vylineTotal,
+    cacheSize,
+    savedMediaSize,
+  };
+}

--- a/Vyline/backend/src/storage/vylineStorageInfo.ts
+++ b/Vyline/backend/src/storage/vylineStorageInfo.ts
@@ -31,8 +31,16 @@ export const VYLINE_CACHE_DIR = join(VYLINE_STORAGE_DIR, "cache");
 export const VYLINE_SAVED_MEDIA_DIR = join(VYLINE_STORAGE_DIR, "saved-media");
 
 const CDN_CACHE_DIR = join(VYLINE_CACHE_DIR, "cdn-cache");
+const ICON_CACHE_DIR = join(VYLINE_CACHE_DIR, "icons");
 const LEGACY_CDN_CACHE_DIR = join(VYLINE_DATA_DIR, "cdn-cache");
 const LEGACY_MEDIA_CACHE_DIR = join(VYLINE_DATA_DIR, "media-cache");
+
+const MEDIA_TYPE_DIRS = {
+  image: join(VYLINE_SAVED_MEDIA_DIR, "images"),
+  video: join(VYLINE_SAVED_MEDIA_DIR, "videos"),
+  audio: join(VYLINE_SAVED_MEDIA_DIR, "audio"),
+  file: join(VYLINE_SAVED_MEDIA_DIR, "files"),
+} as const;
 
 async function dirSize(target: string): Promise<number> {
   if (!existsSync(target)) return 0;
@@ -93,11 +101,18 @@ async function getDiskInfo(
 
 export async function getVylineStorageInfo() {
   const driveLetter = extractDriveLetter(VYLINE_STORAGE_DIR);
-  const [cacheSize, savedMediaSize] = await Promise.all([
-    dirSize(VYLINE_CACHE_DIR),
-    dirSize(VYLINE_SAVED_MEDIA_DIR),
-  ]);
+  const [cdnCacheSize, iconCacheSize, imagesSize, videosSize, audioSize, filesSize] =
+    await Promise.all([
+      dirSize(CDN_CACHE_DIR),
+      dirSize(ICON_CACHE_DIR),
+      dirSize(MEDIA_TYPE_DIRS.image),
+      dirSize(MEDIA_TYPE_DIRS.video),
+      dirSize(MEDIA_TYPE_DIRS.audio),
+      dirSize(MEDIA_TYPE_DIRS.file),
+    ]);
 
+  const cacheSize = cdnCacheSize + iconCacheSize;
+  const savedMediaSize = imagesSize + videosSize + audioSize + filesSize;
   const vylineTotal = cacheSize + savedMediaSize;
   const disk = await getDiskInfo(driveLetter);
 
@@ -108,5 +123,15 @@ export async function getVylineStorageInfo() {
     vylineTotal,
     cacheSize,
     savedMediaSize,
+    cache: {
+      cdn: cdnCacheSize,
+      icons: iconCacheSize,
+    },
+    savedMedia: {
+      image: imagesSize,
+      video: videosSize,
+      audio: audioSize,
+      file: filesSize,
+    },
   };
 }

--- a/Vyline/packages/line-types/line_types.ts
+++ b/Vyline/packages/line-types/line_types.ts
@@ -16791,11 +16791,11 @@ export interface createCollectionForUser_result {
 }
 
 export interface createCombinationSticker_args {
-  request: any;
+  request: CreateCombinationStickerRequest;
 }
 
 export interface createCombinationSticker_result {
-  success: any;
+  success: CreateCombinationStickerResponse;
   e: ShopException;
 }
 

--- a/Vyline/packages/line-types/thrift.ts
+++ b/Vyline/packages/line-types/thrift.ts
@@ -29748,14 +29748,14 @@ export const Thrift: LooseType = {
     {
       fid: 2,
       name: "request",
-      struct: "YN0_Ob1_C",
+      struct: "CreateCombinationStickerRequest",
     },
   ],
   createCombinationSticker_result: [
     {
       fid: 0,
       name: "success",
-      struct: "YN0_Ob1_D",
+      struct: "CreateCombinationStickerResponse",
     },
     {
       fid: 1,

--- a/Vyline/packages/protocol/package.json
+++ b/Vyline/packages/protocol/package.json
@@ -9,6 +9,10 @@
       "types": "./stack/_dist/client/mod.d.ts",
       "default": "./stack/client/mod.ts"
     },
+    "./stack/assert": {
+      "types": "./stack/assert.ts",
+      "default": "./stack/assert.ts"
+    },
     "./stack/base": {
       "types": "./stack/_dist/base/mod.d.ts",
       "default": "./stack/base/mod.ts"

--- a/Vyline/packages/protocol/src/client/VylineClient.ts
+++ b/Vyline/packages/protocol/src/client/VylineClient.ts
@@ -84,7 +84,10 @@ async function finalizeLogin(
   if (isDesktopEmulation(mode)) {
     patchDesktopTransport(base, profile);
   }
-  const e2ee = await ensureValidE2EEIdentity(base, { desktopKeysPath });
+  const e2ee = await ensureValidE2EEIdentity(
+    base,
+    desktopKeysPath ? { desktopKeysPath } : {},
+  );
   base.log("vyline:e2ee", { phase: "ensure-after-login", mode, ...e2ee });
   return new Client(base);
 }

--- a/Vyline/packages/protocol/src/client/VylineClient.ts
+++ b/Vyline/packages/protocol/src/client/VylineClient.ts
@@ -29,6 +29,7 @@ export interface VylineLoginInit {
   storagePath: string;
   /** 省略時は VYLINE_DEVICE / ANDROIDSECONDARY */
   deviceMode?: VylineDeviceMode | string;
+  desktopKeysPath?: string;
 }
 
 export function applyDesktopHeaders(client: Client, profile: DesktopProfile): void {
@@ -77,12 +78,13 @@ async function finalizeLogin(
   base: BaseClient,
   profile: DesktopProfile,
   mode: VylineDeviceMode,
+  desktopKeysPath?: string,
 ): Promise<VylineClient> {
   await base.loginProcess.ready();
   if (isDesktopEmulation(mode)) {
     patchDesktopTransport(base, profile);
   }
-  const e2ee = await ensureValidE2EEIdentity(base);
+  const e2ee = await ensureValidE2EEIdentity(base, { desktopKeysPath });
   base.log("vyline:e2ee", { phase: "ensure-after-login", mode, ...e2ee });
   return new Client(base);
 }
@@ -106,7 +108,7 @@ export async function loginWithEmail(
     password: opts.password,
     ...(opts.pincode !== undefined ? { pincode: opts.pincode } : {}),
   });
-  return finalizeLogin(base, init.profile, mode);
+  return finalizeLogin(base, init.profile, mode, init.desktopKeysPath);
 }
 
 export async function loginWithQR(
@@ -123,7 +125,7 @@ export async function loginWithQR(
     patchDesktopTransport(base, init.profile);
   }
   await base.loginProcess.withQrCode({});
-  return finalizeLogin(base, init.profile, mode);
+  return finalizeLogin(base, init.profile, mode, init.desktopKeysPath);
 }
 
 export async function loginWithToken(
@@ -135,7 +137,7 @@ export async function loginWithToken(
     patchDesktopTransport(base, init.profile);
   }
   await base.loginProcess.login({ authToken });
-  return finalizeLogin(base, init.profile, mode);
+  return finalizeLogin(base, init.profile, mode, init.desktopKeysPath);
 }
 
 export async function sendText(

--- a/Vyline/packages/protocol/src/client/VylineClient.ts
+++ b/Vyline/packages/protocol/src/client/VylineClient.ts
@@ -84,10 +84,7 @@ async function finalizeLogin(
   if (isDesktopEmulation(mode)) {
     patchDesktopTransport(base, profile);
   }
-  const e2ee = await ensureValidE2EEIdentity(
-    base,
-    desktopKeysPath ? { desktopKeysPath } : {},
-  );
+  const e2ee = await ensureValidE2EEIdentity(base, desktopKeysPath ? { desktopKeysPath } : {});
   base.log("vyline:e2ee", { phase: "ensure-after-login", mode, ...e2ee });
   return new Client(base);
 }

--- a/Vyline/packages/protocol/src/domain/profile.ts
+++ b/Vyline/packages/protocol/src/domain/profile.ts
@@ -10,7 +10,6 @@ import type { ProfileUpdateInput } from "./types.js";
 import {
   getMyExtendedProfile,
   getMyProfile,
-  updateMyBirthday,
   updateMyProfile,
   uploadMyProfileBackground,
   uploadMyProfileImage,
@@ -42,11 +41,10 @@ export class ProfileDomain {
     }
     if (input.hiddenFromList !== undefined) update.hiddenFromList = input.hiddenFromList;
     const hasAttrs = Object.keys(update).length > 0;
-    if (!hasAttrs && !input.birthday) {
+    if (!hasAttrs) {
       throw new Error("ProfileDomain.update: empty update");
     }
     if (hasAttrs) await updateMyProfile(this.client, update);
-    if (input.birthday) await updateMyBirthday(this.client, input.birthday);
   }
 
   async uploadAvatar(data: Blob) {

--- a/Vyline/packages/protocol/src/domain/types.ts
+++ b/Vyline/packages/protocol/src/domain/types.ts
@@ -12,14 +12,6 @@ export interface ProfileUpdateInput {
   allowSearchByUserid?: boolean;
   allowSearchByEmail?: boolean;
   hiddenFromList?: boolean;
-  birthday?: {
-    year?: string;
-    day: string;
-    yearEnabled?: boolean;
-    dayEnabled?: boolean;
-    yearPrivacy?: "PUBLIC" | "PRIVATE";
-    dayPrivacy?: "PUBLIC" | "PRIVATE";
-  };
 }
 
 export type ChatUpdateAttribute = "NAME" | "PICTURE_STATUS";

--- a/Vyline/packages/protocol/src/login/ensureE2EE.ts
+++ b/Vyline/packages/protocol/src/login/ensureE2EE.ts
@@ -53,13 +53,15 @@ export interface E2EEIdentityStatus {
   matchedKeyIds: number[];
   serverLatestKeyId: number | null;
   reason: string;
+  desktopKeysPath?: string;
 }
 
-function resolveDesktopKeysPath(): string {
+function resolveDesktopKeysPath(desktopKeysPath?: string): string {
+  if (desktopKeysPath) return desktopKeysPath;
   const candidates = [
     join(process.cwd(), "Vyline", "backend", "data", "desktop-e2ee-keys.json"),
     join(process.cwd(), "data", "desktop-e2ee-keys.json"),
-    defaultDesktopE2EEKeysPath(join(process.cwd(), "data")),
+    defaultDesktopE2EEKeysPath(),
   ];
   for (const p of candidates) {
     if (loadDesktopE2EEKeyDump(p)) return p;
@@ -100,6 +102,7 @@ export async function ensureValidE2EEIdentity(
     forceNewSenderKey?: boolean;
     /** true のときだけ、サーバ最新の秘密鍵が無い場合に新規登録する。既定 false */
     allowRegisterNewKey?: boolean;
+    desktopKeysPath?: string;
   } = {},
 ): Promise<E2EEIdentityStatus> {
   const base = asBase(client);
@@ -120,7 +123,7 @@ export async function ensureValidE2EEIdentity(
   }
 
   let imported = 0;
-  const dumpPath = resolveDesktopKeysPath();
+  const dumpPath = resolveDesktopKeysPath(opts.desktopKeysPath);
   const dump = loadDesktopE2EEKeyDump(dumpPath);
   if (dump) {
     const result = await importDesktopE2EEKeys(base, dump);
@@ -211,6 +214,7 @@ export async function ensureValidE2EEIdentity(
         keyId: fresh.keyId,
         matchedKeyIds: [...matchedKeyIds, fresh.keyId],
         serverLatestKeyId: fresh.keyId,
+        desktopKeysPath: opts.desktopKeysPath,
         reason: opts.forceNewSenderKey
           ? `registered fresh sender key ${fresh.keyId} (forced)`
           : `registered fresh sender key ${fresh.keyId} (server latest ${serverLatestKeyId} had no local priv)`,
@@ -229,6 +233,7 @@ export async function ensureValidE2EEIdentity(
           keyId: latest.keyId,
           matchedKeyIds,
           serverLatestKeyId,
+          desktopKeysPath: opts.desktopKeysPath,
           reason: `failed to register fresh sender key; fell back to ${latest.keyId}`,
         };
       }
@@ -238,6 +243,7 @@ export async function ensureValidE2EEIdentity(
         keyId: null,
         matchedKeyIds,
         serverLatestKeyId,
+        desktopKeysPath: opts.desktopKeysPath,
         reason: "failed to repair E2EE identity",
       };
     }
@@ -262,6 +268,7 @@ export async function ensureValidE2EEIdentity(
         keyId: latest.keyId,
         matchedKeyIds,
         serverLatestKeyId,
+        desktopKeysPath: opts.desktopKeysPath,
         reason: `no local priv for server latest ${serverLatestKeyId}; using matched ${latest.keyId} (no new register — protects phone Letter Sealing)`,
       };
     }
@@ -271,6 +278,7 @@ export async function ensureValidE2EEIdentity(
       keyId: null,
       matchedKeyIds,
       serverLatestKeyId,
+      desktopKeysPath: opts.desktopKeysPath,
       reason:
         "no matched local keys; refusing to auto-register (set allowRegisterNewKey to override)",
     };
@@ -292,6 +300,7 @@ export async function ensureValidE2EEIdentity(
     keyId: sender.keyId,
     matchedKeyIds,
     serverLatestKeyId,
+    desktopKeysPath: opts.desktopKeysPath,
     reason:
       imported > 0
         ? `imported ${imported} desktop keys; sender=${sender.keyId}`

--- a/Vyline/packages/protocol/src/login/ensureE2EE.ts
+++ b/Vyline/packages/protocol/src/login/ensureE2EE.ts
@@ -53,7 +53,7 @@ export interface E2EEIdentityStatus {
   matchedKeyIds: number[];
   serverLatestKeyId: number | null;
   reason: string;
-  desktopKeysPath?: string;
+  desktopKeysPath?: string | undefined;
 }
 
 function resolveDesktopKeysPath(desktopKeysPath?: string): string {
@@ -102,7 +102,7 @@ export async function ensureValidE2EEIdentity(
     forceNewSenderKey?: boolean;
     /** true のときだけ、サーバ最新の秘密鍵が無い場合に新規登録する。既定 false */
     allowRegisterNewKey?: boolean;
-    desktopKeysPath?: string;
+    desktopKeysPath?: string | undefined;
   } = {},
 ): Promise<E2EEIdentityStatus> {
   const base = asBase(client);

--- a/Vyline/packages/protocol/src/login/importDesktopE2EE.ts
+++ b/Vyline/packages/protocol/src/login/importDesktopE2EE.ts
@@ -30,7 +30,7 @@ function asBase(client: AnyClient): BaseClient {
 
 /** 既定の抽出ファイルパス */
 export function defaultDesktopE2EEKeysPath(dataDir?: string): string {
-  const dir = dataDir ?? join(process.cwd(), "data");
+  const dir = dataDir ?? (process.env.VYLINE_DATA_DIR ?? join(process.cwd(), "data"));
   return join(dir, "desktop-e2ee-keys.json");
 }
 

--- a/Vyline/packages/protocol/src/login/importDesktopE2EE.ts
+++ b/Vyline/packages/protocol/src/login/importDesktopE2EE.ts
@@ -30,7 +30,7 @@ function asBase(client: AnyClient): BaseClient {
 
 /** 既定の抽出ファイルパス */
 export function defaultDesktopE2EEKeysPath(dataDir?: string): string {
-  const dir = dataDir ?? (process.env.VYLINE_DATA_DIR ?? join(process.cwd(), "data"));
+  const dir = dataDir ?? process.env.VYLINE_DATA_DIR ?? join(process.cwd(), "data");
   return join(dir, "desktop-e2ee-keys.json");
 }
 

--- a/Vyline/packages/protocol/src/obs/download.ts
+++ b/Vyline/packages/protocol/src/obs/download.ts
@@ -14,7 +14,7 @@ export function obsMessageDataUrl(
   messageId: string,
   isPreview = false,
   square = false,
-  prefix = "https://obs.line-apps.com/",
+  prefix = process.env.VYLINE_OBS_PREFIX ?? "https://obs-jp.line-apps.com/",
 ): string {
   return `${prefix}r/${square ? "g2" : "talk"}/m/${encodeURIComponent(messageId)}${
     isPreview ? "/preview" : ""

--- a/Vyline/packages/protocol/src/protocol/profileOps.ts
+++ b/Vyline/packages/protocol/src/protocol/profileOps.ts
@@ -29,21 +29,6 @@ export interface MyProfileUpdate {
   hiddenFromList?: boolean;
 }
 
-/** ExtendedProfile.birthday — Desktop: TalkService_updateExtendedProfileAttribute */
-export interface MyBirthdayUpdate {
-  /** "YYYY" — 空で年非表示 */
-  year?: string;
-  /** "MMDD" */
-  day: string;
-  yearEnabled?: boolean;
-  dayEnabled?: boolean;
-  yearPrivacy?: "PUBLIC" | "PRIVATE";
-  dayPrivacy?: "PUBLIC" | "PRIVATE";
-}
-
-/** ExtendedProfileAttribute.BIRTHDAY（Thrift: attr i32、誕生日のみ） */
-const EXTENDED_PROFILE_ATTR_BIRTHDAY = 0;
-
 function bool(v: boolean): string {
   return v ? "true" : "false";
 }
@@ -85,28 +70,6 @@ export async function updateMyProfile(client: Client, update: MyProfileUpdate): 
 
 export async function getMyExtendedProfile(client: Client) {
   return client.base.talk.getExtendedProfile({ syncReason: "INTERNAL" });
-}
-
-export async function updateMyBirthday(client: Client, birthday: MyBirthdayUpdate): Promise<void> {
-  const day = birthday.day.replace(/[^0-9]/g, "").slice(0, 4);
-  if (day.length !== 4) {
-    throw new Error("birthday.day must be MMDD");
-  }
-  const year = (birthday.year ?? "").replace(/[^0-9]/g, "").slice(0, 4);
-  await client.base.talk.updateExtendedProfileAttribute({
-    reqSeq: await client.base.getReqseq(),
-    attr: EXTENDED_PROFILE_ATTR_BIRTHDAY,
-    extendedProfile: {
-      birthday: {
-        year,
-        day,
-        yearEnabled: birthday.yearEnabled ?? Boolean(year),
-        dayEnabled: birthday.dayEnabled ?? true,
-        yearPrivacyLevelType: birthday.yearPrivacy ?? "PRIVATE",
-        dayPrivacyLevelType: birthday.dayPrivacy ?? "PUBLIC",
-      },
-    },
-  });
 }
 
 export async function uploadMyProfileImage(

--- a/Vyline/packages/protocol/src/tools/extractDesktopE2EEKeys.ts
+++ b/Vyline/packages/protocol/src/tools/extractDesktopE2EEKeys.ts
@@ -7,7 +7,7 @@
  * 手順:
  * 1. "privateKey" ASCII をメモリ走査し近傍を dump
  * 2. keyId / publicKey / privateKey をパース
- * 3. Curve25519 でペア検証 → desktop-e2ee-keys.json に保存
+ * 3. Curve25519 でペア検証 → desktop-e2ee-keys-{accountId}.json に保存
  *
  * 実行: bun Vyline/packages/protocol/src/tools/extractDesktopE2EEKeys.ts
  */
@@ -23,8 +23,6 @@ import type { DesktopE2EEKey, DesktopE2EEKeyDump } from "../login/importDesktopE
 
 const REPO = join(dirname(fileURLToPath(import.meta.url)), "../../../../..");
 const DATA = join(REPO, "Vyline", "backend", "data");
-const OUT = join(DATA, "desktop-e2ee-keys.json");
-const RAW_OUT = join(DATA, "e2ee-selfchain-raw.txt");
 
 function verifyPair(privB64: string, pubB64: string): boolean {
   try {
@@ -38,19 +36,19 @@ function verifyPair(privB64: string, pubB64: string): boolean {
 }
 
 /** PowerShell: "privateKey" ヒット近傍の ASCII 窓を dump */
-function dumpPrivateKeyWindows(): string {
+function dumpPrivateKeyWindows(rawOut: string): string {
   const ps1 = join(dirname(fileURLToPath(import.meta.url)), "scanLinePrivateKeyWindows.ps1");
   const r = spawnSync(
     "powershell.exe",
-    ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", ps1, "-OutFile", RAW_OUT],
+    ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", ps1, "-OutFile", rawOut],
     { encoding: "utf-8", maxBuffer: 64 * 1024 * 1024, timeout: 180_000 },
   );
   if (r.error) throw r.error;
   if (r.status !== 0) {
     throw new Error(`scan failed: ${r.stderr || r.stdout}`);
   }
-  if (!existsSync(RAW_OUT)) return "";
-  return readFileSync(RAW_OUT, "utf8");
+  if (!existsSync(rawOut)) return "";
+  return readFileSync(rawOut, "utf8");
 }
 
 function parseKeys(raw: string): Map<number, DesktopE2EEKey> {
@@ -81,13 +79,55 @@ function parseKeys(raw: string): Map<number, DesktopE2EEKey> {
 async function main(): Promise<void> {
   const tokensPath = join(DATA, "tokens.json");
   if (!existsSync(tokensPath)) throw new Error(`missing ${tokensPath}`);
-  const tokens = JSON.parse(readFileSync(tokensPath, "utf8")) as {
-    main?: { authToken: string };
-  };
-  if (!tokens.main?.authToken) throw new Error("no main authToken");
+  const tokens = JSON.parse(readFileSync(tokensPath, "utf8")) as Record<
+    string,
+    {
+      authToken?: string;
+      storageFile?: string;
+    }
+  >;
+
+  const accountArgIndex = process.argv.indexOf("--account");
+  const requestedAccount = accountArgIndex >= 0 ? process.argv[accountArgIndex + 1] : undefined;
+
+  if (accountArgIndex >= 0 && !requestedAccount) {
+    throw new Error("--account requires an account ID");
+  }
+
+  const availableAccounts = Object.entries(tokens).filter(
+    ([, entry]) => typeof entry?.authToken === "string" && entry.authToken.length > 0,
+  );
+
+  let selected: [string, { authToken?: string; storageFile?: string }] | undefined;
+
+  if (requestedAccount) {
+    selected = availableAccounts.find(([accountId]) => accountId === requestedAccount);
+
+    if (!selected) {
+      throw new Error(
+        `account "${requestedAccount}" not found. available: ${availableAccounts
+          .map(([accountId]) => accountId)
+          .join(", ")}`,
+      );
+    }
+  } else {
+    selected =
+      availableAccounts.find(([accountId]) => accountId === "main") ?? availableAccounts[0];
+  }
+
+  if (!selected) throw new Error("no authToken");
+
+  const [accountId, tokenEntry] = selected;
+  const authToken = tokenEntry.authToken!;
+
+  const OUT = join(DATA, `desktop-e2ee-keys-${accountId}.json`);
+  const RAW_OUT = join(DATA, `e2ee-selfchain-raw-${accountId}.txt`);
+
+  console.log(`[extract] using account: ${accountId}`);
+  console.log(`[extract] output: ${OUT}`);
 
   console.log("[extract] scanning LINE.exe for privateKey windows...");
-  const raw = dumpPrivateKeyWindows();
+  const raw = dumpPrivateKeyWindows(RAW_OUT);
   if (!raw || raw.includes("NO_PROCESS") || raw.includes("OPENFAIL")) {
     throw new Error("LINE.exe not readable — open official LINE Desktop and retry");
   }
@@ -99,9 +139,10 @@ async function main(): Promise<void> {
   );
 
   const profile = loadCachedOrFallback(join(DATA, "vyline"));
-  const client = await loginWithToken(tokens.main.authToken, {
+  const client = await loginWithToken(authToken, {
     profile,
-    storagePath: join(DATA, "storage-main.json"),
+    storagePath: tokenEntry.storageFile ?? join(DATA, `storage-${accountId}.json`),
+    desktopKeysPath: OUT,
   });
   await client.base.talk.getProfile();
   const mid = client.base.profile?.mid;

--- a/Vyline/packages/protocol/stack/_dist/base/core/mod.d.ts
+++ b/Vyline/packages/protocol/stack/_dist/base/core/mod.d.ts
@@ -6,7 +6,7 @@ import { InternalError } from "./utils/error.js";
 import { type Continuable, continueRequest } from "./utils/continue.js";
 export type { Continuable, Device, DeviceDetails, Log };
 export { continueRequest, InternalError };
-import { AuthService, CallService, ChannelService, LiffService, RelationService, SquareLiveTalkService, SquareService, TalkService } from "../service/mod.js";
+import { AuthService, CallService, ChannelService, LiffService, RelationService, ShopService, SquareLiveTalkService, SquareService, TalkService } from "../service/mod.js";
 import { Login } from "../login/mod.js";
 import { Thrift } from "../thrift/mod.js";
 import { RequestClient } from "../request/mod.js";
@@ -98,6 +98,7 @@ export declare class BaseClient extends TypedEventEmitter<ClientEvents> {
     readonly channel: ChannelService;
     readonly liff: LiffService;
     readonly relation: RelationService;
+    readonly shop: ShopService;
     readonly livetalk: SquareLiveTalkService;
     readonly square: SquareService;
     readonly talk: TalkService;
@@ -138,6 +139,7 @@ export declare class BaseClient extends TypedEventEmitter<ClientEvents> {
     getToType(mid: string): number | null;
     reqseqs?: Record<string, number>;
     getReqseq(name?: string): Promise<number>;
+    getReqseqs(name?: string, count?: number): Promise<number[]>;
     readonly fetch: Fetch;
     /**
      * returns polling client.

--- a/Vyline/packages/protocol/stack/_dist/base/obs/mod.d.ts
+++ b/Vyline/packages/protocol/stack/_dist/base/obs/mod.d.ts
@@ -72,11 +72,21 @@ export declare class LineObs {
     /**
      * @description Upload obs message to talk.
      */
-    uploadObjTalk(to: string, type: ObjType, data: Blob, oid?: string, filename?: string, durationMs?: number): Promise<{
+    uploadObjTalk(to: string, type: ObjType, data: Blob, oid?: string, filename?: string, durationMs?: number, reqseqOverride?: number): Promise<{
         objId: string;
         objHash: string;
         headers: Headers;
     }>;
+    uploadObjTalkBatch(to: string, items: Array<{
+        type: ObjType;
+        data: Blob;
+        filename?: string;
+        durationMs?: number;
+    }>): Promise<Array<{
+        objId: string;
+        objHash: string;
+        headers: Headers;
+    }>>;
     uploadObjectForService(options: {
         data: Blob;
         oType?: ObjType;
@@ -101,6 +111,17 @@ export declare class LineObs {
         filename?: string;
         /** Optional thumbnail; encrypted with the same keyMaterial. #103. */
         preview?: Blob;
+        relatedMessageId?: string;
+        messageRelationType?: "FORWARD" | "AUTO_REPLY" | "SUBORDINATE" | "REPLY";
+    }): Promise<Message>;
+    uploadObjTalkMessage(options: {
+        to: string;
+        type: ObjType;
+        data: Blob;
+        filename?: string;
+        durationMs?: number;
+        relatedMessageId?: string;
+        messageRelationType?: "FORWARD" | "AUTO_REPLY" | "SUBORDINATE" | "REPLY";
     }): Promise<Message>;
     downloadMediaByE2EE(message: Message): Promise<File | null>;
 }

--- a/Vyline/packages/protocol/stack/_dist/base/service/shop/mod.d.ts
+++ b/Vyline/packages/protocol/stack/_dist/base/service/shop/mod.d.ts
@@ -32,7 +32,9 @@ export declare class ShopService implements BaseService {
     getCoinUseAndRefundHistory(...param: Parameters<typeof LINEStruct.getCoinUseAndRefundHistory_args>): Promise<LINETypes.getCoinUseAndRefundHistory_result["success"]>;
     getCoinProducts(...param: Parameters<typeof LINEStruct.getCoinProducts_args>): Promise<LINETypes.getCoinProducts_result["success"]>;
     getCoinPurchaseHistory(...param: Parameters<typeof LINEStruct.getCoinPurchaseHistory_args>): Promise<LINETypes.getCoinPurchaseHistory_result["success"]>;
+    canCreateCombinationSticker(...param: Parameters<typeof LINEStruct.canCreateCombinationSticker_args>): Promise<LINETypes.canCreateCombinationSticker_result["success"]>;
     createCombinationSticker(...param: Parameters<typeof LINEStruct.createCombinationSticker_args>): Promise<LINETypes.createCombinationSticker_result["success"]>;
+    isStickerAvailableForCombinationSticker(...param: Parameters<typeof LINEStruct.isStickerAvailableForCombinationSticker_args>): Promise<LINETypes.isStickerAvailableForCombinationSticker_result["success"]>;
     shouldShowWelcomeStickerBanner(...param: Parameters<typeof LINEStruct.shouldShowWelcomeStickerBanner_args>): Promise<LINETypes.shouldShowWelcomeStickerBanner_result["success"]>;
     stopBundleSubscription(...param: Parameters<typeof LINEStruct.stopBundleSubscription_args>): Promise<LINETypes.stopBundleSubscription_result["success"]>;
     getProductLatestVersionForUser(...param: Parameters<typeof LINEStruct.getProductLatestVersionForUser_args>): Promise<LINETypes.getProductLatestVersionForUser_result["success"]>;

--- a/Vyline/packages/protocol/stack/_dist/base/service/talk/mod.d.ts
+++ b/Vyline/packages/protocol/stack/_dist/base/service/talk/mod.d.ts
@@ -52,6 +52,7 @@ export declare class TalkService implements BaseService {
         contentType?: LINETypes.ContentType;
         contentMetadata?: Record<string, string>;
         relatedMessageId?: string;
+        messageRelationType?: "FORWARD" | "AUTO_REPLY" | "SUBORDINATE" | "REPLY";
         location?: LINETypes.Location;
         chunks?: string[] | Buffer[];
         e2ee?: boolean;

--- a/Vyline/packages/protocol/stack/assert.ts
+++ b/Vyline/packages/protocol/stack/assert.ts
@@ -1,0 +1,88 @@
+import { AssertionError, strict as assertStrict } from "node:assert";
+import { inspect, isDeepStrictEqual } from "node:util";
+
+type AsyncOrSync<T> = T | Promise<T>;
+
+function normalizeMessage(message: unknown): string | undefined {
+  return typeof message === "string" && message.length > 0 ? message : undefined;
+}
+
+function formatValue(value: unknown): string {
+  return inspect(value, { depth: 5, breakLength: 120 });
+}
+
+function createAssertionError(message: string): AssertionError {
+  return new AssertionError({
+    message,
+    stackStartFn: assert,
+  });
+}
+
+export function assert(value: unknown, message?: string): asserts value {
+  assertStrict.ok(value, message);
+}
+
+export function assertEquals<T>(actual: T, expected: T, message?: string): void {
+  if (!isDeepStrictEqual(actual, expected)) {
+    throw createAssertionError(message ?? `Values are not equal.\n\nActual: ${formatValue(actual)}\nExpected: ${formatValue(expected)}`);
+  }
+}
+
+export function assertNotEquals<T>(actual: T, expected: T, message?: string): void {
+  if (isDeepStrictEqual(actual, expected)) {
+    throw createAssertionError(message ?? `Expected values to differ, but both were ${formatValue(actual)}`);
+  }
+}
+
+export function assertMatch(actual: string, expected: RegExp, message?: string): void {
+  if (!expected.test(actual)) {
+    throw createAssertionError(message ?? `Expected ${formatValue(actual)} to match ${expected}`);
+  }
+}
+
+export function assertInstanceOf<T>(value: unknown, ctor: new (...args: any[]) => T, message?: string): asserts value is T {
+  if (!(value instanceof ctor)) {
+    throw createAssertionError(message ?? `Expected value to be instance of ${ctor.name}`);
+  }
+}
+
+export function assertThrows(
+  fn: () => unknown,
+  ErrorClass?: new (...args: any[]) => Error,
+  msgIncludes?: string,
+): Error {
+  try {
+    fn();
+  } catch (error) {
+    if (ErrorClass && !(error instanceof ErrorClass)) {
+      throw createAssertionError(`Expected ${ErrorClass.name}, got ${(error as Error)?.constructor?.name ?? typeof error}`);
+    }
+    const expectedMessage = normalizeMessage(msgIncludes);
+    if (expectedMessage && !(error instanceof Error && error.message.includes(expectedMessage))) {
+      throw createAssertionError(`Expected error message to include ${expectedMessage}`);
+    }
+    return error as Error;
+  }
+  throw createAssertionError("Expected function to throw");
+}
+
+export async function assertRejects(
+  fnOrPromise: AsyncOrSync<unknown> | (() => AsyncOrSync<unknown>),
+  ErrorClass?: new (...args: any[]) => Error,
+  msgIncludes?: string,
+): Promise<Error> {
+  try {
+    const result = typeof fnOrPromise === "function" ? fnOrPromise() : fnOrPromise;
+    await result;
+  } catch (error) {
+    if (ErrorClass && !(error instanceof ErrorClass)) {
+      throw createAssertionError(`Expected ${ErrorClass.name}, got ${(error as Error)?.constructor?.name ?? typeof error}`);
+    }
+    const expectedMessage = normalizeMessage(msgIncludes);
+    if (expectedMessage && !(error instanceof Error && error.message.includes(expectedMessage))) {
+      throw createAssertionError(`Expected error message to include ${expectedMessage}`);
+    }
+    return error as Error;
+  }
+  throw createAssertionError("Expected promise to reject");
+}

--- a/Vyline/packages/protocol/stack/base/core/mod.ts
+++ b/Vyline/packages/protocol/stack/base/core/mod.ts
@@ -17,6 +17,7 @@ import {
   ChannelService,
   LiffService,
   RelationService,
+  ShopService,
   SquareLiveTalkService,
   SquareService,
   TalkService,
@@ -126,6 +127,7 @@ export class BaseClient extends TypedEventEmitter<ClientEvents> {
   readonly channel: ChannelService;
   readonly liff: LiffService;
   readonly relation: RelationService;
+  readonly shop: ShopService;
   readonly livetalk: SquareLiveTalkService;
   readonly square: SquareService;
   readonly talk: TalkService;
@@ -200,6 +202,7 @@ export class BaseClient extends TypedEventEmitter<ClientEvents> {
     this.liff = new LiffService(this);
     this.livetalk = new SquareLiveTalkService(this);
     this.relation = new RelationService(this);
+    this.shop = new ShopService(this);
     this.square = new SquareService(this);
     this.talk = new TalkService(this);
   }
@@ -222,6 +225,11 @@ export class BaseClient extends TypedEventEmitter<ClientEvents> {
   }
   reqseqs?: Record<string, number>;
   async getReqseq(name: string = "talk"): Promise<number> {
+    const [seq] = await this.getReqseqs(name, 1);
+    return seq ?? 0;
+  }
+
+  async getReqseqs(name: string = "talk", count: number = 1): Promise<number[]> {
     if (!this.reqseqs) {
       this.reqseqs = JSON.parse(((await this.storage.get("reqseq")) ?? "{}").toString()) as Record<
         string,
@@ -231,10 +239,11 @@ export class BaseClient extends TypedEventEmitter<ClientEvents> {
     if (!this.reqseqs[name]) {
       this.reqseqs[name] = 0;
     }
-    const seq = this.reqseqs[name];
-    this.reqseqs[name]++;
+    const start = this.reqseqs[name];
+    const safeCount = Math.max(0, Math.floor(count));
+    this.reqseqs[name] += safeCount;
     await this.storage.set("reqseq", JSON.stringify(this.reqseqs));
-    return seq;
+    return Array.from({ length: safeCount }, (_, index) => start + index);
   }
 
   // NOTE: use allow function.

--- a/Vyline/packages/protocol/stack/base/core/typed-event-emitter/index.test.ts
+++ b/Vyline/packages/protocol/stack/base/core/typed-event-emitter/index.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assertEquals } from "@vyline/protocol/stack/assert";
 import { TypedEventEmitter } from "./index.ts";
 
 Deno.test("promise() should be vaild", async () => {

--- a/Vyline/packages/protocol/stack/base/core/utils/devices.test.ts
+++ b/Vyline/packages/protocol/stack/base/core/utils/devices.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assertEquals } from "@vyline/protocol/stack/assert";
 import { getDeviceDetails } from "./devices.ts";
 
 Deno.test("getDeviceDetails returns current default app profiles", () => {

--- a/Vyline/packages/protocol/stack/base/e2ee/aes_gcm_siv.test.ts
+++ b/Vyline/packages/protocol/stack/base/e2ee/aes_gcm_siv.test.ts
@@ -1,6 +1,6 @@
-import { assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assertEquals } from "@vyline/protocol/stack/assert";
 import { Buffer } from "node:buffer";
-import { gcmsiv } from "npm:/@noble/ciphers@^2.2/aes.js";
+import { gcmsiv } from "@noble/ciphers/aes.js";
 
 // RFC 8452 §C.2 test vector: AES-256-GCM-SIV with non-empty AAD.
 // key=01000000…, nonce=030000000000000000000000, aad=01, plaintext=0200000000000000

--- a/Vyline/packages/protocol/stack/base/e2ee/key_selection.test.ts
+++ b/Vyline/packages/protocol/stack/base/e2ee/key_selection.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assert, assertEquals } from "@vyline/protocol/stack/assert";
 import { Buffer } from "node:buffer";
 import { E2EE } from "./mod.ts";
 

--- a/Vyline/packages/protocol/stack/base/login/mod.test.ts
+++ b/Vyline/packages/protocol/stack/base/login/mod.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assertEquals } from "@vyline/protocol/stack/assert";
 import { registrationAuthEndpoint } from "./mod.ts";
 
 Deno.test("registration auth endpoint uses v4 for Android devices", () => {

--- a/Vyline/packages/protocol/stack/base/login/respond_e2ee.test.ts
+++ b/Vyline/packages/protocol/stack/base/login/respond_e2ee.test.ts
@@ -1,5 +1,5 @@
 import { Buffer } from "node:buffer";
-import { assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assertEquals } from "@vyline/protocol/stack/assert";
 import { Login } from "./mod.ts";
 
 // Minimal stub of BaseClient.request — captures the NestedArray and

--- a/Vyline/packages/protocol/stack/base/obs/mod.ts
+++ b/Vyline/packages/protocol/stack/base/obs/mod.ts
@@ -47,7 +47,8 @@ export interface ObsMetadata {
 
 export class LineObs {
   client: BaseClient;
-  prefix = "https://obs.line-apps.com/";
+  // リージョン別エンドポイント（JP アカウントは obs-jp。アルバム(GID)付与はリージョン側で行われる）
+  prefix = process.env.VYLINE_OBS_PREFIX ?? "https://obs-jp.line-apps.com/";
   constructor(client: BaseClient) {
     this.client = client;
   }

--- a/Vyline/packages/protocol/stack/base/obs/mod.ts
+++ b/Vyline/packages/protocol/stack/base/obs/mod.ts
@@ -141,6 +141,7 @@ export class LineObs {
     oid?: string,
     filename?: string,
     durationMs?: number,
+    reqseqOverride?: number,
   ): Promise<{
     objId: string;
     objHash: string;
@@ -150,7 +151,7 @@ export class LineObs {
       throw new InternalError("Not setup yet", "Please call 'login()' first");
     }
     const ext = MimeType[data.type as keyof typeof MimeType];
-    const reqseqValue = await this.client.getReqseq("talk");
+    const reqseqValue = oid ? undefined : (reqseqOverride ?? (await this.client.getReqseq("talk")));
     const param: {
       oid: string;
       reqseq?: string;
@@ -190,6 +191,112 @@ export class LineObs {
       obsPath: `${toType}/m/${oid ?? "reqseq"}`,
       filename: param.name,
       params: param,
+    });
+  }
+
+  public async uploadObjTalkBatch(
+    to: string,
+    items: Array<{
+      type: ObjType;
+      data: Blob;
+      filename?: string;
+      durationMs?: number;
+    }>,
+  ): Promise<Array<{ objId: string; objHash: string; headers: Headers }>> {
+    if (!items.length) return [];
+    const reqseqs = await this.client.getReqseqs("talk", items.length);
+    return await Promise.all(
+      items.map((item, index) =>
+        this.uploadObjTalk(
+          to,
+          item.type,
+          item.data,
+          undefined,
+          item.filename,
+          item.durationMs,
+          reqseqs[index],
+        ),
+      ),
+    );
+  }
+
+  public async uploadObjTalkMessage(options: {
+    to: string;
+    type: ObjType;
+    data: Blob;
+    filename?: string;
+    durationMs?: number;
+    relatedMessageId?: string;
+    messageRelationType?: "FORWARD" | "AUTO_REPLY" | "SUBORDINATE" | "REPLY";
+  }): Promise<Message> {
+    const {
+      to,
+      type,
+      data,
+      filename,
+      durationMs,
+      relatedMessageId,
+      messageRelationType,
+    } = options;
+    const ext = MimeType[data.type as keyof typeof MimeType];
+    const typeSet: {
+      image: [string, 1];
+      video: [string, 2];
+      audio: [string, 3];
+      file: [string, 14];
+      gif: [string, 1];
+    } = {
+      image: ["emi", 1],
+      video: ["emv", 2],
+      audio: ["ema", 3],
+      file: ["emf", 14],
+      gif: ["emi", 1],
+    };
+    const [obsNamespace, contentType] = typeSet[type];
+    const params: Record<string, string> = { type: "file" };
+    if (type === "image" || type === "gif") {
+      params["cat"] = "original";
+    }
+    if (type === "gif") {
+      params["type"] = "image";
+    }
+    if (type === "audio" || type === "video") {
+      params["duration"] = (durationMs ?? 1919).toString();
+    }
+    const toType: "talk" | "g2" = to[0] === "m" || to[0] === "t" ? "g2" : "talk";
+    const oid = crypto.randomUUID();
+    const { objId } = await this.uploadObjectForService({
+      data,
+      oType: type,
+      obsPath: `${toType}/m/${oid}`,
+      params: {
+        ...params,
+        ver: "2.0",
+        name: filename || `vyline.${ext}`,
+      },
+    });
+
+    return await this.client.talk.sendMessage({
+      to,
+      contentType,
+      contentMetadata: {
+        SID: obsNamespace,
+        OID: objId,
+        FILE_SIZE: data.size.toString(),
+        fileName: filename || `line.${ext}`,
+        ...(type === "image" || type === "gif" || type === "video"
+          ? {
+              MEDIA_CONTENT_INFO: JSON.stringify({
+                category: "original",
+                fileSize: data.size,
+                extension: ext,
+                animated: type === "gif",
+              }),
+            }
+          : {}),
+      },
+      relatedMessageId,
+      messageRelationType: relatedMessageId ? messageRelationType : undefined,
     });
   }
 
@@ -279,8 +386,10 @@ export class LineObs {
     filename?: string;
     /** Optional thumbnail; encrypted with the same keyMaterial. #103. */
     preview?: Blob;
+    relatedMessageId?: string;
+    messageRelationType?: "FORWARD" | "AUTO_REPLY" | "SUBORDINATE" | "REPLY";
   }): Promise<Message> {
-    const { data, oType, to, filename, preview } = options;
+    const { data, oType, to, filename, preview, relatedMessageId, messageRelationType } = options;
     const typeSet: {
       image: [string, 1];
       video: [string, 2];
@@ -361,7 +470,10 @@ export class LineObs {
     } catch (e) {
       if (
         e instanceof Error &&
-        (e.name === "Not support E2EE" || e.message?.startsWith("Not support E2EE"))
+        (e.name === "Not support E2EE" ||
+          e.message?.startsWith("Not support E2EE") ||
+          e.message.includes("E2EE_RETRY_PLAIN") ||
+          e.message.includes("member settings off"))
       ) {
         e2ee = false;
         chunks = [];
@@ -379,7 +491,6 @@ export class LineObs {
         SID: obsNamespace,
         OID: objId,
         FILE_SIZE: edata.size.toString(),
-        // Desktop 準拠: メディア鍵は受信側が OBS データを復号するために必ず載せる
         keyMaterial,
         fileName: filename || `line.${ext}`,
         ...(e2ee ? { e2eeVersion: "2" } : {}),
@@ -394,6 +505,8 @@ export class LineObs {
             }
           : {}),
       },
+      relatedMessageId,
+      messageRelationType: relatedMessageId ? messageRelationType : undefined,
     });
   }
 

--- a/Vyline/packages/protocol/stack/base/obs/upload_e2ee.test.ts
+++ b/Vyline/packages/protocol/stack/base/obs/upload_e2ee.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assert, assertEquals } from "@vyline/protocol/stack/assert";
 import { Buffer } from "node:buffer";
 import { LineObs } from "./mod.ts";
 

--- a/Vyline/packages/protocol/stack/base/push/h2_fetch.test.ts
+++ b/Vyline/packages/protocol/stack/base/push/h2_fetch.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assert, assertEquals } from "@vyline/protocol/stack/assert";
 import { getH2EnabledFetchForNode } from "./h2_fetch.ts";
 
 // On Deno (which is what this test runs under), getH2EnabledFetchForNode

--- a/Vyline/packages/protocol/stack/base/request/auth_token.test.ts
+++ b/Vyline/packages/protocol/stack/base/request/auth_token.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals, assertMatch } from "jsr:@std/assert@^1.0.2";
+import { assert, assertEquals, assertMatch } from "@vyline/protocol/stack/assert";
 import {
   createPrimaryAccessToken,
   isJwt,

--- a/Vyline/packages/protocol/stack/base/request/legy.test.ts
+++ b/Vyline/packages/protocol/stack/base/request/legy.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assertEquals } from "@vyline/protocol/stack/assert";
 import { decodeLegyHeaders, encodeLegyHeaders, xxhash32 } from "./legy.ts";
 import { Buffer } from "node:buffer";
 

--- a/Vyline/packages/protocol/stack/base/service/relation/mod.test.ts
+++ b/Vyline/packages/protocol/stack/base/service/relation/mod.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assertEquals } from "@vyline/protocol/stack/assert";
 import { type NestedArray, Protocols } from "../../thrift/readwrite/declares.ts";
 import { readThrift } from "../../thrift/readwrite/read.ts";
 import { writeThrift } from "../../thrift/readwrite/write.ts";

--- a/Vyline/packages/protocol/stack/base/service/shop/mod.ts
+++ b/Vyline/packages/protocol/stack/base/service/shop/mod.ts
@@ -294,12 +294,36 @@ export class ShopService implements BaseService {
     );
   }
 
+  async canCreateCombinationSticker(
+    ...param: Parameters<typeof LINEStruct.canCreateCombinationSticker_args>
+  ): Promise<LINETypes.canCreateCombinationSticker_result["success"]> {
+    return await this.client.request.request(
+      LINEStruct.canCreateCombinationSticker_args(...param),
+      "canCreateCombinationSticker",
+      this.protocolType,
+      true,
+      this.requestPath,
+    );
+  }
+
   async createCombinationSticker(
     ...param: Parameters<typeof LINEStruct.createCombinationSticker_args>
   ): Promise<LINETypes.createCombinationSticker_result["success"]> {
     return await this.client.request.request(
       LINEStruct.createCombinationSticker_args(...param),
       "createCombinationSticker",
+      this.protocolType,
+      true,
+      this.requestPath,
+    );
+  }
+
+  async isStickerAvailableForCombinationSticker(
+    ...param: Parameters<typeof LINEStruct.isStickerAvailableForCombinationSticker_args>
+  ): Promise<LINETypes.isStickerAvailableForCombinationSticker_result["success"]> {
+    return await this.client.request.request(
+      LINEStruct.isStickerAvailableForCombinationSticker_args(...param),
+      "isStickerAvailableForCombinationSticker",
       this.protocolType,
       true,
       this.requestPath,

--- a/Vyline/packages/protocol/stack/base/service/talk/compact.test.ts
+++ b/Vyline/packages/protocol/stack/base/service/talk/compact.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertInstanceOf, assertThrows } from "jsr:@std/assert@^1.0.2";
+import { assertEquals, assertInstanceOf, assertThrows } from "@vyline/protocol/stack/assert";
 import {
   CompactMessageProtocolError,
   decodeCompactMessageResponse,

--- a/Vyline/packages/protocol/stack/base/service/talk/mod.ts
+++ b/Vyline/packages/protocol/stack/base/service/talk/mod.ts
@@ -95,17 +95,28 @@ export class TalkService implements BaseService {
     contentType?: LINETypes.ContentType;
     contentMetadata?: Record<string, string>;
     relatedMessageId?: string;
+    messageRelationType?: "FORWARD" | "AUTO_REPLY" | "SUBORDINATE" | "REPLY";
     location?: LINETypes.Location;
     chunks?: string[] | Buffer[];
     e2ee?: boolean;
   }): Promise<LINETypes.Message> {
-    const { to, text, contentType, contentMetadata, relatedMessageId, location, e2ee, chunks } = {
+    const {
+      to,
+      text,
+      contentType,
+      contentMetadata,
+      relatedMessageId,
+      messageRelationType,
+      location,
+      e2ee,
+      chunks,
+    } = {
       contentType: "NONE" as LINETypes.ContentType,
       contentMetadata: {},
       ...options,
     };
     if ((e2ee && !chunks && location) || (e2ee && !chunks && text)) {
-      const chunks = await this.client.e2ee.encryptE2EEMessage(
+      const encrypted = await this.client.e2ee.encryptE2EEMessage(
         to,
         text || location || "invalid",
         contentType,
@@ -118,15 +129,16 @@ export class TalkService implements BaseService {
           e2eeMark: "2",
         },
       };
-      const options = {
+      const next = {
         to,
         contentType,
         contentMetadata: _contentMetadata,
         relatedMessageId,
+        messageRelationType,
         e2ee,
-        chunks,
+        chunks: encrypted.chunks,
       };
-      return this.sendMessage(options);
+      return this.sendMessage(next);
     }
 
     const message = LINEStruct.sendMessage_args({
@@ -146,7 +158,7 @@ export class TalkService implements BaseService {
         relatedMessageId,
         ...(relatedMessageId
           ? {
-              messageRelationType: "REPLY",
+              messageRelationType: messageRelationType ?? "REPLY",
               relatedMessageServiceCode: "TALK",
             }
           : {}),

--- a/Vyline/packages/protocol/stack/base/thrift/readwrite/struct.ts
+++ b/Vyline/packages/protocol/stack/base/thrift/readwrite/struct.ts
@@ -3127,6 +3127,81 @@ export function CanCreateCombinationStickerRequest(
 ): NestedArray {
   return typeof param === "undefined" ? [] : [[14, 1, [11, param.packageIds]]];
 }
+export function StickerLayoutInfo(
+  param?: PartialDeep<LINETypes.StickerLayoutInfo> | undefined,
+): NestedArray {
+  return typeof param === "undefined"
+    ? []
+    : [
+        [4, 1, param.width],
+        [4, 2, param.height],
+        [4, 3, param.rotation],
+        [4, 4, param.x],
+        [4, 5, param.y],
+      ];
+}
+export function StickerLayoutStickerInfo(
+  param?: PartialDeep<LINETypes.StickerLayoutStickerInfo> | undefined,
+): NestedArray {
+  return typeof param === "undefined"
+    ? []
+    : [
+        [10, 1, param.stickerId],
+        [10, 2, param.productId],
+        [11, 3, param.stickerHash],
+        [11, 4, param.stickerOptions],
+        [10, 5, param.stickerVersion],
+      ];
+}
+export function StickerLayout(
+  param?: PartialDeep<LINETypes.StickerLayout> | undefined,
+): NestedArray {
+  return typeof param === "undefined"
+    ? []
+    : [
+        [12, 1, StickerLayoutInfo(param.layoutInfo)],
+        [12, 2, StickerLayoutStickerInfo(param.stickerInfo)],
+      ];
+}
+export function CombinationStickerMetadata(
+  param?: PartialDeep<LINETypes.CombinationStickerMetadata> | undefined,
+): NestedArray {
+  return typeof param === "undefined"
+    ? []
+    : [
+        [10, 1, param.version],
+        [4, 2, param.canvasWidth],
+        [4, 3, param.canvasHeight],
+        [15, 4, [12, param.stickerLayouts && param.stickerLayouts.map((e) => StickerLayout(e))]],
+      ];
+}
+export function CombinationStickerStickerData(
+  param?: PartialDeep<LINETypes.CombinationStickerStickerData> | undefined,
+): NestedArray {
+  return typeof param === "undefined"
+    ? []
+    : [
+        [11, 1, param.packageId],
+        [11, 2, param.stickerId],
+        [10, 3, param.version],
+      ];
+}
+export function CreateCombinationStickerResponse(
+  param?: PartialDeep<LINETypes.CreateCombinationStickerResponse> | undefined,
+): NestedArray {
+  return typeof param === "undefined" ? [] : [[11, 1, param.id]];
+}
+export function CreateCombinationStickerRequest(
+  param?: PartialDeep<LINETypes.CreateCombinationStickerRequest> | undefined,
+): NestedArray {
+  return typeof param === "undefined"
+    ? []
+    : [
+        [12, 1, CombinationStickerMetadata(param.metadata)],
+        [15, 2, [12, param.stickers && param.stickers.map((e) => CombinationStickerStickerData(e))]],
+        [11, 3, param.idOfPreviousVersionOfCombinationSticker],
+      ];
+}
 export function CancelChatInvitationRequest(
   param?: PartialDeep<LINETypes.CancelChatInvitationRequest> | undefined,
 ): NestedArray {
@@ -3777,6 +3852,22 @@ export function ChannelException(
     ? []
     : [
         [8, 1, ChannelErrorCode(param.code)],
+        [11, 2, param.reason],
+        [13, 3, [11, 11, param.parameterMap]],
+      ];
+}
+export function Ob1_EnumC12652p1(
+  param: LINETypes.Ob1_EnumC12652p1 | undefined,
+): (LINETypes.Ob1_EnumC12652p1 & number) | undefined {
+  return typeof param === "string" ? LINETypes.enums.Ob1_EnumC12652p1[param] : param;
+}
+export function ShopException(
+  param?: PartialDeep<LINETypes.ShopException> | undefined,
+): NestedArray {
+  return typeof param === "undefined"
+    ? []
+    : [
+        [8, 1, Ob1_EnumC12652p1(param.code)],
         [11, 2, param.reason],
         [13, 3, [11, 11, param.parameterMap]],
       ];
@@ -6849,7 +6940,19 @@ export function createCollectionForUser_args(
 export function createCombinationSticker_args(
   param?: PartialDeep<LINETypes.createCombinationSticker_args> | undefined,
 ): NestedArray {
-  return typeof param === "undefined" ? [] : [];
+  return typeof param === "undefined"
+    ? []
+    : [[12, 2, CreateCombinationStickerRequest(param.request)]];
+}
+export function createCombinationSticker_result(
+  param?: PartialDeep<LINETypes.createCombinationSticker_result> | undefined,
+): NestedArray {
+  return typeof param === "undefined"
+    ? []
+    : [
+        [12, 0, CreateCombinationStickerResponse(param.success)],
+        [12, 1, ShopException(param.e)],
+      ];
 }
 export function createE2EEKeyBackupEnforced_args(
   param?: PartialDeep<LINETypes.createE2EEKeyBackupEnforced_args> | undefined,

--- a/Vyline/packages/protocol/stack/base/thrift/readwrite/tmc.test.ts
+++ b/Vyline/packages/protocol/stack/base/thrift/readwrite/tmc.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assertEquals } from "@vyline/protocol/stack/assert";
 import { TMoreCompactProtocol } from "./tmc.ts";
 
 Deno.test("decodeZigZag matches standard thrift zigzag for positive values", () => {

--- a/Vyline/packages/protocol/stack/base/thrift/readwrite/write.test.ts
+++ b/Vyline/packages/protocol/stack/base/thrift/readwrite/write.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assertEquals } from "@vyline/protocol/stack/assert";
 import { writeStruct, writeThrift } from "./write.ts";
 import { readThrift } from "./read.ts";
 import { type NestedArray, Protocols } from "./declares.ts";

--- a/Vyline/packages/protocol/stack/client/features/call/andromeda.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/call/andromeda.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assert, assertEquals } from "@vyline/protocol/stack/assert";
 import { Buffer } from "node:buffer";
 import dgram from "node:dgram";
 import { AndromedaTransport } from "./andromeda.ts";

--- a/Vyline/packages/protocol/stack/client/features/call/audio.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/call/audio.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals, assertRejects, assertThrows } from "jsr:@std/assert@^1.0.2";
+import { assert, assertEquals, assertRejects, assertThrows } from "@vyline/protocol/stack/assert";
 import {
   bufferSink,
   bufferSource,

--- a/Vyline/packages/protocol/stack/client/features/call/e2e.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/call/e2e.test.ts
@@ -1,7 +1,7 @@
 // End-to-end: PCM → codec → SRTP wire → SRTP receive → codec → PCM,
 // using a loopback transport. Proves the audio plumbing carries
 // samples bit-identical without needing a real Opus impl.
-import { assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assertEquals } from "@vyline/protocol/stack/assert";
 import { CallSession, type CallTransport } from "./session.ts";
 import {
   type AudioDecoder,

--- a/Vyline/packages/protocol/stack/client/features/call/full_call.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/call/full_call.test.ts
@@ -2,7 +2,7 @@
 // SDP + SRTP + Opus call against a mock UAS that echoes Opus-encoded
 // audio. Proves every layer in the call stack interoperates.
 
-import { assert, assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assert, assertEquals } from "@vyline/protocol/stack/assert";
 import { Buffer } from "node:buffer";
 import dgram from "node:dgram";
 import { AndromedaTransport } from "./andromeda.ts";

--- a/Vyline/packages/protocol/stack/client/features/call/ice.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/call/ice.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assert, assertEquals } from "@vyline/protocol/stack/assert";
 import { formatCandidate, gatherIceCandidates, icePriority, parseCandidate } from "./ice.ts";
 
 Deno.test("icePriority: host candidate ranks higher than srflx", () => {

--- a/Vyline/packages/protocol/stack/client/features/call/mikey.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/call/mikey.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertRejects } from "jsr:@std/assert@^1.0.2";
+import { assertEquals, assertRejects } from "@vyline/protocol/stack/assert";
 import { Buffer } from "node:buffer";
 import { buildMikeyPke, mikeyFromBase64, mikeyToBase64, parseMikey } from "./mikey.ts";
 

--- a/Vyline/packages/protocol/stack/client/features/call/mod.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/call/mod.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assertEquals } from "@vyline/protocol/stack/assert";
 import {
   createCallClient,
   defaultCallFromEnvInfo,

--- a/Vyline/packages/protocol/stack/client/features/call/opus.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/call/opus.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assert, assertEquals } from "@vyline/protocol/stack/assert";
 import { opusCodecFactory } from "./opus.ts";
 
 Deno.test("opusCodecFactory: encodes + decodes a 20ms 48kHz mono frame", async () => {

--- a/Vyline/packages/protocol/stack/client/features/call/planet/cassini.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/call/planet/cassini.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assertEquals } from "@vyline/protocol/stack/assert";
 import {
   buildExchangeAppStrData,
   buildRelReq,

--- a/Vyline/packages/protocol/stack/client/features/call/planet/crypto.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/call/planet/crypto.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertNotEquals } from "jsr:@std/assert@^1.0.2";
+import { assertEquals, assertNotEquals } from "@vyline/protocol/stack/assert";
 import {
   aesCtrDecrypt,
   aesCtrEncrypt,

--- a/Vyline/packages/protocol/stack/client/features/call/planet/framing.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/call/planet/framing.test.ts
@@ -1,5 +1,5 @@
 /** Unit tests for PLANET framing — match values observed in live wire capture. */
-import { assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assertEquals } from "@vyline/protocol/stack/assert";
 import {
   buildFrameHeader,
   makeChunkHdr,

--- a/Vyline/packages/protocol/stack/client/features/call/planet/schema.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/call/planet/schema.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assertEquals } from "@vyline/protocol/stack/assert";
 import {
   CC_MSG,
   decodeCcConnReq,

--- a/Vyline/packages/protocol/stack/client/features/call/planet/transport.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/call/planet/transport.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assert, assertEquals } from "@vyline/protocol/stack/assert";
 import { Buffer } from "node:buffer";
 import { createSocket, type RemoteInfo, type Socket } from "node:dgram";
 import {

--- a/Vyline/packages/protocol/stack/client/features/call/rtcp.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/call/rtcp.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assert, assertEquals } from "@vyline/protocol/stack/assert";
 import { buildRtcpBye, buildRtcpCompound, nowNtp, parseRtcp } from "./rtcp.ts";
 
 Deno.test("nowNtp returns a value above the 1900-epoch threshold", () => {

--- a/Vyline/packages/protocol/stack/client/features/call/sdp.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/call/sdp.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assert, assertEquals } from "@vyline/protocol/stack/assert";
 import { buildAudioOffer, buildSdp, cryptoAttr, parseSdp, readCrypto, readRtpmap } from "./sdp.ts";
 
 Deno.test("buildSdp + parseSdp round-trip", () => {

--- a/Vyline/packages/protocol/stack/client/features/call/session.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/call/session.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals, assertRejects } from "jsr:@std/assert@^1.0.2";
+import { assert, assertEquals, assertRejects } from "@vyline/protocol/stack/assert";
 import { CallSession, type CallTransport } from "./session.ts";
 import type { AudioDecoder, AudioEncoder, CodecFactory, PcmFrame } from "./audio.ts";
 import { bufferSink, bufferSource } from "./audio.ts";

--- a/Vyline/packages/protocol/stack/client/features/call/sip.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/call/sip.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assertEquals } from "@vyline/protocol/stack/assert";
 import {
   buildSip,
   digestResponse,

--- a/Vyline/packages/protocol/stack/client/features/call/srtp.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/call/srtp.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals, assertRejects } from "jsr:@std/assert@^1.0.2";
+import { assert, assertEquals, assertRejects } from "@vyline/protocol/stack/assert";
 import {
   buildRtp,
   deriveSrtpContext,

--- a/Vyline/packages/protocol/stack/client/features/call/stun.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/call/stun.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assert, assertEquals } from "@vyline/protocol/stack/assert";
 import dgram from "node:dgram";
 import { Buffer } from "node:buffer";
 import { buildBindingRequestAsync, parseStun, readMappedAddress } from "./stun.ts";

--- a/Vyline/packages/protocol/stack/client/features/liff.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/liff.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assertEquals } from "@vyline/protocol/stack/assert";
 import { flex, image, sticker, text } from "./liff.ts";
 
 Deno.test("liff.text — plain", () => {

--- a/Vyline/packages/protocol/stack/client/features/message/internal-types.ts
+++ b/Vyline/packages/protocol/stack/client/features/message/internal-types.ts
@@ -1,9 +1,10 @@
 export interface StickerMetadata {
-  STKPKGID: string;
-  STKID: string;
-  STKTXT: string;
-  STKVER: string;
+  STKPKGID?: string;
+  STKID?: string;
+  STKTXT?: string;
+  STKVER?: string;
   STKOPT?: string;
+  CSSTKID?: string;
 }
 export interface EmojiMeta {
   REPLACE: {

--- a/Vyline/packages/protocol/stack/client/features/message/square.ts
+++ b/Vyline/packages/protocol/stack/client/features/message/square.ts
@@ -172,10 +172,14 @@ export class SquareMessage {
       throw new TypeError("The message is not sticker.");
     }
     const stickerMetadata = this.raw.message.contentMetadata as unknown as StickerMetadata;
+    const stickerId = stickerMetadata.CSSTKID ?? stickerMetadata.STKID;
+    if (!stickerId) {
+      throw new TypeError("The sticker ID is missing.");
+    }
     if (stickerMetadata.STKOPT === "A") {
-      return `https://stickershop.line-scdn.net/stickershop/v1/sticker/${stickerMetadata.STKID}/android/sticker_animation.png`;
+      return `https://stickershop.line-scdn.net/stickershop/v1/sticker/${stickerId}/android/sticker_animation.png`;
     } else {
-      return `https://stickershop.line-scdn.net/stickershop/v1/sticker/${stickerMetadata.STKID}/android/sticker.png`;
+      return `https://stickershop.line-scdn.net/stickershop/v1/sticker/${stickerId}/android/sticker.png`;
     }
   }
 

--- a/Vyline/packages/protocol/stack/client/features/message/talk.ts
+++ b/Vyline/packages/protocol/stack/client/features/message/talk.ts
@@ -161,10 +161,14 @@ export class TalkMessage {
       throw new TypeError("The message is not sticker.");
     }
     const stickerMetadata = this.raw.contentMetadata as unknown as StickerMetadata;
+    const stickerId = stickerMetadata.CSSTKID ?? stickerMetadata.STKID;
+    if (!stickerId) {
+      throw new TypeError("The sticker ID is missing.");
+    }
     if (stickerMetadata.STKOPT === "A") {
-      return `https://stickershop.line-scdn.net/stickershop/v1/sticker/${stickerMetadata.STKID}/android/sticker_animation.png`;
+      return `https://stickershop.line-scdn.net/stickershop/v1/sticker/${stickerId}/android/sticker_animation.png`;
     } else {
-      return `https://stickershop.line-scdn.net/stickershop/v1/sticker/${stickerMetadata.STKID}/android/sticker.png`;
+      return `https://stickershop.line-scdn.net/stickershop/v1/sticker/${stickerId}/android/sticker.png`;
     }
   }
 

--- a/Vyline/packages/protocol/stack/client/features/voom.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/voom.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assertEquals } from "@vyline/protocol/stack/assert";
 import { VoomChannelId } from "./voom.ts";
 
 Deno.test("VoomChannelId — TIMELINE id matches LINE Android smali", () => {

--- a/Vyline/packages/protocol/stack/client/features/voom.ts
+++ b/Vyline/packages/protocol/stack/client/features/voom.ts
@@ -92,7 +92,11 @@ export async function voomRest<T = unknown>(
 
 export async function getChannelToken(client: Client, channelId: string): Promise<string> {
   const r = await client.base.channel.issueChannelToken({ channelId });
-  const t = (r as unknown as { token?: string }).token;
+  // 重要: ゲートウェイ(gw.line.naver.jp)は channelAccessToken を X-Line-ChannelToken として
+  // 要求する。r.token(長い方)を渡すと 401「ユーザー認証を更新しています」になる。
+  const t =
+    (r as unknown as { channelAccessToken?: string }).channelAccessToken ??
+    (r as unknown as { token?: string }).token;
   if (!t) throw new Error("issueChannelToken returned no token");
   return t;
 }

--- a/Vyline/packages/protocol/stack/client/features/voom_client.test.ts
+++ b/Vyline/packages/protocol/stack/client/features/voom_client.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assert, assertEquals } from "@vyline/protocol/stack/assert";
 import { createVoomClient, VoomChannelId } from "./voom.ts";
 
 function makeFake() {

--- a/Vyline/packages/protocol/stack/client/fetch_users.test.ts
+++ b/Vyline/packages/protocol/stack/client/fetch_users.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "jsr:@std/assert@^1.0.2";
+import { assert, assertEquals } from "@vyline/protocol/stack/assert";
 import { Client } from "./client.ts";
 
 function buildClient(opts: {

--- a/Vyline/packages/protocol/stack/client/login.test.ts
+++ b/Vyline/packages/protocol/stack/client/login.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertRejects } from "jsr:@std/assert@^1.0.2";
+import { assertEquals, assertRejects } from "@vyline/protocol/stack/assert";
 import { loginWithAuthToken } from "./login.ts";
 import { MemoryStorage } from "../base/storage/mod.ts";
 

--- a/Vyline/packages/protocol/stack/test-preload.ts
+++ b/Vyline/packages/protocol/stack/test-preload.ts
@@ -1,0 +1,5 @@
+import { test } from "bun:test";
+
+globalThis.Deno ??= {
+  test,
+};

--- a/Vyline/packages/types/src/index.ts
+++ b/Vyline/packages/types/src/index.ts
@@ -147,6 +147,15 @@ export interface Message {
   updatedTime?: number;
   /** 編集前のオリジナルテキスト（ローカルキャッシュ用） */
   originalText?: string;
+  /** メッセージ状態 */
+  messageState?: "normal" | "edited" | "revoked-by-other" | "revoked-by-self";
+  /** 状態変更履歴 */
+  history?: Array<{
+    state: "normal" | "edited" | "revoked-by-other" | "revoked-by-self";
+    text: string | null;
+    contentType: string;
+    updatedTime: number;
+  }>;
 }
 
 export interface MessageReaction {

--- a/Vyline/packages/types/src/index.ts
+++ b/Vyline/packages/types/src/index.ts
@@ -125,6 +125,20 @@ export interface MessageContentMeta {
   [key: string]: string | undefined;
 }
 
+export type RetryIntent =
+  | {
+      kind: "text";
+      text: string;
+      relatedMessageId?: string;
+      contentMetadata?: Record<string, string>;
+    }
+  | { kind: "sticker"; packageId: string; stickerId: string; isPremium?: boolean }
+  | {
+      kind: "combinationSticker";
+      items: Array<{ packageId: string; stickerId: string; x?: number; y?: number; size?: number }>;
+    }
+  | { kind: "emoji"; packageId: string; sticonId: string };
+
 export interface Message {
   id: string;
   from: string;

--- a/Vyline/packages/types/src/index.ts
+++ b/Vyline/packages/types/src/index.ts
@@ -35,6 +35,14 @@ export interface LineProfile {
   birthday?: LineBirthday | null | undefined;
   /** アカウント種別: USER=1 / BOT=2（公式アカウントは BOT） */
   userType?: number;
+  /** LYP Premium の加入状態 */
+  premium?: {
+    active: boolean;
+    planType?: string | number;
+    validUntil?: number;
+    onFreeTrial?: boolean;
+    willExpire?: boolean;
+  };
 }
 
 /** VylineCache から返す軽量プロフィール */
@@ -156,7 +164,11 @@ export interface Message {
     contentType: string;
     updatedTime: number;
   }>;
+  /** 取り消し前のメッセージ本体スナップショット */
+  revokedSnapshot?: MessageSnapshot;
 }
+
+export type MessageSnapshot = Omit<Message, "history" | "revokedSnapshot">;
 
 export interface MessageReaction {
   /** リアクションしたユーザー mid */
@@ -230,6 +242,13 @@ export type SavedSession = {
   displayName?: string;
   picturePath?: string;
   statusMessage?: string;
+  premium?: {
+    active: boolean;
+    planType?: string | number;
+    validUntil?: number;
+    onFreeTrial?: boolean;
+    willExpire?: boolean;
+  };
 };
 
 export type AccountsResponse = ApiResult<{

--- a/bun.lock
+++ b/bun.lock
@@ -6,12 +6,13 @@
       "name": "vyline",
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
+        "@types/bun": "^1.4.0",
         "concurrently": "^9.1.2",
       },
     },
     "Vyline/apps/desktop": {
       "name": "@vyline/desktop",
-      "version": "0.4.0-beta",
+      "version": "0.5.1-beta",
       "dependencies": {
         "@vyline/types": "workspace:*",
         "clsx": "^2.1.1",
@@ -280,7 +281,7 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
-    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+    "@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
 
     "@types/crypto-js": ["@types/crypto-js@4.2.2", "", {}, "sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ=="],
 
@@ -338,7 +339,7 @@
 
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
 
-    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+    "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
 
     "camelcase-css": ["camelcase-css@2.0.1", "", {}, "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="],
 
@@ -644,6 +645,10 @@
 
     "@types/thrift/@types/node": ["@types/node@25.9.0", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ=="],
 
+    "@vyline/backend/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@vyline/protocol/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "bun-types/@types/node": ["@types/node@25.9.0", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ=="],
@@ -664,6 +669,18 @@
 
     "@types/thrift/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
+    "@vyline/backend/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "@vyline/protocol/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
     "bun-types/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+
+    "@vyline/backend/@types/bun/bun-types/@types/node": ["@types/node@25.9.0", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ=="],
+
+    "@vyline/protocol/@types/bun/bun-types/@types/node": ["@types/node@25.9.0", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ=="],
+
+    "@vyline/backend/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+
+    "@vyline/protocol/@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
   }
 }

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./Vyline/packages/protocol/stack/test-preload.ts"]

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -113,6 +113,12 @@ bun run typecheck
 | `desktop-e2ee-keys.json` / token をコミット | 秘密情報                 |
 | Desktop 未検証のまま path を変える          | 実機 x-lc:400 の温床     |
 
+### Vyline では公開しない項目
+
+- 自分プロフィールの「誕生日（MMDD / YYYYMMDD）」更新は扱わない。
+- これは Desktop 側でも主に primary 寄りのデバイスタイプでしか安定しないため、Vyline では入力欄を出さず、backend でも更新経路を持たない。
+- 表示用に取得済みの誕生日データは残してよいが、編集導線は追加しない。
+
 ---
 
 ## コード規約（短く）

--- a/docs/README.md
+++ b/docs/README.md
@@ -66,7 +66,6 @@
 | [tools/find-native-symbol.md](./tools/find-native-symbol.md)         | Desktop 内 RPC 名検索        |
 | [tools/desktop-delta.md](./tools/desktop-delta.md)                   | Desktop 更新時の差分調査     |
 | [tools/focus-recovered-source.md](./tools/focus-recovered-source.md) | 復元ソースのピンポイント表示 |
-| [tools/nezu-bot-agent.md](./tools/nezu-bot-agent.md)                 | Nezu BOT 指示チャネル        |
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,9 +1,21 @@
 # Vyline ドキュメント索引
 
-最終更新: 2026-07-31
+最終更新: 2026-08-22
 
 新規参入者は **[onboarding.md](./onboarding.md)** から始めてください。
 エージェントは **[../AGENTS.md](../AGENTS.md)** を最初に読んでください。
+
+---
+
+## API / デプロイ / 開発者ガイド
+
+| ドキュメント                                            | 内容                                                     |
+| ------------------------------------------------------- | -------------------------------------------------------- |
+| [api/openapi.md](./api/openapi.md)                      | OpenAPI / Swagger ルートと仕様の管理方法                 |
+| [api/media-batch.md](./api/media-batch.md)              | 複数メディア一括送信 API                                 |
+| [deployment/docker.md](./deployment/docker.md)          | Docker / Docker Compose デプロイ                         |
+| [developer-guide/plugin-system.md](./developer-guide/plugin-system.md) | プラグインシステム基盤とロードマップ       |
+| [developer-guide/multi-account.md](./developer-guide/multi-account.md) | マルチアカウントデータ分離の現状と計画     |
 
 ---
 

--- a/docs/analysis/README.md
+++ b/docs/analysis/README.md
@@ -15,6 +15,8 @@ agents は `bun run vyline:delta` のレポートが指す feature ごとに、�
 | e2ee-send                | [e2ee-send.md](./e2ee-send.md)                   |                                                      |
 | e2ee-decrypt             | [e2ee-decrypt.md](./e2ee-decrypt.md)             |                                                      |
 | talk-send                | [talk-send.md](./talk-send.md)                   |                                                      |
+| multi-image-send         | [multi-image-send-handoff.md](./multi-image-send-handoff.md) | 複数画像送信の未解決事項と handoff |
+| combination-sticker     | [combination-sticker-handoff.md](./combination-sticker-handoff.md) | 複数スタンプの組み合わせ送信・表示の未解決事項と handoff |
 | sync-events              | [sync-events.md](./sync-events.md)               |                                                      |
 | stickers                 | [stickers.md](./stickers.md)                     |                                                      |
 | line-emoji               | [line-emoji.md](./line-emoji.md)                 |                                                      |

--- a/docs/analysis/combination-sticker-handoff.md
+++ b/docs/analysis/combination-sticker-handoff.md
@@ -1,0 +1,184 @@
+# コンビネーションスタンプ送信 引き継ぎ書
+
+最終更新: 2026-08-21
+
+## 目的
+
+複数スタンプをドラッグして配置し、LINE のコンビネーションスタンプとして作成・送信・表示する機能を完成させる。
+
+現状は UI 上で複数スタンプを配置できるところまで進んでいるが、**送信後に複数スタンプの組み合わせとして安定して表示・再取得できていない**。送信直後は画像が表示されても、再同期後に `🧩` へ置換される事象が残っている。
+
+## 最重要の未解決症状
+
+- コンビネーション作成領域に複数スタンプを配置できる
+- 送信操作も実装済み
+- 送信直後に一瞬画像が見えることがある
+- その後、履歴更新・再同期・再描画で `🧩` に置換される
+- 「複数スタンプを1つのコンビネーションスタンプとして送信できた」ことは未確認
+
+## 現在の実装経路
+
+### UI
+
+対象: `Vyline/apps/desktop/src/components/sticker-emoji-panel.tsx`
+
+- スタンプ長押しでコンビネーション領域へ追加
+- ドラッグで配置を変更
+- 配置情報 `{ packageId, stickerId, x, y, size }` を送信関数へ渡す
+- 通常のメディアドロップとは MIME type `application/x-vyline-sticker` で分離
+- 対応不可パッケージはドラッグ不可にする実装があるため、判定が全経路で効いているか再確認する
+
+### Desktop store
+
+対象: `Vyline/apps/desktop/src/lib/store.ts`
+
+主な処理:
+
+1. `sendCombinationSticker(chatId, items)` が呼ばれる
+2. 各スタンプからローカル表示用の配置を作る
+3. `api.line.sendCombinationSticker(...)` を呼ぶ
+4. 応答メッセージを `mapMessage(...)` で UI 型へ変換
+5. `renderCombinationStickerPreview(...)` でローカル合成 PNG を作成
+6. `CSSTKID` とメッセージIDにプレビューを保存
+7. 送信後に `refreshMessages(..., { force: true })` を予約
+
+注意: retry 経路にも `combinationSticker` が追加されているが、retry 後の確認済みメッセージにローカルプレビューを再登録する処理は不十分。
+
+### Backend
+
+対象: `Vyline/backend/src/service/lineService.ts`
+
+現在の送信は概ね以下の流れ:
+
+```text
+createCombinationStickerCore(accountId, items)
+  -> Shop.createCombinationSticker(...)
+  -> created.id
+
+sendStickerMessage(...)
+  -> contentMetadata: { CSSTKID: created.id }
+```
+
+対象 API: `Vyline/backend/src/api/line.ts`
+
+- `POST /line/:accountId/combination-stickers`
+- `POST /line/:accountId/send-combination-sticker`
+- `POST /line/:accountId/combination-stickers/can-create`
+- `POST /line/:accountId/combination-stickers/available`
+
+## 直近で入った表示修正
+
+対象: `Vyline/apps/desktop/src/lib/mappers.ts`
+
+コンビネーションの識別子は `contentMetadata.CSSTKID` を使う。
+
+プレビュー取得は次の優先順:
+
+```text
+localStorage の CSSTKID キーに保存された data URL
+  -> lineStickerUrl(CSSTKID)
+  -> 通常スタンプのURL
+  -> 最終的な一般スタンプ fallback
+```
+
+重要な修正済み点:
+
+- 以前は保存キーがメッセージID、取得キーが `CSSTKID` で不一致だった
+- 現在は送信後に `CSSTKID` をキーとして保存するよう変更済み
+- キャッシュ未取得時に即 `🧩` を返さず、`lineStickerUrl(CSSTKID)` を試すよう変更済み
+
+それでも `🧩` が出るため、以下のどれかが残っている可能性が高い。
+
+1. 実際の履歴レスポンスに `CSSTKID` が存在しない、または別名・別階層に入っている
+2. `sendCombinationSticker` のレスポンスに `message` がなく、プレビュー保存処理が実行されていない
+3. 再同期時に `CSSTKID` を含む raw message が別の mapper 経路で失われている
+4. `createCombinationSticker` が作成したIDと、送信メッセージに付与されるIDが異なる
+5. `lineStickerUrl(CSSTKID)` がコンビネーション用画像URLとして有効ではない
+6. `mapMessage` 以外で `sticker: "🧩"` を上書きしている
+
+## 次のAIが最初に行う調査
+
+### 1. raw response を確認する
+
+送信直後と再取得時に、次をログ出力して比較する。
+
+- `res.message.id`
+- `res.message.contentType`
+- `res.message.contentMetadata`
+- `res.message.text`
+- `CSSTKID` の型と値
+- `createCombinationSticker` の戻り値 `created.id`
+
+ログにはトークンや本文全体を出さず、ID・キー名だけを出すこと。
+
+### 2. `🧩` の全代入箇所を確認する
+
+```powershell
+rg -n '🧩|sticker\s*:' Vyline/apps/desktop/src
+```
+
+特に次を確認:
+
+- `Vyline/apps/desktop/src/lib/mappers.ts`
+- `Vyline/apps/desktop/src/lib/store.ts`
+- `Vyline/apps/desktop/src/components/message-bubble.tsx`
+
+### 3. mapper 呼び出し経路を全確認する
+
+現在確認すべき呼び出し箇所:
+
+- 初期 hydrate
+- `refreshMessages`
+- `mergeIncomingMessages`
+- 通常送信の確認済みメッセージ処理
+- コンビネーション送信の確認済みメッセージ処理
+- retry 処理
+
+どの経路でも raw の `CSSTKID` が mapper に渡ることを確認する。
+
+### 4. サーバが返すコンビネーション画像を確認する
+
+次のURLが本当に画像を返すか、ブラウザのNetworkで確認する。
+
+```text
+/api/cdn/line?u=https%3A%2F%2Fstickershop.line-scdn.net%2Fstickershop%2Fv1%2Fsticker%2F{CSSTKID}%2Fandroid%2Fsticker.png
+```
+
+無効なら、Desktop/HAR でコンビネーション用の画像URL形式を探す。`CSSTKID` を通常スタンプIDのURLに流用し続けないこと。
+
+### 5. 作成と送信を分離して検証する
+
+- 作成APIだけ呼び、返された `id` で画像取得できるか
+- 作成済みIDを使って送信できるか
+- 送信メッセージの `contentMetadata` にどのキーが付くか
+- 送信後の履歴で同じキーが残るか
+
+## 受け入れ条件
+
+- 2個以上の対応スタンプを配置して送信できる
+- 対応不可スタンプはドラッグできない
+- 送信後に画像が `🧩` へ変わらない
+- 画面再描画、チャット切替、再同期、アプリ再起動後も表示できる
+- 通常の画像送信欄へスタンプが混入しない
+- LINE側の受信者にもコンビネーションスタンプとして届く
+- 単一スタンプ送信の既存動作を壊さない
+
+## 安全な送信テスト先
+
+実グループ・実友だちへ送信しない。許可されたテスト先のみ:
+
+- グループ: `c1efe9d6cf1848350bc91848a8a29963e`
+- BOT: `u81c530b68cc2efdd36911d214bd5f084`
+
+## 現在のワークツリー注意事項
+
+- 作業ブランチは `codex/hide-profile-details`
+- 既に多数の未コミット変更があるため、無関係な差分を revert しない
+- `docs/analysis/multi-image-send-handoff.md` は複数画像送信の別問題の引き継ぎ書
+- 今回の主題は複数画像ではなく、複数スタンプのコンビネーション送信・表示
+- Desktop の型チェックは成功
+- ルート全体の型チェックは既存の `Vyline/backend/src/service/lineService.ts:1046` の型エラーで停止している
+
+## ひとことで言うと
+
+UI配置と送信API呼び出しは存在するが、**LINEの送信レスポンス・履歴レスポンスに含まれるコンビネーションIDと画像取得方法の実証が不足している**。次は `CSSTKID` の実値を送信直後・履歴再取得後で比較し、Desktop/HARの正しいコンビネーション画像取得経路を確定すること。

--- a/docs/analysis/multi-image-send-handoff.md
+++ b/docs/analysis/multi-image-send-handoff.md
@@ -1,6 +1,55 @@
 # multi-image-send — 引き継ぎメモ
 
-最終更新: 2026-08-21
+最終更新: 2026-08-22 04:00（夜間検証で大幅更新）
+
+## 2026-08-22 夜間の結論（重要）
+
+**原因確定: 旧経路はサーバに届いていなかった。**
+
+- `uploadObjTalkMessage`（UUID OBS パス + thrift sendMessage）で送っても
+  **getPreviousMessagesV2 に一切現れない**ことを実機で実証
+- 公式アプリ（HAR は iPhone から捕捉）は **OBS `/r/talk/m/reqseq` に連番 reqseq で
+  アップロードし、サーバ側がメッセージを生成する** 方式
+- 対応: `sendMediaBatch` plain 経路を `uploadObjTalkBatch`（reqseq 連番）へ変更
+  → 2〜3 枚送信で履歴に IMAGE が出ることを実機確認
+- 応答ヘッダ `x-obs-oid`（== 生成メッセージ ID の実測）をキーに送信バイトを
+  ローカル media cache に置き、自クライアントの即表示を実現
+  （reqseq 生成メッセージは contentMetadata に OID を持たないため）
+
+## 未解決
+
+1. **アルバムメタデータ (GID/GSEQ/GTOTAL) の再現未達**
+   - 公式クライアント送信分は `contentMetadata` に GID/GSEQ/GTOTAL が付く
+     （chatdb の ClockAngel 送信分で確認: GID=先頭メッセージID+1 の実測例あり）
+   - Vyline からの reqseq 送信には付かない。OBS 応答ヘッダ `x-line-message-gid`
+     は Desktop HAR で確認済みだが Vyline 分は未確認（ヘッダログの [object Headers] 化は要修正）
+   - UI は `shouldGroupAdjacentImages`（sender + 30s 窓）でフォールバックグルーピング
+   - 次の調査: OBS 応答ヘッダの gid 有無を確認（uploadObjTalk の戻り headers を
+     ちゃんとシリアライズしてログ）、リージョン host / x-line-application 差分
+2. **受信側の最終確認**（朝推奨）: スマホ公式アプリで うがうがうー の
+   2026-08-22 深夜の画像群が表示・開けるか
+3. `x-obs-oid == メッセージID` の一致は 2 回の実測のみ。大量送信での妥当性検証
+
+## テスト手順（実機）
+
+```powershell
+# backend 起動（ログキャプチャ推奨）
+bun Vyline/backend/src/index.ts *> backend.log
+
+# 3枚送信
+POST http://127.0.0.1:3001/line/main/send-media-batch
+{ "chatMid": "c1efe9d6cf1848350bc91848a8a29963e",
+  "items": [ { "dataBase64": "...", "mimeType": "image/png", "mediaType": "image" } x3 ] }
+
+# 履歴確認（force でサーバ取得）
+GET http://127.0.0.1:3001/line/main/messages/c1efe9d6cf1848350bc91848a8a29963e?limit=15&force=1
+# → contentType IMAGE が連続してればOK。media は
+# GET /line/main/media/<chatMid>/<messageId> で X-Vyline-Media-Cache: HIT を確認
+```
+
+---
+
+# 以下: 2026-08-21 時点の旧メモ（参考）
 
 ## 現在の作業状態
 

--- a/docs/analysis/multi-image-send-handoff.md
+++ b/docs/analysis/multi-image-send-handoff.md
@@ -1,0 +1,220 @@
+# multi-image-send — 引き継ぎメモ
+
+最終更新: 2026-08-21
+
+## 現在の作業状態
+
+- 作業ブランチ: `codex/hide-profile-details`
+- ワークツリーは既に複数機能の未コミット変更を含む。無関係な差分を戻さないこと
+- コンビネーションスタンプの表示修正も同じワークツリーに含まれるが、複数画像送信とは別問題
+- Desktop の型チェックは成功: `bun run typecheck` を Desktop ディレクトリで実行
+- ルートの全体型チェックは既存の backend エラーで停止中: `Vyline/backend/src/service/lineService.ts:1046` の `string | null` を `string | undefined` に代入している箇所
+
+## 結論
+
+Vyline はまだ **「本当の複数画像送信」** を実現できていない。
+
+2026-08-21 時点でも未解決で、今のところ「複数選択 UI」や「batch 送信 API」はあるが、最終的な送信結果は 1 message に束ねられていない。
+
+- UI 上で複数画像をまとめて選択して送る導線はある
+- backend / protocol 側でも batch 送信の経路は追加した
+- ただし現状の送信結果は **画像 3 枚なら message 3 件** で、ユーザーが求めている「1 回の送信で複数画像を持つ payload」にはなっていない
+- `sendLiff` は今回の要件から除外すること。ユーザーが明示的に拒否している
+
+## ユーザー要求
+
+- 複数画像を送るときに、チャット欄上の送信前プレビューでまとまって見えること
+- 送信時も UI だけでなく、**実際の payload として multi image** で送れること
+- 合成画像 1 枚にするのは不可
+- 連投で 3 件に分かれるのも不可
+- Desktop の実装や `search tool` 由来の解析を元に移植すること
+- `sendLiff` 経由ではなく探すこと
+
+## 症状
+
+過去に確認された失敗:
+
+- `getLastE2EEPublicKeys(/S4)` → `E2EE_RETRY_PLAIN`
+- `sendMessage(/S4)` → `REFRESH_MEDIA_FLOW`
+
+その後、`determineMediaMessageFlow` を送信前に呼んで plain / reqseq 経路へ分岐する変更は入れたが、**message が 1 件にまとまる問題は未解決**。
+
+## 安全なテスト先
+
+送信テストはこの 2 つのみ:
+
+- グループ `c1efe9d6cf1848350bc91848a8a29963e`
+- BOT `u81c530b68cc2efdd36911d214bd5f084`
+
+## 調査で確認できた事実
+
+### 1. HAR 上の送信
+
+対象:
+
+- `obs-jp.line-apps.com_2026_08_21_20_06_00.har`
+- `uts-front.line-apps.com_2026_08_21_18_13_58.har`
+
+確認できたこと:
+
+- `obs-jp...har` では `POST https://obs-jp.line-apps.com/r/talk/m/reqseq` が 3 件
+- 各リクエストの `X-Obs-Params` は別々の `reqseq`
+- 例:
+  - `17195037`
+  - `17195038`
+  - `17195039`
+- `tomid` は同一チャット
+- `type` は `image`
+- HAR 上では **1 つの HTTP payload に複数画像を同梱している証拠は見つかっていない**
+
+### 2. media flow
+
+ローカルで `determineMediaMessageFlow` を確認した結果:
+
+- chat: `c1efe9d6cf1848350bc91848a8a29963e`
+- `flowMap: {"1":1,"2":1,"3":1,"14":1}`
+- `cacheTtlMillis: "21600000"`
+
+解釈:
+
+- image / video / audio / file ともに `MediaMessageFlow.V1 = 1`
+- この chat は Desktop 準拠で `OBS /r/talk/m/reqseq` に寄せる必要がある
+
+### 3. linejs 調査
+
+参照:
+
+- `https://github.com/evex-dev/linejs`
+
+確認できたこと:
+
+- `packages/linejs/base/obs/mod.ts` に `uploadObjTalk(...)` がある
+- ここは `oid: "reqseq"` と `tomid`, `reqseq` を使って OBS へ送る
+- OpenChat 側コメントでも「reqseq mode では server creates the message」と読める
+- `sendLiff` / `shareMessages` は存在するが、ユーザー要件から除外
+- **LIFF 以外で「1 message の中に複数 image payload を持つ Talk 実装」は見つけられていない**
+
+## 今回入った変更
+
+主に以下:
+
+- frontend で複数選択時の送信を `sendMediaBatch` に寄せた
+- 画像合成処理は削除
+- backend に `sendMediaBatch(...)` を追加
+- `determineMediaMessageFlow` を送信前に呼び、flow=1 なら plain reqseq 経路へ分岐
+- protocol `BaseClient` に `getReqseqs(...)` を追加
+- protocol `LineObs` に `uploadObjTalkBatch(...)` を追加
+- `uploadObjTalkBatch(...)` は複数 `reqseq` をまとめて確保し、各画像を OBS へ投げる
+- E2EE plain fallback で `E2EE_RETRY_PLAIN` / `member settings off` を拾うようにした
+
+## コンビネーションスタンプの直近修正（参考）
+
+複数画像送信とは別だが、直近で `🧩` に置換される不具合を調査した。
+
+- `Vyline/apps/desktop/src/lib/store.ts` でプレビュー保存キーを `mapped.id` だけでなく `CSSTKID` に統一
+- `Vyline/apps/desktop/src/lib/mappers.ts` でキャッシュ未取得時も `🧩` ではなく `lineStickerUrl(CSSTKID)` を表示
+- `Vyline/apps/desktop/src/utils/combinationStickers.ts` にローカルプレビューを保存
+- 送信後の再同期でプレビューを保持する処理を `store.ts` に追加
+
+この変更を複数画像送信の調査と混ぜないこと。`CSSTKID` の問題を直しても、画像3枚が1つのLINEメッセージになるわけではない。
+
+## 重要: まだ未解決な点
+
+今の batch 実装は「route レベルの逐次ループ」よりは Desktop に近いが、**結果としては still 3 messages**。
+
+つまり:
+
+- `sendMediaBatch` はある
+- `uploadObjTalkBatch` もある
+- しかし server side で生成される message が 1 件に束ねられていない
+
+ここが今回の handoff の本題。
+
+## 変更済みファイル
+
+今回の作業で直接触った主要ファイル:
+
+- `Vyline/backend/src/service/lineService.ts`
+- `Vyline/backend/src/api/line.ts`
+- `Vyline/packages/protocol/stack/base/core/mod.ts`
+- `Vyline/packages/protocol/stack/base/obs/mod.ts`
+- `Vyline/packages/protocol/stack/_dist/base/core/mod.d.ts`
+- `Vyline/packages/protocol/stack/_dist/base/obs/mod.d.ts`
+- `Vyline/apps/desktop/src/components/message-input.tsx`
+
+補助的に、UI 側では受信表示をグループ化する変更も入っている:
+
+- `Vyline/apps/desktop/src/components/chat-area.tsx`
+- `Vyline/apps/desktop/src/components/message-bubble.tsx`
+
+ただしこれは送信 payload 解決ではない。
+
+## 既に通した確認
+
+- `bun run --cwd Vyline/backend typecheck`
+- `bun run --cwd Vyline/packages/protocol typecheck`
+- `bun run --cwd Vyline/apps/desktop typecheck`
+- `bunx biome check ...`
+
+また、テスト API 呼び出しで以下は通った:
+
+- `POST http://127.0.0.1:3001/line/main/send-media-batch`
+- 結果: `{ "ok": true, "count": 3 }`
+
+この `count: 3` 自体が、未解決の本質でもある。
+
+## 次の AI が最優先でやること
+
+### 1. Desktop 実装の「message まとまり条件」を特定する
+
+見るべき観点:
+
+- `reqseq` 連番だけで十分なのか
+- 追加の S4 / UTS / LIFF 以外の事前 RPC があるか
+- 複数画像の束ねに必要な `contentMetadata` / `messageRelationType` / `chunks` / `headers` があるか
+- OBS 送信後に別 RPC で group 化している可能性がないか
+
+特に、HAR だけでなく Desktop 解析ツール側で:
+
+- `multi image`
+- `media message flow`
+- `reqseq`
+- `talk/m/reqseq`
+- `messageRelationType`
+- `album`
+- `media bundle`
+
+あたりを重点的に追うこと。
+
+### 2. linejs 以外の Desktop 痕跡を探す
+
+linejs に無いから終わり、ではない。
+
+- Vyline-Search / Desktop 解析結果
+- `rpcMap.ts`
+- recovered strings
+- `source/desktop/` の解析成果
+
+を使って、公式 Desktop がどこで multi image を束ねているか再確認すること。
+
+### 3. UI grouping と送信 payload を混同しない
+
+受信表示を 1 塊に見せる変更は入っているが、ユーザーが欲しいのはそこではない。
+
+判定基準:
+
+- LINE 本体や他クライアントでも「複数画像 1 回送信」として見えるか
+- HAR / RPC / 保存 message に multi-image の痕跡が残るか
+- Vyline ローカル UI だけの grouping になっていないか
+
+## 注意
+
+- `sendLiff` は使わない
+- 合成画像は不可
+- 実グループ・実友だちには送らない
+- 既存の dirty worktree があるので、関係ない差分は巻き込まない
+- 調査用の `.tmp-linejs-b015243/` は未追跡で残っている
+
+## ひとことで言うと
+
+今の実装は **「複数選択を batch 送信するところ」までは進んだが、「LINE の本当の multi image message を再現する条件」がまだ取れていない**。

--- a/docs/developer-guide/multi-account.md
+++ b/docs/developer-guide/multi-account.md
@@ -1,0 +1,72 @@
+# Multi Account Design（複数アカウント分離）
+
+最終更新: 2026-08-22
+
+## 現状（実装済み）
+
+Vyline は `accountId` をキーにデータを分離している。実体はフラットなサフィックス方式。
+
+| データ | パス | 分離 |
+|---|---|---|
+| セッション / トークン | `data/tokens.json` (`{ [accountId]: ... }`) | ✅ key 単位 |
+| チャット / メッセージ DB | `data/chatdb-{accountId}.json` | ✅ ファイル単位 |
+| プロフィール等キャッシュ | `data/vyline-cache-{accountId}.json` | ✅ |
+| 既読レンジ | `data/vyline-readRanges-{accountId}.json` | ✅ |
+| メディアキャッシュ | `data/media-cache/{accountId}/...` | ✅ ディレクトリ単位 |
+| メッセージ詳細ログ | `data/logs/message-log-{accountId}.jsonl` | ✅ |
+| バックアップ | `data/backups/` (スナップショットに accountId を記録) | ✅ メタで分離 |
+| プラグイン有効状態 | `data/plugin-states.json` (`{ [accountId]: ... }`) | ✅ key 単位 |
+
+バックエンドの全ストレージ API は第一引数に `accountId` を受け、
+クライアント管理 (`clientManager`) もアカウントごとに client / ops loop / token watcher を持つ。
+ログアウト時はタイマー・ループを確実に停止する（perf ブランチで修正済み）。
+
+## 未達成（計画）
+
+README の目標に対し、以下が未実装。**移行は既存データのマイグレーションを伴うため
+段階的に行う**。
+
+### 1. アカウントレジストリ
+
+```txt
+data/accounts.json
+{
+  "activeAccountId": "main",
+  "accounts": [
+    { "accountId": "main", "displayName": "Main", "createdAt": "...", "lastUsedAt": "..." }
+  ]
+}
+```
+
+- raw MID は永続化しない（表示名はローカル付名のみ）
+- ログへ raw MID を出さない
+
+### 2. ディレクトリ分離
+
+```txt
+data/accounts/<safe-account-id>/
+  session/ storage/ cache/ media/ db/ logs/ backup/
+```
+
+- `<safe-account-id>` は MID をそのまま使わず hash / sanitized id を使用
+- 移行時は既存 `*-main.json` 等を取り込み、旧ファイルは読み取り互換のため一定期間残す
+
+### 3. アカウント切替の完全性
+
+現状もクライアント単位で分離されているが、以下を明示テストする必要がある:
+
+- 切替中に前アカウントの UI state / メディア URL が残らないこと
+- 切替中の送信が誤って前アカウントで実行されないこと
+- バックアップ復元が別アカウントに混ざらないこと
+
+### 4. 公開 API の account スコープ
+
+公開 REST API (/v1) はすでに `/accounts/{accountId}/...` 形式。
+プラグイン API も同様に account スコープ付き（plugin-foundation で実装済み）。
+
+## マイグレーション方針（将来）
+
+1. accounts.json 導入（既存 accountId をそのまま登録・挙動変更なし）
+2. 新規データの書き込み先を `accounts/<id>/` へ（読み込みは旧パスフォールバック）
+3. 起動時に旧フラットファイルを移行する one-shot migration コマンド
+4. フォールバック削除（破壊的変更・メジャーアップデートで実施）

--- a/docs/development.md
+++ b/docs/development.md
@@ -7,7 +7,7 @@
 ## セットアップ
 
 ```powershell
-# Bun (未インストール時)
+# Bun 1.4 以上 (推奨環境・engines で強制はしない)
 # https://bun.sh
 
 git clone <repo>

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -80,8 +80,7 @@ A. まず `domain/`、次に `lineService`、最後に `api/line.ts`。辞書も
 **Q. 通話は？**  
 A. backend の `acquireRoute` はあるが UI はダミー。触らない。
 
-**Q. Nezu BOT inbox は？**  
-A. エージェントは毎ターン `bun tools/nezu-bot/pollInbox.ts --json` を確認する（[tools/nezu-bot-agent.md](./tools/nezu-bot-agent.md)）。
+
 
 ---
 

--- a/null
+++ b/null
@@ -1,5 +1,0 @@
-Get-ChildItem: 
-Line |
-   4 |  ls "E:\projects\Vyline\Vyline\backend\src\auth\" 2>null || ls "E:\pro …
-     |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-     | Cannot find path 'E:\projects\Vyline\Vyline\backend\src\auth\' because it does not exist.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "vyline",
   "version": "0.5.1-beta",
   "private": true,
+  "engines": {
+    "bun": ">=1.4.0"
+  },
   "workspaces": [
     "Vyline/packages/*",
     "Vyline/apps/*",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "vyline:extract-e2ee": "bun Vyline/packages/protocol/src/tools/extractDesktopE2EEKeys.ts",
     "vyline:decrypt-edb": "bun Vyline/packages/protocol/src/tools/decryptDesktopEdb.ts",
     "vyline:call-test": "bun Vyline/backend/src/tools/callTest.ts",
-    "vyline:get-edited-json": "bun scripts/getEditedMessageJson.ts"
+    "vyline:get-edited-json": "bun scripts/getEditedMessageJson.ts",
+    "postinstall": "git config core.hooksPath .githooks"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
+    "@types/bun": "^1.4.0",
     "concurrently": "^9.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "vyline:decrypt-edb": "bun Vyline/packages/protocol/src/tools/decryptDesktopEdb.ts",
     "vyline:call-test": "bun Vyline/backend/src/tools/callTest.ts",
     "vyline:get-edited-json": "bun scripts/getEditedMessageJson.ts",
+    "test:media": "bun scripts/sendTestMediaBatch.ts",
     "postinstall": "git config core.hooksPath .githooks"
   },
   "devDependencies": {

--- a/scripts/sendTestMediaBatch.ts
+++ b/scripts/sendTestMediaBatch.ts
@@ -1,0 +1,118 @@
+/**
+ * scripts/sendTestMediaBatch.ts — テスト先への複数画像送信スニペット
+ *
+ * 使い方:
+ *   bun scripts/sendTestMediaBatch.ts [--chat <chatMid>] [--account main] [--n 3]
+ *
+ * 既定の送信先は AGENTS.md 許可のテストグループのみ。実グループ・実友だちには送らないこと。
+ * 生成画像は実行ごとにランダム色の PNG。
+ */
+
+import { writeFileSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const APPROVED_TEST_CHATS = new Set([
+  "c1efe9d6cf1848350bc91848a8a29963e", // うがうがうー
+  "u81c530b68cc2efdd36911d214bd5f084", // ねずBOT
+  "u7c6ea9ca829a8dd6249015f79e53a703", // ClockAngel（テスト垢）
+]);
+
+function arg(name: string, fallback: string): string {
+  const i = process.argv.indexOf(`--${name}`);
+  return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback;
+}
+
+/** 単色 PNG を生成する（依存なし） */
+function solidPng(r: number, g: number, b: number, size = 64): Buffer {
+  const w = size;
+  const h = size;
+  const stride = 1 + w * 3;
+  const raw = Buffer.alloc(h * stride);
+  for (let y = 0; y < h; y++) {
+    raw[y * stride] = 0;
+    for (let x = 0; x < w; x++) {
+      const o = y * stride + 1 + x * 3;
+      raw[o] = r;
+      raw[o + 1] = g;
+      raw[o + 2] = b;
+    }
+  }
+  const crcTable: number[] = [];
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    crcTable[n] = c >>> 0;
+  }
+  const crc32 = (buf: Buffer): number => {
+    let c = 0xffffffff;
+    for (const byte of buf) c = crcTable[(c ^ byte) & 0xff] ^ (c >>> 8);
+    return (c ^ 0xffffffff) >>> 0;
+  };
+  const chunk = (type: string, data: Buffer): Buffer => {
+    const len = Buffer.alloc(4);
+    len.writeUInt32BE(data.length);
+    const td = Buffer.concat([Buffer.from(type), data]);
+    const crc = Buffer.alloc(4);
+    crc.writeUInt32BE(crc32(td));
+    return Buffer.concat([len, td, crc]);
+  };
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(w, 0);
+  ihdr.writeUInt32BE(h, 4);
+  ihdr[8] = 8; // bit depth
+  ihdr[9] = 2; // RGB
+  return Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    chunk("IHDR", ihdr),
+    chunk("IDAT", raw),
+    chunk("IEND", Buffer.alloc(0)),
+  ]);
+}
+
+const account = arg("account", "main");
+const chatMid = arg("chat", "");
+const count = Math.min(Math.max(Number(arg("n", "3")), 1), 10);
+
+if (!chatMid || !APPROVED_TEST_CHATS.has(chatMid)) {
+  console.error(
+    `--chat には許可されたテスト先のみ指定できます:\n${[...APPROVED_TEST_CHATS].join("\n")}`,
+  );
+  process.exit(1);
+}
+
+const base = process.env.VYLINE_BACKEND_URL ?? "http://127.0.0.1:3001";
+const items = [];
+for (let i = 0; i < count; i++) {
+  const png = solidPng(
+    60 + Math.floor(Math.random() * 180),
+    60 + Math.floor(Math.random() * 180),
+    60 + Math.floor(Math.random() * 180),
+  );
+  items.push({
+    dataBase64: png.toString("base64"),
+    mimeType: "image/png",
+    filename: `vyline-test-${Date.now()}-${i}.png`,
+    mediaType: "image" as const,
+  });
+}
+
+const res = await fetch(`${base}/line/${account}/send-media-batch`, {
+  method: "POST",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify({ chatMid, items }),
+});
+const body = await res.text();
+console.log(`POST /send-media-batch -> ${res.status}`);
+console.log(body);
+
+// 履歴を確認して relation / IMAGE の有無を表示
+await new Promise((r) => setTimeout(r, 4000));
+const hist = await fetch(`${base}/line/${account}/messages/${chatMid}?limit=${count + 5}&force=1`);
+const data = (await hist.json()) as {
+  messages?: Array<{ id: string; contentType: string; relatedMessageId?: string }>;
+};
+const recent = (data.messages ?? []).sort((a, b) => Number(b.id) - Number(a.id)).slice(0, count);
+for (const m of recent) {
+  console.log(`${m.id} ${m.contentType} rel=${m.relatedMessageId ?? "-"}`);
+}


### PR DESCRIPTION
## Summary
- docs/developer-guide/multi-account.md: 現状の accountId 分離マップ（実装済み）と accounts.json・ディレクトリ分離・切替完全性の計画、段階的マイグレーション方針
- docs/README.md 索引に api/deployment/developer-guide の新規ドキュメントを追加

## Test
- docs のみ（pre-push hook 全チェック通過）