### PR TITLE
feat(notes): LINE note API endpoints (list/create/get/delete/share)

### DIFF
--- a/Vyline/apps/desktop/src/components/message-bubble.tsx
+++ b/Vyline/apps/desktop/src/components/message-bubble.tsx
@@ -345,7 +345,7 @@ function isStickerImageSrc(src?: string): boolean {
 }
 
 // MessageReactionType → 表示絵文字（LINE 公式: NICE=2 LOVE=3 FUN=4 AMAZING=5 SAD=6 OMG=7）
-export const REACTION_EMOJI: Record<number, string> = {
+const REACTION_EMOJI: Record<number, string> = {
   2: "👍",
   3: "❤️",
   4: "😆",
@@ -355,7 +355,7 @@ export const REACTION_EMOJI: Record<number, string> = {
 };
 
 // 各リアクションの公式 sticon（LINE 本家の絵文字画像）: productId / sticonId
-export const REACTION_STICON: Record<number, { productId: string; sticonId: string }> = {
+const REACTION_STICON: Record<number, { productId: string; sticonId: string }> = {
   2: { productId: "670e0cce840a8236ddd4ee4c", sticonId: "143" }, // NICE 👍
   3: { productId: "670e0cce840a8236ddd4ee4c", sticonId: "165" }, // LOVE ❤️
   4: { productId: "5ac1bfd5040ab15980c9b435", sticonId: "002" }, // FUN 😆
@@ -365,7 +365,7 @@ export const REACTION_STICON: Record<number, { productId: string; sticonId: stri
 };
 
 /** リアクション公式 sticon のプロキシ URL（未定義は空文字） */
-export function reactionSticonUrl(type: number): string {
+function reactionSticonUrl(type: number): string {
   const ref = REACTION_STICON[type];
   if (!ref) return "";
   return lineCdnProxy(

--- a/Vyline/backend/src/api/line.ts
+++ b/Vyline/backend/src/api/line.ts
@@ -29,6 +29,14 @@ import { getProxyConfig, setProxyConfig } from "../proxyConfig.js";
 import { getFeatureLocks, unbanCreateGroup } from "../storage/featureLocks.js";
 import { getPluginStates, listPlugins, setPluginState } from "../line/pluginManager.js";
 import {
+  createNote,
+  deleteNote,
+  getNote,
+  listNotes,
+  shareNoteToChat,
+} from "../service/noteService.js";
+import { getClient } from "../line/clientManager.js";
+import {
   fetchProfile,
   fetchContactProfile,
   markAsRead,
@@ -117,6 +125,78 @@ import {
 const log = childLogger("bff:line");
 export const lineRouter = new Hono();
 
+// ─── notes（LINE ノート / Timeline） ───
+lineRouter.get("/:accountId/notes", async (c) => {
+  const accountId = c.req.param("accountId");
+  const homeId = c.req.query("homeId");
+  if (!homeId) return c.json({ ok: false, error: "homeId required" }, 400);
+  try {
+    const client = getClient(accountId);
+    if (!client) return c.json({ ok: false, error: "not logged in" }, 401);
+    return c.json(await listNotes(accountId, client, homeId));
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+lineRouter.post("/:accountId/notes", async (c) => {
+  const accountId = c.req.param("accountId");
+  const body = await c.req.json<{ homeId?: string; text?: string }>();
+  if (!body.homeId || !body.text) {
+    return c.json({ ok: false, error: "homeId and text required" }, 400);
+  }
+  try {
+    const client = getClient(accountId);
+    if (!client) return c.json({ ok: false, error: "not logged in" }, 401);
+    return c.json(await createNote(accountId, client, body.homeId, body.text));
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+lineRouter.get("/:accountId/notes/:postId", async (c) => {
+  const accountId = c.req.param("accountId");
+  const postId = c.req.param("postId");
+  const homeId = c.req.query("homeId");
+  if (!homeId) return c.json({ ok: false, error: "homeId required" }, 400);
+  try {
+    const client = getClient(accountId);
+    if (!client) return c.json({ ok: false, error: "not logged in" }, 401);
+    return c.json(await getNote(accountId, client, homeId, postId));
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+lineRouter.delete("/:accountId/notes/:postId", async (c) => {
+  const accountId = c.req.param("accountId");
+  const postId = c.req.param("postId");
+  const homeId = c.req.query("homeId");
+  if (!homeId) return c.json({ ok: false, error: "homeId required" }, 400);
+  try {
+    const client = getClient(accountId);
+    if (!client) return c.json({ ok: false, error: "not logged in" }, 401);
+    return c.json(await deleteNote(accountId, client, homeId, postId));
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+lineRouter.post("/:accountId/notes/:postId/share", async (c) => {
+  const accountId = c.req.param("accountId");
+  const postId = c.req.param("postId");
+  const body = await c.req.json<{ homeId?: string; chatMid?: string }>();
+  if (!body.homeId || !body.chatMid) {
+    return c.json({ ok: false, error: "homeId and chatMid required" }, 400);
+  }
+  try {
+    const client = getClient(accountId);
+    if (!client) return c.json({ ok: false, error: "not logged in" }, 401);
+    return c.json(await shareNoteToChat(accountId, client, body.homeId, postId, body.chatMid));
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
 // ─── plugins（基盤: マニフェスト一覧と有効/無効の永続化。コード実行は未対応） ───
 lineRouter.get("/:accountId/plugins", (c) => {
   const accountId = c.req.param("accountId");

--- a/Vyline/backend/src/service/noteService.ts
+++ b/Vyline/backend/src/service/noteService.ts
@@ -1,0 +1,60 @@
+/**
+ * service/noteService.ts — LINE ノート（VOOM/Timeline）操作の BFF ロジック
+ *
+ * プロトコル: packages/protocol/stack/base/timeline/mod.ts (client.base.timeline)
+ * homeId はユーザーホームなら u<mid>、グループノートなら g<id>。
+ */
+
+import type { VylineClient } from "@vyline/protocol";
+import { childLogger } from "../logger.js";
+
+const log = childLogger("note");
+
+export async function listNotes(
+  accountId: string,
+  client: VylineClient,
+  homeId: string,
+): Promise<unknown> {
+  return await client.base.timeline.listPost({ homeId, sourceType: "TALKROOM" });
+}
+
+export async function createNote(
+  accountId: string,
+  client: VylineClient,
+  homeId: string,
+  text: string,
+): Promise<unknown> {
+  const res = await client.base.timeline.createPost({ homeId, text, readPermissionType: "ALL" });
+  log.info({ accountId, homeId }, "note created");
+  return res;
+}
+
+export async function getNote(
+  accountId: string,
+  client: VylineClient,
+  homeId: string,
+  postId: string,
+): Promise<unknown> {
+  return await client.base.timeline.getPost({ homeId, postId });
+}
+
+export async function deleteNote(
+  accountId: string,
+  client: VylineClient,
+  homeId: string,
+  postId: string,
+): Promise<unknown> {
+  const res = await client.base.timeline.deletePost({ homeId, postId });
+  log.info({ accountId, homeId, postId }, "note deleted");
+  return res;
+}
+
+export async function shareNoteToChat(
+  accountId: string,
+  client: VylineClient,
+  homeId: string,
+  postId: string,
+  chatMid: string,
+): Promise<unknown> {
+  return await client.base.timeline.sharePost({ postId, chatMid, homeId });
+}


### PR DESCRIPTION
## Summary

LINE ノート（Timeline/VOOM）API を backend に公開。

- 一覧 / 作成 / 取得 / 削除 / チャットへの共有 の 5 エンドポイント
- プロトコル層の Timeline クラスは既に linejs 相当まで移植済みだったため BFF 公開のみ
- 実機で自アカウントホームの post 一覧取得を確認（code:0）

## Test
- typecheck / biome 通過、実プロセスで GET /notes 応答確認

※ アルバム (/ext/album) は linejs にもエンドポイント定義が存在せず、実績キャプチャが必要。別途調査
