### PR TITLE
chore: bump version to 0.6.0-beta + 自動 bump スクリプト

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -267,9 +267,23 @@ bun run vyline:update  # Desktop を最新版へ更新（root 直下でも可）
 
 - バージョン形式: セマンティックバージョン（`X.Y.Z` または `X.Y.Z-beta`）
 - beta は非公開テスト段階。public リリース前に外す
-- `CHANGELOG.md` にも同バージョンのエントリを追加
-- リリース時は `docs/distribution.md` のリリースチェックリストに従う
-- `UPDATE_NOTES.items` は変更内容を箇条書きで記載（ユーザーが起動時に確認する内容）
+- リリース時は Git タグ **`v<version>`**（例: `v0.6.0-beta`）を作成する。タグ = 4 箇所のバージョン + CHANGELOG エントリが揃ったコミットを指す
+- 破壊的変更 → major、機能追加 → minor、修正のみ → patch。Beta 期間中は `-beta` 接尾辞を維持
+
+### 自動 bump（AI・人間共通の手順）
+
+```powershell
+bun run bump -- 0.7.0        # 指定バージョンへ一括更新（4 箇所 + UPDATE_NOTES.title のバージョン部分）
+bun run bump -- minor        # 相対指定も可 (major / minor / patch)
+bun run bump -- 0.7.0 --tag  # git tag v0.7.0 まで自動作成
+```
+
+スクリプト (`scripts/bump-version.ts`) が機械的な置換を行う。エージェントがバージョンを上げるときは手動編集ではなくこのスクリプトを使い、残りを仕上げる:
+
+1. `UPDATE_NOTES.items` を今回の変更内容に書き換え（ユーザーが起動時に確認する内容・古い内容は削除）
+2. `CHANGELOG.md` に同バージョンのエントリを追加（Unreleased を統合）
+3. README 冒頭 NOTE の「現在のバージョン」と「状態」行を目視確認
+4. リリース時は `docs/distribution.md` のリリースチェックリストに従う
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,51 +46,47 @@
 
 ---
 
-## [Unreleased] — 2026-08-19 — Keepメモ, 背景, 通話状態, 法的対応
+## [0.6.0-beta] — 2026-08-23 — Backup & ログ & セルフホスト
 
 ### 新機能
 
-- **Keepメモ** — 自分自身のトーク（`mid === myMid`）を `isSelf` フラグで判定し「Keepメモ」と表示。公式アイコン（IconMemo）を使用し、プロフィール詳細の自動取得・共通グループ・ブロック操作をスキップ
-- **プロフィール背景の表示** — 相手のプロフィール背景（VOOM home API から取得）をトーク背景に表示。プロフィール描画時にチャットの `backgroundUrl` もストアへ伝搬
-- **グループ通話状態** — グループヘッダーに「通話中」バッジを 15 秒ポーリングで表示（`GET /call/group-status`）
-- **共通グループの高速化** — プロフィール・メンバー描画時に VylineCache 一括読みで共通グループを取得（RPC なし）
-- **送信取り消しエラー表示** — 可能時間超過（`MESSAGE_NOT_DESTRUCTIBLE` / message too old）を専用通知「取り消し失敗(送信取り消し可能な時間を過ぎています)」で表示
-- **利用規約・免責同意ゲート** — ログイン直後に ToS 同意画面を表示し、同意しない限り同期・通信・表示を含めアプリは一切動作しない。skip 等の想定外手法も同意とみなす（localStorage `vyline:tos-consent-v1`）
-
-### 修正
-
-- リアクション・公式画像 / カスタム（sticon）対応は調査中（次ラウンド）
-- **既読高速化ウォーターマーク** — 相手の最終既読地点をローカルキャッシュし、それ以前の自分のメッセージを全て既読フラグ付け。毎回の既読 API 取得を 30s TTL キャッシュで避けて高速化。既読地点は `getMessageReadRange`（10s タイムアウト）で取得し、キャッシュが有効期限切れまたは read イベント時に再取得。
-- **deltaAfterId 最適化** — `fetchMessagesSince` / `pollMessagesDelta` で `afterMessageId` が既知の場合、`getMessageBoxes` RPC（最大 5s）を省略し合成カーソルで最新を取得。リアクション表示高速化。
-- **受信ポーリング高速化** — `useVylineSync.ts` でイベントポーリング間隔を 4s/12s/60s から **2s/8s/60s** へ変更。ポーリングタイマーを分離し、slow delta 完了を待たずに即座に次の poll をスケジュール。
-
-### その他
-
-- ブロック操作の UI 統合 — サイドバー・プロフィール・設定からブロック/ブロック解除を実行可能。ブロック中の友だちへの送信を UI および API レベルで防止。
-
-## [Unreleased] — 2026-08-18 — Rebranding, Backup & Logging
-
-### 新機能
-
-- **VylineBackup** — トーク履歴・メディアのスナップショットをサーバーに保存（`data/backups/`）。設定 > VylineBackup から作成・復元・削除。復元は「すべて / チャット選択」「メディア含む / テキストのみ」を選択可能（[docs](docs/plugin-api.md 参照、バックアップは [selfhosting.md](docs/selfhosting.md) の `data/` ボリュームに永続化）
+- **VylineBackup** — トーク履歴・メディアのスナップショットをサーバーに保存（`data/backups/`）。設定 > VylineBackup から作成・復元・削除。復元は「すべて / チャット選択」「メディア含む / テキストのみ」を選択可能（バックアップは [selfhosting.md](docs/selfhosting.md) の `data/` ボリュームに永続化）
 - **チャット詳細ログ** — チャット内容・アナウンス（CHATEVENT）をタイミング付き JSONL で記録（`data/logs/message-log-<account>.jsonl`）。画像・動画・音声・ファイル・スタンプのメディア情報も記録。設定 > 詳細・復元 > デバッグログで閲覧
-- **Nezu→Vy リブランディング** — パッケージ名 `@vyline/nezuline` → `@vyline/protocol`、`NezuClient`/`NezuUpdater`/`NezuCache`/`NezuStorage` → `Vyline*`。旧 `nezu-*` データ・`nezuline` ディレクトリからの自動移行
-- **予定機能を docs に記載** — プラグイン API・オープンチャット（実装未確定）を [docs/tasks/STATUS.md](docs/tasks/STATUS.md) / [docs/plugin-api.md](docs/plugin-api.md) に整理
-
-## [Unreleased] — 2026-08-18 — Self-host & Stability
-
-### 新機能
-
 - **セルフホスト対応（Docker）** — バックエンドが本番フロントビルドを同一オリジンで配信。`docker compose up -d --build` のワンコマンドで自宅サーバーに Vyline を構築可能（[docs/selfhosting.md](docs/selfhosting.md)）
 - **メディアのサーバー側キャッシュ** — 画像・動画を `data/media-cache/` に永続化。端末を変えても過去の画像が残る
 - **環境変数の拡充** — `VYLINE_HOST` / `VYLINE_CORS_ORIGIN` / `VYLINE_STATIC_DIR` / `VYLINE_MEDIA_CACHE_DIR` / `VYLINE_CDN_CACHE_DIR`。Docker ボリュームで全データを永続化
 - **アンケート / あみだくじ / イベント作成の自動化** — 作成後に Flex メッセージを自動送信（投票・結果共有・スケジュール共有ボタン付き）
 - **ブロック表示** — ブロック済み連絡先をチャット一覧に赤丸バッジで表示
+- **複数画像の同時送信** — 複数画像を選択して個別の IMAGE メッセージとして送信し、チャット内でグルーピング表示。コンボスタンプ（複数スタンプ連投）にも対応
+- **FILE メッセージ描画** — ファイル添付メッセージの表示に対応（未知の content type は安全にガード）
+- **Keepメモ** — 自分自身のトーク（`mid === myMid`）を `isSelf` フラグで判定し「Keepメモ」と表示。公式アイコン（IconMemo）を使用し、プロフィール詳細の自動取得・共通グループ・ブロック操作をスキップ
+- **プロフィール背景の表示** — 相手のプロフィール背景（VOOM home API から取得）をトーク背景に表示。プロフィール描画時にチャットの `backgroundUrl` もストアへ伝搬
+- **グループ通話状態** — グループヘッダーに「通話中」バッジを 15 秒ポーリングで表示（`GET /call/group-status`）
+- **共通グループの高速化** — プロフィール・メンバー描画時に VylineCache 一括読みで共通グループを取得（RPC なし）
+- **リアクションキャッシュ** — リアクション取得をキャッシュしてメッセージ一覧の再描画を高速化
+- **送信取り消しエラー表示** — 可能時間超過（`MESSAGE_NOT_DESTRUCTIBLE` / message too old）を専用通知「取り消し失敗(送信取り消し可能な時間を過ぎています)」で表示
+- **利用規約・免責同意ゲート** — ログイン直後に ToS 同意画面を表示し、同意しない限り同期・通信・表示を含めアプリは一切動作しない。skip 等の想定外手法も同意とみなす（localStorage `vyline:tos-consent-v1`）
+- **Nezu→Vy リブランディング** — パッケージ名 `@vyline/nezuline` → `@vyline/protocol`、`NezuClient`/`NezuUpdater`/`NezuCache`/`NezuStorage` → `Vyline*`。旧 `nezu-*` データ・`nezuline` ディレクトリからの自動移行
+- **予定機能を docs に記載** — プラグイン API・オープンチャット（実装未確定）を [docs/tasks/STATUS.md](docs/tasks/STATUS.md) / [docs/plugin-api.md](docs/plugin-api.md) に整理
+
+### 改善
+
+- **既読高速化ウォーターマーク** — 相手の最終既読地点をローカルキャッシュし、それ以前の自分のメッセージを全て既読フラグ付け。毎回の既読 API 取得を 30s TTL キャッシュで避けて高速化。既読地点は `getMessageReadRange`（10s タイムアウト）で取得し、キャッシュが有効期限切れまたは read イベント時に再取得
+- **deltaAfterId 最適化** — `fetchMessagesSince` / `pollMessagesDelta` で `afterMessageId` が既知の場合、`getMessageBoxes` RPC（最大 5s）を省略し合成カーソルで最新を取得。リアクション表示高速化
+- **受信ポーリング高速化** — `useVylineSync.ts` でイベントポーリング間隔を 4s/12s/60s から **2s/8s/60s** へ変更。ポーリングタイマーを分離し、slow delta 完了を待たずに即座に次の poll をスケジュール
+- **高画質画像送信** — 表示タブの「高画質で画像送信」トグルで圧縮せず元画質のまま送信可能
 
 ### 修正
 
 - アンケート作成・投票の `206` エラー（LINE 公式 LIFF API の要求ヘッダ不足）を修正
 - スケジュール共有でグループ名照合に失敗する問題を `groups/{chatMid}` API 直接取得に変更
+- ブロックリストをキャッシュ + background キュー + 8s タイムアウトで取得し、504 を回避
+- `useVirtualList` の実測高さ変更時にオフセットを再計算するよう修正
+
+### その他
+
+- **ブロック操作の UI 統合** — サイドバー・プロフィール・設定からブロック/ブロック解除を実行可能。ブロック中の友だちへの送信を UI および API レベルで防止
+- 既定のデバイスモードを IOSIPAD に統一（プロトコル実装と整合）
 
 ## [0.4.0-beta] — 2026-08-17 — Mention & Media
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <p align="center">
-  <img alt="version" src="https://img.shields.io/badge/version-0.5.1--beta-a78bfa?style=flat-square" />
+  <img alt="version" src="https://img.shields.io/badge/version-0.6.0--beta-a78bfa?style=flat-square" />
   <img alt="license" src="https://img.shields.io/badge/license-MIT-22c55e?style=flat-square" />
   <img alt="runtime" src="https://img.shields.io/badge/runtime-Bun-f472b6?style=flat-square" />
   <img alt="backend" src="https://img.shields.io/badge/backend-Hono-e879f9?style=flat-square" />
@@ -31,7 +31,7 @@
 > Vyline は **LINE 非公式・未承認**のサードパーティクライアントです。LINE 株式会社および LY Corporation とは関係ありません。利用規約への抵触やアカウント停止を含むリスクを理解したうえで、自己責任で使用してください。
 
 > [!NOTE]
-> 2026年8月20日に Beta 0.5.0 として公開を開始しました。現在のバージョンは **Beta 0.5.1** です。Beta 版のため、仕様変更・不具合・データ損失が発生する可能性があります。
+> 2026年8月20日に Beta 0.5.0 として公開を開始しました。現在のバージョンは **Beta 0.6.0** です。Beta 版のため、仕様変更・不具合・データ損失が発生する可能性があります。
 
 ---
 
@@ -46,7 +46,7 @@
 | 対象 | UI を自分好みに調整したいユーザー、開発者、セルフホスト利用者 |
 | 特徴 | 自前プロトコル、VyTheme、公開 API、ローカル優先のデータ管理 |
 | 技術 | React + Vite / Hono on Bun / TypeScript / Thrift |
-| 状態 | Beta 0.5.1 |
+| 状態 | Beta 0.6.0 |
 | ライセンス | MIT |
 
 ## 主な機能
@@ -339,6 +339,30 @@ bun run dev
 ```
 
 既存のログイン状態は維持されます。詳細な変更内容は [CHANGELOG.md](CHANGELOG.md) を参照してください。
+
+---
+
+## バージョニング
+
+Vyline はセマンティックバージョン（`X.Y.Z`、Beta 期間中は `X.Y.Z-beta`）を採用します。リリース時は Git タグ `v<version>`（例: `v0.6.0-beta`）を作成します。
+
+バージョンは次の **4 箇所を同一に** 保つ必要があります:
+
+| 場所 | フィールド |
+| --- | --- |
+| `package.json`（ルート） | `version` |
+| `Vyline/apps/desktop/package.json` | `version` |
+| `Vyline/apps/desktop/src/lib/store.ts` | `UPDATE_NOTES.version`（+ `title` / `items` はユーザー向け更新内容） |
+| `README.md` | バッジの `version-...` |
+
+手動更新の手間を避けるため、bump スクリプトで一括更新できます:
+
+```bash
+bun run bump -- 0.7.0        # 指定バージョンへ一括更新
+bun run bump -- patch         # 0.6.0-beta → 0.6.1-beta のように相対指定も可 (major / minor / patch)
+```
+
+スクリプトは上記のバージョン箇所と README バッジを自動で書き換えます。`UPDATE_NOTES.items` と CHANGELOG エントリはリリースごとに手動（または AI エージェント）で追記します。詳細は [AGENTS.md](AGENTS.md) の「バージョン管理」を参照してください。
 
 ---
 

--- a/Vyline/apps/desktop/package.json
+++ b/Vyline/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyline/desktop",
-  "version": "0.5.1-beta",
+  "version": "0.6.0-beta",
   "private": true,
   "type": "module",
   "scripts": {

--- a/Vyline/apps/desktop/src/lib/store.ts
+++ b/Vyline/apps/desktop/src/lib/store.ts
@@ -279,12 +279,16 @@ function messagePreview(m: Message): string {
 }
 
 export const UPDATE_NOTES = {
-  version: "0.5.1-beta",
-  title: "Vyline 0.5.1-beta — メッセージ編集UI + プッシュ通知切替",
+  version: "0.6.0-beta",
+  title: "Vyline 0.6.0-beta — Backup & ログ & セルフホスト",
   items: [
-    "メッセージ編集UIを追加",
-    "プッシュ通知のON/OFF切替を設定に追加",
-    "バージョン表記を 0.5.1-beta に統一",
+    "VylineBackup: トーク履歴・メディアのスナップショット作成/復元/削除",
+    "チャット詳細ログ（JSONL）を追加（設定 > 詳細・復元 > デバッグログ）",
+    "セルフホスト対応（Docker Compose）+ メディアのサーバー側キャッシュ",
+    "複数画像の同時送信とグルーピング表示、FILE メッセージ描画",
+    "Keepメモ、プロフィール背景表示、通話中バッジ、リアクションキャッシュ高速化",
+    "リブランディング: @vyline/protocol（旧 @vyline/nezuline）、Nezu* → Vyline*",
+    "利用規約・免責同意ゲートをログイン直後に追加",
   ],
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vyline",
-  "version": "0.5.1-beta",
+  "version": "0.6.0-beta",
   "private": true,
   "engines": {
     "bun": ">=1.4.0"
@@ -33,6 +33,7 @@
     "test:media": "bun scripts/sendTestMediaBatch.ts",
     "test:api": "bun scripts/apiSmokeTest.ts",
     "update": "git submodule update --init --recursive && git pull --ff-only && bun install && bun run build",
+    "bump": "bun scripts/bump-version.ts",
     "postinstall": "git config core.hooksPath .githooks"
   },
   "devDependencies": {

--- a/scripts/bump-version.ts
+++ b/scripts/bump-version.ts
@@ -1,0 +1,86 @@
+#!/usr/bin/env bun
+/**
+ * バージョン一括更新スクリプト。
+ *
+ * 使い方:
+ *   bun run bump -- 0.7.0        # 指定バージョンへ更新
+ *   bun run bump -- minor        # 現在のバージョンから相対指定 (major / minor / patch)
+ *   bun run bump -- 0.7.0 --tag  # 更新後に git tag v<version> を作成
+ *
+ * 更新対象（AGENTS.md「バージョン管理」参照）:
+ *   - package.json (ルート)
+ *   - Vyline/apps/desktop/package.json
+ *   - Vyline/apps/desktop/src/lib/store.ts の UPDATE_NOTES.version / title
+ *   - README.md のバッジ
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+
+const args = process.argv.slice(2).filter((a) => a !== "--");
+const tag = args.includes("--tag");
+const spec = args.find((a) => !a.startsWith("--"));
+
+if (!spec) {
+  console.error("使い方: bun run bump -- <version|major|minor|patch> [--tag]");
+  process.exit(1);
+}
+
+const ROOT = new URL("..", import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1");
+
+function read(p: string) {
+  return readFileSync(`${ROOT}/${p}`, "utf8");
+}
+function write(p: string, content: string) {
+  writeFileSync(`${ROOT}/${p}`, content);
+}
+
+const rootPkg = JSON.parse(read("package.json")) as { version: string };
+const current = rootPkg.version;
+
+let next: string;
+if (["major", "minor", "patch"].includes(spec)) {
+  const m = current.match(/^(\d+)\.(\d+)\.(\d+)(-.*)?$/);
+  if (!m) throw new Error(`現在のバージョンが不正です: ${current}`);
+  const [, maj, min, pat, suffix = ""] = m;
+  const bumped = { major: [+maj + 1, 0, 0], minor: [+maj, +min + 1, 0], patch: [+maj, +min, +pat + 1] }[spec as "major" | "minor" | "patch"];
+  next = `${bumped[0]}.${bumped[1]}.${bumped[2]}${suffix}`;
+} else {
+  next = spec;
+}
+
+if (!/^\d+\.\d+\.\d+(-[\w.]+)?$/.test(next)) {
+  throw new Error(`バージョン形式が不正です: ${next} (例: 1.2.3 / 1.2.3-beta)`);
+}
+
+// 1. package.json x2
+for (const p of ["package.json", "Vyline/apps/desktop/package.json"]) {
+  write(p, read(p).replace(/"version": "[^"]+"/, `"version": "${next}"`));
+}
+
+// 2. store.ts UPDATE_NOTES (version と title 内のバージョン部分のみ置換、title 後半は保持)
+const storePath = "Vyline/apps/desktop/src/lib/store.ts";
+let store = read(storePath);
+store = store.replace(
+  /(export const UPDATE_NOTES = \{\s*version: ")[^"]+(",\s*title: "Vyline )([^"]*?)((?:\d[\w.-]*)")/,
+  `$1${next}$2${next}$4`,
+);
+write(storePath, store);
+
+// 3. README badge (shields.io は `-` を `--` にエスケープ)
+const readmePath = "README.md";
+write(
+  readmePath,
+  read(readmePath).replace(/badge\/version-[\w.-]+-a78bfa/, `badge/version-${next.replaceAll("-", "--")}-a78bfa`),
+);
+
+console.log(`バージョンを ${current} → ${next} に更新しました。`);
+console.log("次の手動作業:");
+console.log(`  - ${storePath}: UPDATE_NOTES.title / items を今回の変更内容に合わせて編集`);
+console.log("  - CHANGELOG.md: 新バージョンのエントリを追記");
+console.log("  - README.md: 冒頭 NOTE の「現在のバージョン」と「状態」行を確認");
+
+if (tag) {
+  const proc = Bun.spawnSync(["git", "tag", `v${next}`]);
+  if (proc.exitCode === 0) console.log(`タグ v${next} を作成しました。`);
+  else console.error("git tag に失敗しました。");
+}


### PR DESCRIPTION
## 変更内容

バージョンを **0.5.1-beta → 0.6.0-beta** に更新し、以後のバージョン運用を自動化しました。

### バージョン更新 (4 箇所を統一)

| 場所 | 変更 |
| --- | --- |
| `package.json` (ルート) | `version: 0.6.0-beta` + `bump` スクリプト追加 |
| `Vyline/apps/desktop/package.json` | `version: 0.6.0-beta` |
| `Vyline/apps/desktop/src/lib/store.ts` | `UPDATE_NOTES.version / title / items` を 0.6.0-beta の内容に刷新 |
| `README.md` | バッジ + 冒頭 NOTE + 状態行を Beta 0.6.0 に更新 |

### UPDATE_NOTES の刷新

古い「メッセージ編集UI + プッシュ通知切替」から、0.5.1-beta 以降の変更（VylineBackup、チャット詳細ログ、Docker セルフホスト、複数画像送信、FILE 描画、Keepメモ、リアクションキャッシュ、リブランディング、ToS 同意ゲート）に書き換え。

### CHANGELOG.md

`[Unreleased]` 3 セクション (08-18 x2, 08-19) を `[0.6.0-beta] — 2026-08-23 — Backup & ログ & セルフホスト` エントリに統合。未記載だった複数画像送信・FILE 描画・リアクションキャッシュ・ブロックリスト 504 回避・useVirtualList 修正も追記。

### バージョニングの自動化

- 新規 `scripts/bump-version.ts`: `bun run bump -- <version|major|minor|patch> [--tag]` で 4 箇所 + UPDATE_NOTES.title を一括置換、`--tag` で `v<version>` タグ作成まで対応
- README に「バージョニング」セクション追加
- AGENTS.md「バージョン管理」に Git タグ (`v<version>`) の概念と自動 bump 手順を記載 → AI・人間どちらでも同一手順で bump 可能

## テスト確認結果

- [x] `bun run typecheck` 通過
- [x] pre-push hook (typecheck / biome / build) 通過
- [x] `bun run bump -- 0.6.0-beta` 実行で冪等性を確認（title 後半を保持するよう修正済み）
