### PR TITLE
perf: window frontend chat and message rendering

### DIFF
--- a/Vyline/apps/desktop/src/components/sidebar.tsx
+++ b/Vyline/apps/desktop/src/components/sidebar.tsx
@@ -515,7 +515,7 @@ function SidebarBase() {
         <p className="px-4 pb-1.5 text-[0.7rem] text-[var(--vy-text-dim)]">ドラッグして並び替え</p>
       )}
 
-      <div className="vy-scroll flex-1 overflow-y-auto px-2 pb-3">
+      <div ref={listRef} className="vy-scroll flex-1 overflow-y-auto px-2 pb-3">
         {filtered.length === 0 ? (
           <div className="flex flex-col items-center gap-2 px-6 py-16 text-center">
             <span className="flex h-12 w-12 items-center justify-center rounded-full bg-[var(--vy-surface-2)] text-[var(--vy-text-dim)]">

--- a/Vyline/apps/desktop/src/components/sidebar.tsx
+++ b/Vyline/apps/desktop/src/components/sidebar.tsx
@@ -182,6 +182,7 @@ function SidebarBase() {
   const listRef = useRef<HTMLDivElement>(null);
   const [rowH, setRowH] = useState(70); // ChatRow 概算: avatar48 + py-2.5×2 + mb-0.5
   const [win, setWin] = useState({ start: 0, end: 24 });
+  const [hasMeasured, setHasMeasured] = useState(false);
   const recomputeWin = useCallback(() => {
     const el = listRef.current;
     if (!el) return;
@@ -194,8 +195,11 @@ function SidebarBase() {
   useEffect(() => {
     const row = listRef.current?.querySelector<HTMLElement>("[data-vy-chat-row]");
     const h = row?.offsetHeight ?? 0;
-    if (h > 0 && Math.abs(h - rowH) > 1) setRowH(h);
-  }, [win.start, rowH]);
+    if (h > 0) {
+      if (Math.abs(h - rowH) > 1) setRowH(h);
+      if (!hasMeasured) setHasMeasured(true);
+    }
+  }, [win.start, rowH, hasMeasured]);
 
   useEffect(() => {
     recomputeWin();
@@ -523,7 +527,7 @@ function SidebarBase() {
           </div>
         ) : (
           <>
-            {winStart > 0 && <div style={{ height: winStart * rowH }} aria-hidden />}
+            {hasMeasured && winStart > 0 && <div style={{ height: winStart * rowH }} aria-hidden />}
             {filtered.slice(winStart, winEnd).map((chat) => (
               <ChatRow
                 key={chat.id}
@@ -550,7 +554,7 @@ function SidebarBase() {
                 preview={previewMap.get(chat.id) ?? null}
               />
             ))}
-            {filtered.length - winEnd > 0 && (
+            {hasMeasured && filtered.length - winEnd > 0 && (
               <div style={{ height: (filtered.length - winEnd) * rowH }} aria-hidden />
             )}
           </>

--- a/Vyline/apps/desktop/src/hooks/useVirtualList.ts
+++ b/Vyline/apps/desktop/src/hooks/useVirtualList.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 /**
  * 可変高さリストのウィンドウ仮想化
@@ -28,6 +28,7 @@ export function useVirtualList<T>({
   const measuredTick = useRef(0);
   const tickScheduled = useRef(false);
   const refCache = useRef(new Map<string, (el: HTMLElement | null) => void>());
+  const observers = useRef(new Map<string, ResizeObserver>());
   const offsets = useMemo(() => {
     const arr: number[] = [];
     let acc = 0;
@@ -90,13 +91,41 @@ export function useVirtualList<T>({
     (key: string) => {
       let cb = refCache.current.get(key);
       if (!cb) {
-        cb = (el: HTMLElement | null) => measure(key, el);
+        cb = (el: HTMLElement | null) => {
+          observers.current.get(key)?.disconnect();
+          observers.current.delete(key);
+          if (!el) return;
+          measure(key, el);
+          if (typeof ResizeObserver === "undefined") return;
+          const observer = new ResizeObserver(() => measure(key, el));
+          observer.observe(el);
+          observers.current.set(key, observer);
+        };
         refCache.current.set(key, cb);
       }
       return cb;
     },
     [measure],
   );
+
+  useEffect(() => {
+    const keys = new Set(rows.map((row) => row.key));
+    for (const key of heights.current.keys()) {
+      if (!keys.has(key)) heights.current.delete(key);
+    }
+    for (const key of refCache.current.keys()) {
+      if (keys.has(key)) continue;
+      observers.current.get(key)?.disconnect();
+      observers.current.delete(key);
+      refCache.current.delete(key);
+    }
+  }, [rows]);
+
+  useEffect(() => {
+    return () => {
+      for (const observer of observers.current.values()) observer.disconnect();
+    };
+  }, []);
 
   // 行キー → スクロール位置（center: 可視中央に寄せる）
   const scrollToKey = useCallback(

--- a/Vyline/apps/desktop/src/hooks/useVirtualList.ts
+++ b/Vyline/apps/desktop/src/hooks/useVirtualList.ts
@@ -38,6 +38,8 @@ export function useVirtualList<T>({
     return { offsets: arr, total: acc };
   }, [rows, estimateHeight, measuredTick.current]);
 
+  const hasMeasured = measuredTick.current > 0;
+
   const onScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
     setScrollTop(e.currentTarget.scrollTop);
   }, []);
@@ -117,8 +119,10 @@ export function useVirtualList<T>({
   }, []);
 
   const visibleRows = useMemo(() => rows.slice(visible.startIdx, visible.endIdx), [rows, visible]);
-  const topSpacer = offsets.offsets[visible.startIdx] ?? 0;
-  const bottomSpacer = offsets.total - (offsets.offsets[visible.endIdx] ?? offsets.total);
+  const topSpacer = hasMeasured ? (offsets.offsets[visible.startIdx] ?? 0) : 0;
+  const bottomSpacer = hasMeasured
+    ? offsets.total - (offsets.offsets[visible.endIdx] ?? offsets.total)
+    : 0;
 
   return {
     containerRef,


### PR DESCRIPTION
## Summary
- virtualize the sidebar chat list
- batch variable-height message measurements per animation frame
- observe row resize events so delayed media loads keep offsets accurate
- clean stale measurement observers when rows change

## Fix included
- attach the sidebar scroll ref required for windowing; without it only the initial window rendered

## Validation
- bun run typecheck
- bun run lint
- bun run --cwd Vyline/apps/desktop build

The build emits the existing Vite chunk-size warning only.