### PR TITLE
feat: GitHub Pages で Swagger UI を公開

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,41 @@
+name: Deploy API Docs to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "openapi.yaml"
+      - "Vyline/backend/src/api/openapi.line.ts"
+      - "scripts/build-api-docs.ts"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - name: Build static docs
+        run: bun scripts/build-api-docs.ts dist-api-docs
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist-api-docs
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,5 @@ tools/data/
 # ── Backend runtime caches (never commit) ────────────────────────
 Vyline/backend/storage/cache/
 Vyline/backend/storage/saved-media/
+
+dist-api-docs/

--- a/docs/api/openapi.md
+++ b/docs/api/openapi.md
@@ -19,6 +19,14 @@ GET /openapi.yaml    公開 REST API の YAML
 GET /openapi/v1.yaml /openapi.yaml へのリダイレクト
 ```
 
+## GitHub Pages
+
+push to `main` 時に `.github/workflows/pages.yml` が静的ドキュメントを生成し、
+**https://nezumi0627.github.io/vyline/** へデプロイする。
+
+- 生成: `bun scripts/build-api-docs.ts <outdir>`（BFF spec を TS から JSON 化 + ルート `openapi.yaml` をコピー）
+- 手動実行も可（workflow_dispatch）
+
 Swagger UI は CDN からスクリプトを読み込むため、オフライン環境では `openapi.json` /
 `openapi.yaml` を直接確認すること。
 

--- a/scripts/build-api-docs.ts
+++ b/scripts/build-api-docs.ts
@@ -1,0 +1,47 @@
+/**
+ * scripts/build-api-docs.ts — GitHub Pages 用 API ドキュメント生成
+ *
+ * 出力先: <outdir>/
+ *   index.html     Swagger UI（2 spec 切替）
+ *   openapi.json   BFF (/line) spec — openapi.line.ts から生成
+ *   openapi.yaml   公開 REST API (/v1) spec — リポジトリルートからコピー
+ */
+
+import { copyFile, mkdir } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { lineOpenApiSpec } from "../Vyline/backend/src/api/openapi.line.js";
+
+const outDir = process.argv[2] ?? join(dirname(fileURLToPath(import.meta.url)), "..", "dist-api-docs");
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+await mkdir(outDir, { recursive: true });
+await Bun.write(join(outDir, "openapi.json"), JSON.stringify(lineOpenApiSpec, null, 2));
+await copyFile(join(root, "openapi.yaml"), join(outDir, "openapi.yaml"));
+await Bun.write(
+  join(outDir, "index.html"),
+  `<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <title>Vyline API Docs</title>
+    <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css" />
+  </head>
+  <body>
+    <div id="swagger"></div>
+    <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js" crossorigin></script>
+    <script>
+      SwaggerUIBundle({
+        urls: [
+          { name: "Public API (/v1)", url: "openapi.yaml" },
+          { name: "BFF API (/line)", url: "openapi.json" },
+        ],
+        dom_id: "#swagger",
+        deepLinking: true,
+      });
+    </script>
+  </body>
+</html>
+`,
+);
+console.log(`API docs generated at ${outDir}`);


### PR DESCRIPTION
## 変更内容

- \scripts/build-api-docs.ts\ — Pages 用静的ドキュメント生成スクリプト（BFF spec を openapi.line.ts から JSON 化、ルート openapi.yaml をコピー、Swagger UI の index.html を出力）
- \.github/workflows/pages.yml\ — push to main（spec 関連変更時）+ workflow_dispatch で GitHub Pages へデプロイ
- \docs/api/openapi.md\ — Pages URL と生成フローを追記
- \.gitignore\ — dist-api-docs/ を追加

## デプロイ先

https://nezumi0627.github.io/vyline/

※ 初回のみ Settings > Pages > Source を「GitHub Actions」に変更が必要

## テスト確認

- \un scripts/build-api-docs.ts\ で静的生成を検証済み（openapi.json / openapi.yaml / index.html が出力されること）
- \un run typecheck\ / \un run lint\ 通過（pre-push フックで実行）