### PR TITLE
Fix/ci docker build loose types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,12 @@ jobs:
           bun-version: latest
       - run: bun install
       - run: bun run build
+
+  docker-build:
+    name: Docker build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - run: docker build --pull -t vyline .

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY Vyline/packages/types/package.json Vyline/packages/types/
 COPY Vyline/packages/protocol/package.json Vyline/packages/protocol/
 COPY Vyline/packages/line-types/package.json Vyline/packages/line-types/
 COPY Vyline/packages/loose-types/package.json Vyline/packages/loose-types/
-RUN bun install --frozen-lockfile || bun install
+RUN bun install --frozen-lockfile --ignore-scripts
 
 FROM oven/bun:1 AS build
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ COPY Vyline/backend/package.json Vyline/backend/
 COPY Vyline/packages/types/package.json Vyline/packages/types/
 COPY Vyline/packages/protocol/package.json Vyline/packages/protocol/
 COPY Vyline/packages/line-types/package.json Vyline/packages/line-types/
+COPY Vyline/packages/loose-types/package.json Vyline/packages/loose-types/
 RUN bun install --frozen-lockfile || bun install
 
 FROM oven/bun:1 AS build

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ COPY Vyline/packages/types/package.json Vyline/packages/types/
 COPY Vyline/packages/protocol/package.json Vyline/packages/protocol/
 COPY Vyline/packages/line-types/package.json Vyline/packages/line-types/
 COPY Vyline/packages/loose-types/package.json Vyline/packages/loose-types/
+COPY Vyline/packages/plugin-sdk/package.json Vyline/packages/plugin-sdk/
 RUN bun install --frozen-lockfile --ignore-scripts
 
 FROM oven/bun:1 AS build


### PR DESCRIPTION
## Summary

Dockerイメージがworkspace依存の不足によりビルドできない問題を修正します。
同じDockerビルドをGitHub Actionsで継続的に検証します。

## Changes

- CIに `docker build --pull -t vyline .` を実行するDockerビルドジョブを追加
- CIのcheckoutでsubmoduleを再帰的に取得
- Docker依存ステージへ `loose-types` と `plugin-sdk` のpackage manifestを追加
- Docker内では不要なGitフック用install scriptを抑止

## Test Plan

- [x] `bun run typecheck` が通る
- [x] `bun run dev` で起動確認
- [x] `docker build --pull -t vyline .` が通る
- [x] `vyline:latest` イメージが正常に生成される

## Screenshots

UI変更なし
