### PR TITLE
perf: フロントエンド描画最適化（サイドバー windowing・memo 化・hydrate バースト統合）

### DIFF
--- a/Vyline/apps/desktop/src/components/chat-area.tsx
+++ b/Vyline/apps/desktop/src/components/chat-area.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, useCallback } from "react";
+import { memo, useEffect, useMemo, useRef, useState, useCallback } from "react";
 import { useStore, displayName, type Message } from "@/lib/store";
 import { cn } from "@/lib/utils";
 import { useCall } from "@/hooks/useCall";
@@ -72,7 +72,7 @@ function shouldGroupAdjacentImages(left: Message, right: Message): boolean {
   );
 }
 
-export function ChatArea() {
+function ChatAreaBase() {
   const activeChatId = useStore((s) => s.activeChatId);
   const chats = useStore((s) => s.chats);
   const messages = useStore((s) => s.messages);
@@ -240,7 +240,7 @@ export function ChatArea() {
     visibleRows,
     topSpacer,
     bottomSpacer,
-    measure,
+    rowRef,
     scrollToKey,
     scrollToBottom,
   } = useVirtualList<MsgRow>({ rows, estimateHeight: estimateMsgHeight });
@@ -548,7 +548,7 @@ export function ChatArea() {
             {topSpacer > 0 && <div style={{ height: topSpacer }} aria-hidden />}
             {visibleRows.map(({ key, item }) =>
               item.kind === "day" ? (
-                <div key={key} ref={(el) => measure(key, el)} className="my-3 flex justify-center">
+                <div key={key} ref={rowRef(key)} className="my-3 flex justify-center">
                   <span className="rounded-full bg-[color-mix(in_oklab,var(--vy-text)_12%,transparent)] px-3 py-1 text-[0.7rem] font-medium text-[var(--vy-text)] backdrop-blur">
                     {item.label}
                   </span>
@@ -557,7 +557,7 @@ export function ChatArea() {
                 <div
                   key={key}
                   id={key}
-                  ref={(el) => measure(key, el)}
+                  ref={rowRef(key)}
                   className={cnRow(
                     item.searching,
                     item.isMatch,
@@ -617,6 +617,8 @@ export function ChatArea() {
     </div>
   );
 }
+
+export const ChatArea = memo(ChatAreaBase);
 
 function cnRow(
   searching: boolean,

--- a/Vyline/apps/desktop/src/components/chat-shell.tsx
+++ b/Vyline/apps/desktop/src/components/chat-shell.tsx
@@ -1,11 +1,11 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { useStore } from "@/lib/store";
 import { Sidebar } from "@/components/sidebar";
 import { ChatArea } from "@/components/chat-area";
 import { cn } from "@/lib/utils";
 import { IconPanelLeft } from "@/components/icons";
 
-export function ChatShell() {
+function ChatShellBase() {
   const activeChatId = useStore((s) => s.activeChatId);
   const sidebarWidth = useStore((s) => s.sidebarWidth);
   const setSidebarWidth = useStore((s) => s.setSidebarWidth);
@@ -95,3 +95,5 @@ export function ChatShell() {
     </div>
   );
 }
+
+export const ChatShell = memo(ChatShellBase);

--- a/Vyline/apps/desktop/src/components/sidebar.tsx
+++ b/Vyline/apps/desktop/src/components/sidebar.tsx
@@ -112,7 +112,7 @@ function moveId(order: string[], fromId: string, toId: string): string[] {
   return next;
 }
 
-export function Sidebar() {
+function SidebarBase() {
   const chats = useStore((s) => s.chats);
   const messages = useStore((s) => s.messages);
   const [createGroupOpen, setCreateGroupOpen] = useState(false);
@@ -177,6 +177,33 @@ export function Sidebar() {
     }
     return sortChats(list, sort, messages, customOrder);
   }, [chats, tab, query, messages, sort, customOrder, liveOrder]);
+
+  // --- チャット一覧の固定高ウィンドウリング（全件描画による DOM/listener 膨張を防ぐ） ---
+  const listRef = useRef<HTMLDivElement>(null);
+  const [rowH, setRowH] = useState(70); // ChatRow 概算: avatar48 + py-2.5×2 + mb-0.5
+  const [win, setWin] = useState({ start: 0, end: 24 });
+  const recomputeWin = useCallback(() => {
+    const el = listRef.current;
+    if (!el) return;
+    const start = Math.max(0, Math.floor(el.scrollTop / rowH) - 10);
+    const end = Math.min(filtered.length, Math.ceil((el.scrollTop + el.clientHeight) / rowH) + 10);
+    setWin((p) => (p.start === start && p.end === end ? p : { start, end }));
+  }, [filtered.length, rowH]);
+
+  // 実測行高で補正（フォントメトリ差分の累積ドリフト防止）
+  useEffect(() => {
+    const row = listRef.current?.querySelector<HTMLElement>("[data-vy-chat-row]");
+    const h = row?.offsetHeight ?? 0;
+    if (h > 0 && Math.abs(h - rowH) > 1) setRowH(h);
+  }, [win.start, rowH]);
+
+  useEffect(() => {
+    recomputeWin();
+  }, [recomputeWin]);
+
+  // ウィンドウ範囲（filtered 縮小時の空描画防止にクランプ）
+  const winStart = Math.min(win.start, filtered.length);
+  const winEnd = Math.max(winStart, Math.min(win.end, filtered.length));
 
   useEffect(() => {
     liveOrderRef.current = liveOrder;
@@ -495,32 +522,38 @@ export function Sidebar() {
             </p>
           </div>
         ) : (
-          filtered.map((chat) => (
-            <ChatRow
-              key={chat.id}
-              chat={chat}
-              active={chat.id === activeChatId}
-              draggable={sort === "custom"}
-              dragging={dragId === chat.id}
-              blocked={blockedSet.has(chat.id)}
-              onClick={() => openChat(chat.id)}
-              onContextMenu={(e) => openRowMenu(e, chat)}
-              onDragStart={() => onDragStart(chat.id)}
-              onDragEnd={finishDrag}
-              onDragOver={(e) => {
-                if (sort !== "custom" || !dragIdRef.current) return;
-                e.preventDefault();
-                e.dataTransfer.dropEffect = "move";
-                onDragOverRow(chat.id);
-              }}
-              onDrop={(e) => {
-                e.preventDefault();
-                finishDrag();
-              }}
-              streamerMode={streamerMode}
-              preview={previewMap.get(chat.id) ?? null}
-            />
-          ))
+          <>
+            {winStart > 0 && <div style={{ height: winStart * rowH }} aria-hidden />}
+            {filtered.slice(winStart, winEnd).map((chat) => (
+              <ChatRow
+                key={chat.id}
+                chat={chat}
+                active={chat.id === activeChatId}
+                draggable={sort === "custom"}
+                dragging={dragId === chat.id}
+                blocked={blockedSet.has(chat.id)}
+                onClick={() => openChat(chat.id)}
+                onContextMenu={(e) => openRowMenu(e, chat)}
+                onDragStart={() => onDragStart(chat.id)}
+                onDragEnd={finishDrag}
+                onDragOver={(e) => {
+                  if (sort !== "custom" || !dragIdRef.current) return;
+                  e.preventDefault();
+                  e.dataTransfer.dropEffect = "move";
+                  onDragOverRow(chat.id);
+                }}
+                onDrop={(e) => {
+                  e.preventDefault();
+                  finishDrag();
+                }}
+                streamerMode={streamerMode}
+                preview={previewMap.get(chat.id) ?? null}
+              />
+            ))}
+            {filtered.length - winEnd > 0 && (
+              <div style={{ height: (filtered.length - winEnd) * rowH }} aria-hidden />
+            )}
+          </>
         )}
       </div>
 
@@ -534,6 +567,8 @@ export function Sidebar() {
     </aside>
   );
 }
+
+export const Sidebar = memo(SidebarBase);
 
 const ChatRow = memo(function ChatRow({
   chat,
@@ -606,6 +641,7 @@ const ChatRow = memo(function ChatRow({
 
   return (
     <div
+      data-vy-chat-row
       draggable={draggable}
       onDragStart={(e) => {
         if (!draggable) return;

--- a/Vyline/apps/desktop/src/hooks/useLineData.ts
+++ b/Vyline/apps/desktop/src/hooks/useLineData.ts
@@ -9,7 +9,7 @@
  * useEffect が回り chats=[] になるループは禁止。
  */
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useMemo, useEffect, useRef, useState } from "react";
 import { api } from "../api/client.js";
 import type { Chat, LineProfile, Message } from "../types/index.js";
 import { looksLikeMid, type ContactInfo } from "../lib/mappers.js";
@@ -399,13 +399,13 @@ export function useLineData({ accountId }: UseLineDataOptions) {
     void loadMessages(selectedChatMid);
   }, [selectedChatMid, loadMessages]);
 
-  const avatarCache = (() => {
+  const avatarCache = useMemo(() => {
     const m = new Map<string, string>();
     for (const [mid, info] of contactCache) {
       if (info.thumbnailUrl) m.set(mid, info.thumbnailUrl);
     }
     return m;
-  })();
+  }, [contactCache]);
 
   return {
     profile,

--- a/Vyline/apps/desktop/src/hooks/useVirtualList.ts
+++ b/Vyline/apps/desktop/src/hooks/useVirtualList.ts
@@ -26,6 +26,8 @@ export function useVirtualList<T>({
   const heights = useRef(new Map<string, number>());
   const [, setMeasuredTick] = useState(0);
   const measuredTick = useRef(0);
+  const tickScheduled = useRef(false);
+  const refCache = useRef(new Map<string, (el: HTMLElement | null) => void>());
   const offsets = useMemo(() => {
     const arr: number[] = [];
     let acc = 0;
@@ -70,11 +72,29 @@ export function useVirtualList<T>({
     const prev = heights.current.get(key);
     if (prev !== h) {
       heights.current.set(key, h);
-      // 実測が変わるたびにオフセット再計算をトリガー
-      measuredTick.current++;
-      setMeasuredTick((t) => t + 1);
+      // 同一フレーム内の計測変更を 1 再描画に統合（画像遅延ロード時の再描画連鎖を抑制）
+      if (tickScheduled.current) return;
+      tickScheduled.current = true;
+      requestAnimationFrame(() => {
+        tickScheduled.current = false;
+        measuredTick.current++;
+        setMeasuredTick((t) => t + 1);
+      });
     }
   }, []);
+
+  // 行キーごとに安定した ref を返す（毎レンダーの ref 再アタッチ → 再計測の連鎖を防ぐ）
+  const rowRef = useCallback(
+    (key: string) => {
+      let cb = refCache.current.get(key);
+      if (!cb) {
+        cb = (el: HTMLElement | null) => measure(key, el);
+        refCache.current.set(key, cb);
+      }
+      return cb;
+    },
+    [measure],
+  );
 
   // 行キー → スクロール位置（center: 可視中央に寄せる）
   const scrollToKey = useCallback(
@@ -107,6 +127,7 @@ export function useVirtualList<T>({
     topSpacer,
     bottomSpacer,
     measure,
+    rowRef,
     scrollToKey,
     scrollToBottom,
   };

--- a/Vyline/apps/desktop/src/hooks/useVylineSync.ts
+++ b/Vyline/apps/desktop/src/hooks/useVylineSync.ts
@@ -52,6 +52,8 @@ export function useVylineSync(enabled = true) {
   const { hiddenSet } = useHiddenChats(enabled ? accountId : null);
 
   const syncingChat = useRef(false);
+  const lastHydrateAt = useRef(0);
+  const hydrateTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   const refreshReadReceipts = useStore((s) => s.refreshReadReceipts);
 
@@ -198,30 +200,40 @@ export function useVylineSync(enabled = true) {
 
     if (!line.chats.length && useStore.getState().chats.length > 0) return;
 
-    hydrateLineData({
-      profile: line.profile
-        ? {
-            displayName: line.profile.displayName,
-            phoneticName: line.profile.phoneticName,
-            pictureStatus: line.profile.pictureStatus,
-            statusMessage: line.profile.statusMessage,
-            thumbnailUrl: line.profile.thumbnailUrl,
-            musicProfile: line.profile.musicProfile,
-            birthday: line.profile.birthday,
-            backgroundUrl: line.profile.backgroundUrl,
-            profileId: line.profile.profileId,
-            premium: line.profile.premium ?? null,
-          }
-        : null,
+    // contactCache の逐次解決など連続更新を 1 回の hydrate にまとめる
+    // （連鎖する全チャット再マップ → 長タスク・ヒープ膨張を抑止）
+    const run = () => {
+      lastHydrateAt.current = Date.now();
+      hydrateLineData({
+        profile: line.profile
+          ? {
+              displayName: line.profile.displayName,
+              phoneticName: line.profile.phoneticName,
+              pictureStatus: line.profile.pictureStatus,
+              statusMessage: line.profile.statusMessage,
+              thumbnailUrl: line.profile.thumbnailUrl,
+              musicProfile: line.profile.musicProfile,
+              birthday: line.profile.birthday,
+              backgroundUrl: line.profile.backgroundUrl,
+              profileId: line.profile.profileId,
+              premium: line.profile.premium ?? null,
+            }
+          : null,
+        chats: line.chats,
+        messages: line.messages,
+        hiddenMids: hiddenSet,
+        contactCache: line.contactCache,
+      });
+    };
 
-      chats: line.chats,
-
-      messages: line.messages,
-
-      hiddenMids: hiddenSet,
-
-      contactCache: line.contactCache,
-    });
+    const wait = Math.max(0, 300 - (Date.now() - lastHydrateAt.current));
+    if (wait === 0) {
+      run();
+      return;
+    }
+    clearTimeout(hydrateTimer.current);
+    hydrateTimer.current = setTimeout(run, wait);
+    return () => clearTimeout(hydrateTimer.current);
   }, [
     enabled,
 


### PR DESCRIPTION
# 概要

パフォーマンスプロファイル（localhost:5173）で検出されたフロントエンドの描画・メモリ問題を修正する PR です。

## プロファイル所見 → 原因 → 対応

| プロファイル所見 | 原因 | 対応 |
|---|---|---|
| DOM nodes 12 → 10,348 / Listeners 10 → 4,269 | サイドバーが全チャットを全件描画（行数 × タッチ/ドラッグハンドラ数と一致） | チャット一覧を**固定高ウィンドウリング化**（可視 ±10 行 overscan、実測行高でドリフト補正） |
| Scripting 2,370ms・長タスク 370–790ms 複数 | `useLineData` が `VylineApp` に配置されており、contactCache 解決のたび（起動時〜80 回）アプリ全体が再描画 | `Sidebar` / `ChatArea` / `ChatShell` を `memo` 化し、親からの再描画連鎖を遮断 |
| JS heap 989kB → 616MB に急増 | hydrate 効果が contactCache 更新のたびに発火し、全チャット+全メッセージを再マップ | `hydrateLineData` を **300ms バースト統合**（初回は即時、連続更新は trailing で 1 回に圧縮） |
| `On_ign…node` の大量反復（React reconcile 過多） | `useVirtualList` の ref が毎レンダー再生成 → 全可視行の再アタッチ → 再計測 → setState の連鎖 | 行 ref をキーごとに**安定化** + 計測 tick を **rAF 統合**（同一フレームの N 変更を 1 再描画に） |
| — | `avatarCache` が毎レンダーで Map を再構築 | `useMemo` 化 |

## 変更ファイル（6 件 / +136 −63）

- `apps/desktop/src/components/sidebar.tsx` — チャット一覧のウィンドウリング + `memo`
- `apps/desktop/src/components/chat-area.tsx` — `rowRef` 差し替え + `memo`
- `apps/desktop/src/components/chat-shell.tsx` — `memo`
- `apps/desktop/src/hooks/useVylineSync.ts` — hydrate バースト統合
- `apps/desktop/src/hooks/useVirtualList.ts` — 行 ref 安定化 + rAF 統合
- `apps/desktop/src/hooks/useLineData.ts` — `avatarCache` の useMemo 化

## テスト確認結果

- ✅ `bun run typecheck`（protocol / backend / desktop の 3 パッケージ）
- ✅ `biome check Vyline`（本 PR の変更範囲。※ `backend/src/tools/lkbsProbe.ts` は本 PR と無関係な未コミットローカルファイルのため対象外）
- ✅ `bun run build`（vite 本番ビルド）
- ✅ pre-push フック（typecheck + lint + build）通過
- ✅ CI 全チェック通過（TypeScript / Lint / Build / Docker build + runtime smoke）

## レビュー時の動作確認ポイント

- サイドバーのスクロール・ドラッグ並び替え（カスタムソート時）・長押し（タッチ）メニューが従来通り機能するか
- チャット切替・スクロール時のカクつき（ジャンク）が減っているか
- 起動直後のプロファイルで DOM nodes / Listeners / JS heap の伸びが改善しているか
