### PR TITLE
fix: Swagger UI に standalone preset を追加

### DIFF
--- a/Vyline/backend/src/index.ts
+++ b/Vyline/backend/src/index.ts
@@ -118,19 +118,25 @@ function docsHtml(c: Context): Response {
     <meta charset="utf-8" />
     <title>Vyline API Docs</title>
     <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css" />
+    <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js" crossorigin></script>
+    <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-standalone-preset.js" crossorigin></script>
   </head>
   <body>
     <div id="swagger"></div>
-    <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js" crossorigin></script>
     <script>
-      SwaggerUIBundle({
-        urls: [
-          { name: "BFF API (/line)", url: "/openapi.json" },
-          { name: "Public API (/v1)", url: "/openapi.yaml" },
-        ],
-        dom_id: "#swagger",
-        deepLinking: true,
-      });
+      window.onload = () =>
+        SwaggerUIBundle({
+          urls: [
+            { name: "BFF API (/line)", url: "/openapi.json" },
+            { name: "Public API (/v1)", url: "/openapi.yaml" },
+          ],
+          "urls.primaryName": "BFF API (/line)",
+          dom_id: "#swagger",
+          deepLinking: true,
+          presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
+          plugins: [SwaggerUIBundle.plugins.DownloadUrl],
+          layout: "StandaloneLayout",
+        });
     </script>
   </body>
 </html>`;

--- a/scripts/build-api-docs.ts
+++ b/scripts/build-api-docs.ts
@@ -26,19 +26,25 @@ await Bun.write(
     <meta charset="utf-8" />
     <title>Vyline API Docs</title>
     <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css" />
+    <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js" crossorigin></script>
+    <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-standalone-preset.js" crossorigin></script>
   </head>
   <body>
     <div id="swagger"></div>
-    <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js" crossorigin></script>
     <script>
-      SwaggerUIBundle({
-        urls: [
-          { name: "Public API (/v1)", url: "openapi.yaml" },
-          { name: "BFF API (/line)", url: "openapi.json" },
-        ],
-        dom_id: "#swagger",
-        deepLinking: true,
-      });
+      window.onload = () =>
+        SwaggerUIBundle({
+          urls: [
+            { name: "Public API (/v1)", url: "openapi.yaml" },
+            { name: "BFF API (/line)", url: "openapi.json" },
+          ],
+          "urls.primaryName": "Public API (/v1)",
+          dom_id: "#swagger",
+          deepLinking: true,
+          presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
+          plugins: [SwaggerUIBundle.plugins.DownloadUrl],
+          layout: "StandaloneLayout",
+        });
     </script>
   </body>
 </html>


### PR DESCRIPTION
## 原因

GitHub Pages の Swagger UI で「No API definition provided」と表示される。
urls オプションは Topbar プラグイン (swagger-ui-standalone-preset.js) が必要だが、preset を読み込んでいなかったため spec が一切読み込まれていなかった。

## 変更内容

- scripts/build-api-docs.ts — standalone preset 追加 + presets/plugins/layout 設定
- Vyline/backend/src/index.ts — ローカル /docs も同様に修正（同じバグ）

## テスト確認

- ローカル静的サーバ + headless Chrome で描画確認済み（definition セレクタ表示、spec ロード成功）
- bun run typecheck 通過