### PR TITLE
fix: Pages workflow に setup-bun を追加

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,6 +25,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
       - name: Build landing page
         run: bun scripts/build-landing.ts dist-landing
       - name: Setup Pages


### PR DESCRIPTION
ランディングページ生成 (bun scripts/build-landing.ts) で bun が見つからず失敗していたため setup-bun ステップを追加。