### PR TITLE
chore: Pages をランディングページへ変更 (Swagger UI は vyline-api に移設)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,13 +1,11 @@
-name: Deploy API Docs to GitHub Pages
+name: Deploy landing page to GitHub Pages
 
 on:
   push:
     branches: [main]
     paths:
-      - "openapi.yaml"
-      - "Vyline/backend/src/api/openapi.line.ts"
-      - "scripts/build-api-docs.ts"
       - ".github/workflows/pages.yml"
+      - "scripts/build-landing.ts"
   workflow_dispatch:
 
 permissions:
@@ -27,15 +25,14 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
-      - name: Build static docs
-        run: bun scripts/build-api-docs.ts dist-api-docs
+      - name: Build landing page
+        run: bun scripts/build-landing.ts dist-landing
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: dist-api-docs
+          path: dist-landing
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/docs/api/openapi.md
+++ b/docs/api/openapi.md
@@ -21,11 +21,11 @@ GET /openapi/v1.yaml /openapi.yaml へのリダイレクト
 
 ## GitHub Pages
 
-push to `main` 時に `.github/workflows/pages.yml` が静的ドキュメントを生成し、
-**https://nezumi0627.github.io/vyline/** へデプロイする。
+- **Swagger UI**: **https://nezumi0627.github.io/vyline-api/**
+  （`nezumi0627/vyline-api` リポジトリが毎日 03:00 UTC + 手動実行で本リポジトリの main から生成）
+- **ランディングページ**: https://nezumi0627.github.io/vyline/（`pages.yml` + `scripts/build-landing.ts`）
 
-- 生成: `bun scripts/build-api-docs.ts <outdir>`（BFF spec を TS から JSON 化 + ルート `openapi.yaml` をコピー）
-- 手動実行も可（workflow_dispatch）
+生成: `bun scripts/build-api-docs.ts <outdir>`（BFF spec を TS から JSON 化 + ルート `openapi.yaml` をコピー）
 
 Swagger UI は CDN からスクリプトを読み込むため、オフライン環境では `openapi.json` /
 `openapi.yaml` を直接確認すること。

--- a/scripts/build-landing.ts
+++ b/scripts/build-landing.ts
@@ -1,0 +1,51 @@
+/**
+ * scripts/build-landing.ts — GitHub Pages 用ランディングページ生成
+ *
+ * Swagger UI は nezumi0627.github.io/vyline-api に移設済み。
+ * 出力先: <outdir>/index.html
+ */
+
+import { mkdir } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const outDir = process.argv[2] ?? join(dirname(fileURLToPath(import.meta.url)), "..", "dist-landing");
+await mkdir(outDir, { recursive: true });
+await Bun.write(
+  join(outDir, "index.html"),
+  `<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Vyline</title>
+    <style>
+      :root { color-scheme: dark; }
+      body {
+        margin: 0; min-height: 100vh; display: grid; place-items: center;
+        background: #0f1115; color: #e6e6e6;
+        font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+      }
+      main { text-align: center; padding: 2rem; }
+      h1 { font-size: 2.5rem; margin: 0 0 .5rem; letter-spacing: .02em; }
+      p  { color: #9aa0a6; margin: 0 0 2rem; }
+      a.btn {
+        display: inline-block; margin: 0 .5rem .5rem; padding: .7rem 1.4rem;
+        border: 1px solid #3a3f4b; border-radius: 8px; text-decoration: none;
+        color: #e6e6e6; transition: border-color .15s;
+      }
+      a.btn:hover { border-color: #85ea2d; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Vyline</h1>
+      <p>Self-hosted third-party LINE client</p>
+      <a class="btn" href="https://github.com/nezumi0627/vyline">GitHub</a>
+      <a class="btn" href="https://nezumi0627.github.io/vyline-api/">API Docs (Swagger UI)</a>
+    </main>
+  </body>
+</html>
+`,
+);
+console.log(`Landing page generated at ${outDir}`);


### PR DESCRIPTION
## 変更内容

- Swagger UI の公開先を https://nezumi0627.github.io/vyline-api/ (nezumi0627/vyline-api リポジトリ) に移設
  - vyline-api 側ワークフローが本リポジトリの main から spec を生成 (毎日 03:00 UTC + 手動実行)
- 本リポジトリの Pages はシンプルなランディングページに変更
  - scripts/build-landing.ts を新規追加 (GitHub / API Docs へのリンク)
- docs/api/openapi.md の URL を更新

## テスト確認

- https://nezumi0627.github.io/vyline-api/ で Swagger UI 描画を headless Chrome で確認済み
- bun run typecheck 通過