### PR TITLE
feat(release): automate Windows Linux and Docker distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,98 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/nezumi0627/vyline
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { submodules: recursive }
+      - name: Validate tag and package version
+        run: |
+          test "${GITHUB_REF_NAME#v}" = "$(node -p \"require('./package.json').version\")"
+      - uses: oven-sh/setup-bun@v2
+        with: { bun-version: "1.4.0" }
+      - run: bun install --frozen-lockfile
+      - run: bun run typecheck
+      - run: bun run lint
+      - run: bun test
+
+  windows:
+    needs: quality
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { submodules: recursive }
+      - uses: oven-sh/setup-bun@v2
+        with: { bun-version: "1.4.0" }
+      - run: bun install --frozen-lockfile
+      - run: choco install innosetup --no-progress --yes
+      - run: bun run package:windows
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows-installer
+          path: dist/windows/VylineSetup-*.exe
+
+  linux:
+    needs: quality
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { submodules: recursive }
+      - uses: oven-sh/setup-bun@v2
+        with: { bun-version: "1.4.0" }
+      - run: bun install --frozen-lockfile
+      - run: bun run package:linux
+      - uses: actions/upload-artifact@v4
+        with:
+          name: linux-archive
+          path: dist/linux/Vyline-linux-x64-*.tar.gz
+
+  docker:
+    needs: quality
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { submodules: recursive }
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ github.ref_name }}
+            type=raw,value=latest
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: VYLINE_VERSION=${{ github.ref_name }}
+
+  publish:
+    needs: [windows, linux, docker]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with: { path: dist, merge-multiple: true }
+      - uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            dist/VylineSetup-*.exe
+            dist/Vyline-linux-x64-*.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ pnpm-debug.log*
 
 # ── Bun ──────────────────────────────────────────────────────
 .bun/
+.bun-cache/
 
 # ── Data (tokens / E2EE keys — never commit) ─────────────────
 /backend/data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@
 # ビルド: docker build -t vyline .
 # 実行:  docker run -p 3000:3000 -v ./data:/app/data vyline
 
-FROM oven/bun:1 AS deps
+ARG BUN_VERSION=1.4.0
+ARG VYLINE_VERSION=dev
+FROM oven/bun:${BUN_VERSION} AS deps
 WORKDIR /app
 COPY package.json bun.lock* ./
 COPY Vyline/apps/desktop/package.json Vyline/apps/desktop/
@@ -15,7 +17,8 @@ COPY Vyline/packages/plugin/sdk/package.json Vyline/packages/plugin/sdk/
 COPY Vyline/packages/themes/package.json Vyline/packages/themes/
 RUN bun install --frozen-lockfile --ignore-scripts
 
-FROM oven/bun:1 AS build
+ARG BUN_VERSION=1.4.0
+FROM oven/bun:${BUN_VERSION} AS build
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/Vyline/apps/desktop/node_modules ./Vyline/apps/desktop/node_modules
@@ -24,13 +27,17 @@ COPY --from=deps /app/Vyline/packages ./Vyline/packages
 COPY . .
 RUN bun run build
 
-FROM oven/bun:1
+ARG BUN_VERSION=1.4.0
+ARG VYLINE_VERSION=dev
+FROM oven/bun:${BUN_VERSION}
 WORKDIR /app
 ENV NODE_ENV=production \
+    VYLINE_VERSION=${VYLINE_VERSION} \
     VYLINE_HOST=0.0.0.0 \
     PORT=3000 \
     VYLINE_DATA_DIR=/app/data \
     VYLINE_STORAGE_DIR=/app/storage
+LABEL org.opencontainers.image.title="Vyline" org.opencontainers.image.source="https://github.com/nezumi0627/Vyline" org.opencontainers.image.version="$VYLINE_VERSION"
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/Vyline/backend/node_modules ./Vyline/backend/node_modules
 COPY --from=build /app/Vyline/packages ./Vyline/packages

--- a/README.md
+++ b/README.md
@@ -129,10 +129,11 @@ Vyline の継続的な開発を支えるメンテナーとコントリビュー�
 | --- | --- | --- |
 | 開発・動作確認 | Bun + ソースコード | フロントエンドとバックエンドを個別に確認できます |
 | 自宅サーバー・複数端末 | Docker Compose | データをボリュームに保存して Web ブラウザから利用できます |
-| Windows の単体アプリ | 準備中 | Vyline Desktop のインストーラーは今後提供予定です |
+| Windows の単体アプリ | Beta 対応 | GitHub Releases の `VylineSetup-<version>.exe` を使用します |
+| Linux の単体アプリ | Beta 対応 | GitHub Releases の `Vyline-linux-x64-<version>.tar.gz` を使用します |
 
 > [!NOTE]
-> 現在、一般ユーザー向けの公式インストーラーはありません。まずは Bun または Docker を使用してください。
+> Windows版・Linux版は GitHub Releases から導入できます。サーバー用途では Docker Compose を使用してください。
 
 ### ソースコードからインストール（Bun）
 
@@ -199,13 +200,24 @@ docker compose up -d --build
 ### Docker環境の更新
 
 ```bash
-git pull --ff-only
-docker compose up -d --build
+docker compose pull
+docker compose up -d
 ```
+
+ソースコードからイメージを作り直す場合は、`git pull --ff-only && docker compose up -d --build` を使用します。
 
 `docker compose up -d --build` が既存コンテナを再作成しても、ホスト側の `./data/` ディレクトリは維持されます。**`data/` にはセッションや鍵が含まれるため、削除しないでください。**
 
 トーク履歴、画像、セッションなどは `./data/` へ永続化され、同じ LINE セッションを複数の Web ブラウザから利用できます。
+
+### Linux単体版
+
+```bash
+tar -xzf Vyline-linux-x64-<version>.tar.gz
+cd Vyline-linux-x64-<version>
+./install.sh
+~/.local/bin/vyline
+```
 
 設定方法と Cloudflare Access を利用した外部公開については、[セルフホストガイド](docs/selfhosting.md) を参照してください。
 

--- a/Vyline/apps/desktop/src/components/settings-sections.tsx
+++ b/Vyline/apps/desktop/src/components/settings-sections.tsx
@@ -1250,12 +1250,12 @@ function InfoSection() {
           </p>
           {updateInfo?.hasUpdate && (
             <a
-              href={updateInfo.url ?? "#"}
+              href={updateInfo.downloadUrl ?? updateInfo.url ?? "#"}
               target="_blank"
               rel="noopener noreferrer"
               className="mt-3 inline-flex items-center gap-1.5 rounded-full bg-[color-mix(in_oklab,var(--vy-accent)_16%,transparent)] px-3 py-1 text-xs font-semibold text-[var(--vy-accent)] transition-colors hover:bg-[color-mix(in_oklab,var(--vy-accent)_26%,transparent)]"
             >
-              更新あり: v{updateInfo.latestVersion}
+              更新あり: v{updateInfo.latestVersion}（インストーラー）
             </a>
           )}
           {checking && <p className="mt-3 text-xs text-[var(--vy-text-dim)]">更新を確認中…</p>}

--- a/Vyline/apps/desktop/src/lib/updater.ts
+++ b/Vyline/apps/desktop/src/lib/updater.ts
@@ -4,8 +4,7 @@
  * GitHub Releases から最新バージョンをチェックし、
  * 更新があれば通知する。
  *
- * exe 配布時は Vyline Updater (別プロセス) が
- * ダウンロードと置換を行う。
+ * Windows 配布時は GitHub Release の Setup.exe を直接案内する。
  */
 
 import { UPDATE_NOTES } from "./store";
@@ -19,6 +18,7 @@ export interface UpdateInfo {
   latestVersion: string | null;
   hasUpdate: boolean;
   url: string | null;
+  downloadUrl: string | null;
   body: string | null;
   error: string | null;
 }
@@ -35,6 +35,7 @@ export async function checkForUpdates(): Promise<UpdateInfo> {
         latestVersion: null,
         hasUpdate: false,
         url: null,
+        downloadUrl: null,
         body: null,
         error: `GitHub API returned ${res.status}`,
       };
@@ -43,14 +44,19 @@ export async function checkForUpdates(): Promise<UpdateInfo> {
       tag_name?: string;
       html_url?: string;
       body?: string;
+      assets?: Array<{ name?: string; browser_download_url?: string }>;
     };
     const tag = release.tag_name?.replace(/^v/, "") ?? null;
     const hasUpdate = tag != null && tag !== current;
+    const downloadUrl =
+      release.assets?.find((asset) => asset.name === `VylineSetup-${tag}.exe`)
+        ?.browser_download_url ?? null;
     return {
       currentVersion: current,
       latestVersion: tag,
       hasUpdate,
       url: release.html_url ?? null,
+      downloadUrl,
       body: release.body ?? null,
       error: null,
     };
@@ -60,6 +66,7 @@ export async function checkForUpdates(): Promise<UpdateInfo> {
       latestVersion: null,
       hasUpdate: false,
       url: null,
+      downloadUrl: null,
       body: null,
       error: err instanceof Error ? err.message : String(err),
     };

--- a/Vyline/backend/src/index.ts
+++ b/Vyline/backend/src/index.ts
@@ -96,7 +96,9 @@ app.route("/api/v1", publicRouter);
 // /docs, /swagger    — Swagger UI（CDN）
 app.get("/openapi.yaml", async (c) => {
   try {
-    const yamlPath = join(dirname(fileURLToPath(import.meta.url)), "../../../openapi.yaml");
+    const yamlPath =
+      process.env.VYLINE_OPENAPI_PATH ??
+      join(dirname(fileURLToPath(import.meta.url)), "../../../openapi.yaml");
     const yaml = await readFile(yamlPath, "utf8");
     return new Response(yaml, {
       status: 200,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   vyline:
+    image: ${VYLINE_IMAGE:-ghcr.io/nezumi0627/vyline:latest}
     build: .
+    pull_policy: missing
     ports:
       - "3000:3000"
     volumes:

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -5,7 +5,8 @@
 ## ビルドと起動
 
 ```bash
-docker compose up -d --build
+docker compose pull
+docker compose up -d
 ```
 
 - アプリは `http://localhost:3000` で起動する（フロントエンド同梱）。

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -1,79 +1,20 @@
-# Vyline 配布ガイド（Windows exe）
+# Vyline 配布ガイド（Windows / Linux / Docker）
 
-最終更新: 2026-08-24
+`v<version>` タグを push すると GitHub Actions が品質チェック後に Windows Setup.exe、Linux x64 tar.gz、GHCR Docker image を作成します。
 
-## 目的
-
-開発サーバー（`bun run dev`）ではなく、エンドユーザー向けに **単一 exe / インストーラ** で配布するための手順と設計メモです。
-
-## バージョン正本
-
-| 場所                                                            | 役割                             |
-| --------------------------------------------------------------- | -------------------------------- |
-| `Vyline/apps/desktop/src/lib/store.ts` → `UPDATE_NOTES.version` | UI / What's New / updater が参照 |
-| ルート `package.json` / `apps/desktop/package.json`             | npm / ビルドメタ                 |
-| GitHub Release tag (`vX.Y.Z`)                                   | `checkForUpdates()` が比較       |
-
-リリース時は **3 箇所を同じセマンティックバージョン** に揃える。
-
-## 現状のアップデーター
-
-`apps/desktop/src/lib/updater.ts` は GitHub Releases の latest を確認し、差分があれば情報タブで通知します。
-
-- API: `https://api.github.com/repos/nezumi0627/Vyline/releases/latest`
-- exe 置換は別プロセス（Vyline Updater）を想定。Web 版では URL 遷移のみ
-
-## 推奨パッケージ構成（予定）
-
-```
-VylineSetup-0.3.1.exe
-├── Vyline.exe          # フロント + 埋め込み backend 起動
-├── resources/
-│   ├── backend/        # bun コンパイル or 同梱 runtime
-│   └── web/            # vite build 成果物
-└── VylineUpdater.exe   # 差分 DL → 置換 → 再起動
+```bash
+docker compose pull
+docker compose up -d
 ```
 
-実装オプション（いずれか）:
+Linux単体版は `Vyline-linux-x64-<version>.tar.gz` を展開し、`./install.sh` を実行します。Windows単体版は `VylineSetup-<version>.exe` を実行します。いずれも Bun の事前インストールは不要です。
 
-1. **Tauri 2** — 軽量・WebView2・updater プラグインあり（推奨候補）
-2. **electron-builder** — 実績多いが重量
-3. **自前 bun compile + Inno Setup** — 依存最小・メンテは自前
+ローカルビルド:
 
-## ビルド手順（開発用アセット）
-
-```powershell
-# UI 本番ビルド
-bun run build
-
-# 型チェック
-bun run typecheck
+```bash
+bun run package:linux
 ```
 
-成果物: `Vyline/apps/desktop/dist/`
+Windowsでは Inno Setup 6 を導入して `bun run package:windows` を実行します。
 
-backend は現状 `bun Vyline/backend/src/index.ts`。exe 同梱時は:
-
-- `PORT` をローカル固定（例: 18765）
-- frontend は相対 `/api` ではなく同梱 backend を指す
-- `Vyline/backend/data/` はユーザー AppData へリダイレクト
-
-## インストーラ要件
-
-- [ ] 初回に WebView2 / VC++ ランタイム確認
-- [ ] データディレクトリ: `%APPDATA%\Vyline\`
-- [ ] 自動起動オプション（任意）
-- [ ] アンインストールで data を残す/消す選択
-- [ ] コード署名（推奨・SmartScreen 回避）
-
-## リリースチェックリスト
-
-1. `UPDATE_NOTES` を更新（version + items）
-2. `package.json` の version を揃える
-3. `bun run typecheck` / 手動スモーク（ログイン・送信・スタンプ・ブロック）
-4. GitHub Release を作成（tag `vX.Y.Z`、アセットに Setup.exe）
-5. What's New が起動時に出ることを確認（`seenUpdateVersion`）
-
-## 秘密情報
-
-`desktop-e2ee-keys.json` / tokens / session は **配布物に含めない**。ユーザーマシンの AppData のみ。
+データ保存先は Windows が `%APPDATA%\\Vyline\\`、Linux が `${XDG_DATA_HOME:-~/.local/share}/Vyline/`、Docker が Compose の `./data/` と `./storage/` です。tokens、セッション、E2EE鍵を配布物やDockerイメージに含めないでください。

--- a/docs/user-guide/update.md
+++ b/docs/user-guide/update.md
@@ -27,9 +27,11 @@ bun run update
 ## Docker の場合
 
 ```bash
-docker compose pull        # ベースイメージの更新（任意）
-docker compose up -d --build
+docker compose pull        # GHCR の最新 Vyline イメージを取得
+docker compose up -d
 ```
+
+ソースコードから再ビルドする場合は `docker compose up -d --build` を使います。
 
 ## 更新前のバックアップ（推奨)
 

--- a/installer/Vyline.iss
+++ b/installer/Vyline.iss
@@ -1,0 +1,41 @@
+#ifndef AppVersion
+  #define AppVersion "0.0.0-dev"
+#endif
+#ifndef SourceDir
+  #define SourceDir "..\\dist\\windows\\Vyline"
+#endif
+#ifndef OutputDir
+  #define OutputDir "..\\dist\\windows"
+#endif
+[Setup]
+AppId={{9B8C7F0E-4E4D-4E7A-9C9F-6D6E5E8C8A21}
+AppName=Vyline
+AppVersion={#AppVersion}
+AppPublisher=nezumi0627
+AppPublisherURL=https://github.com/nezumi0627/Vyline
+DefaultDirName={localappdata}\Programs\Vyline
+DefaultGroupName=Vyline
+OutputDir={#OutputDir}
+OutputBaseFilename=VylineSetup-{#AppVersion}
+Compression=lzma2/ultra64
+SolidCompression=yes
+PrivilegesRequired=lowest
+ArchitecturesInstallIn64BitMode=x64compatible
+CloseApplications=yes
+RestartApplications=no
+Uninstallable=yes
+[Languages]
+Name: "japanese"; MessagesFile: "compiler:Languages\Japanese.isl"
+[Files]
+Source: "{#SourceDir}\Vyline.exe"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#SourceDir}\VylineBackend.exe"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#SourceDir}\openapi.yaml"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#SourceDir}\web\*"; DestDir: "{app}\web"; Flags: ignoreversion recursesubdirs createallsubdirs
+[Icons]
+Name: "{autoprograms}\Vyline"; Filename: "{app}\Vyline.exe"; WorkingDir: "{app}"
+Name: "{autodesktop}\Vyline"; Filename: "{app}\Vyline.exe"; WorkingDir: "{app}"
+[Run]
+Filename: "{app}\Vyline.exe"; Description: "Vylineを起動する"; Flags: nowait postinstall skipifsilent
+[UninstallRun]
+Filename: "{sys}\taskkill.exe"; Parameters: "/F /IM Vyline.exe"; Flags: runhidden
+Filename: "{sys}\taskkill.exe"; Parameters: "/F /IM VylineBackend.exe"; Flags: runhidden

--- a/installer/install-linux.sh
+++ b/installer/install-linux.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+PREFIX="${VYLINE_PREFIX:-${HOME}/.local/opt/vyline}"
+BIN_DIR="${VYLINE_BIN_DIR:-${HOME}/.local/bin}"
+DESKTOP_DIR="${XDG_DATA_HOME:-${HOME}/.local/share}/applications"
+mkdir -p "$PREFIX" "$BIN_DIR" "$DESKTOP_DIR"
+cp -R "$SCRIPT_DIR"/. "$PREFIX"/
+ln -sfn "$PREFIX/Vyline" "$BIN_DIR/vyline"
+cat > "$DESKTOP_DIR/vyline.desktop" <<EOF
+[Desktop Entry]
+Name=Vyline
+Comment=LINE third-party client
+Exec=$BIN_DIR/vyline
+Terminal=false
+Type=Application
+Categories=Network;Chat;
+EOF
+printf 'Vyline installed. Run: %s\n' "$BIN_DIR/vyline"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "server": "bun Vyline/backend/src/index.ts",
     "dev:frontend": "bun run --cwd Vyline/apps/desktop dev",
     "build": "bun run --cwd Vyline/apps/desktop build",
+    "package:windows": "bun scripts/build-windows-release.ts",
+    "package:linux": "bun scripts/build-linux-release.ts",
     "typecheck": "bun run --cwd Vyline/packages/protocol typecheck && bun run --cwd Vyline/backend typecheck && bun run --cwd Vyline/apps/desktop typecheck",
     "lint": "biome check Vyline",
     "vyline:delta": "bun Vyline/packages/protocol/src/tools/reportDesktopDelta.ts",

--- a/scripts/build-linux-release.ts
+++ b/scripts/build-linux-release.ts
@@ -1,0 +1,12 @@
+#!/usr/bin/env bun
+import { chmod, cp, mkdir, readFile, rm } from "node:fs/promises";
+import { join, resolve } from "node:path";
+const root = resolve(import.meta.dir, ".."), { version } = JSON.parse(await readFile(join(root, "package.json"), "utf8")) as { version: string };
+const releaseDir = join(root, "dist", "linux"), packageDir = join(releaseDir, `Vyline-linux-x64-${version}`), webDir = join(packageDir, "web");
+function run(command: string, args: string[]) { const r = Bun.spawnSync([command, ...args], { cwd: root, stdout: "inherit", stderr: "inherit" }); if (r.exitCode !== 0) throw new Error(`${command} failed`); }
+await rm(releaseDir, { recursive: true, force: true }); await mkdir(webDir, { recursive: true }); run("bun", ["run", "build"]);
+await cp(join(root, "Vyline", "apps", "desktop", "dist"), webDir, { recursive: true }); await cp(join(root, "openapi.yaml"), join(packageDir, "openapi.yaml"));
+const args = ["build", "--compile", "--minify", "--target=bun-linux-x64", "--outfile"];
+run("bun", [...args, join(packageDir, "VylineBackend"), join(root, "Vyline", "backend", "src", "index.ts")]); run("bun", [...args, join(packageDir, "Vyline"), join(root, "scripts", "linux-launcher.ts")]);
+await cp(join(root, "installer", "install-linux.sh"), join(packageDir, "install.sh")); await chmod(join(packageDir, "install.sh"), 0o755); await chmod(join(packageDir, "Vyline"), 0o755); await chmod(join(packageDir, "VylineBackend"), 0o755);
+run("tar", ["-czf", join(releaseDir, `Vyline-linux-x64-${version}.tar.gz`), "-C", releaseDir, `Vyline-linux-x64-${version}`]);

--- a/scripts/build-windows-release.ts
+++ b/scripts/build-windows-release.ts
@@ -1,0 +1,14 @@
+#!/usr/bin/env bun
+import { cp, mkdir, readFile, rm } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+const root = resolve(import.meta.dir, "..");
+const { version } = JSON.parse(await readFile(join(root, "package.json"), "utf8")) as { version: string };
+const releaseDir = join(root, "dist", "windows"), packageDir = join(releaseDir, "Vyline"), webDir = join(packageDir, "web");
+function run(command: string, args: string[]) { const r = Bun.spawnSync([command, ...args], { cwd: root, stdout: "inherit", stderr: "inherit" }); if (r.exitCode !== 0) throw new Error(`${command} failed`); }
+function findIscc() { for (const p of ["C:\\Program Files (x86)\\Inno Setup 6\\ISCC.exe", "C:\\Program Files\\Inno Setup 6\\ISCC.exe", "iscc"]) if (p === "iscc" || existsSync(p)) return p; throw new Error("Inno Setup (ISCC.exe) is not installed"); }
+await rm(releaseDir, { recursive: true, force: true }); await mkdir(webDir, { recursive: true });
+run("bun", ["run", "build"]); await cp(join(root, "Vyline", "apps", "desktop", "dist"), webDir, { recursive: true }); await cp(join(root, "openapi.yaml"), join(packageDir, "openapi.yaml"));
+const args = ["build", "--compile", "--minify", "--target=bun-windows-x64", `--windows-version=${version.match(/^\d+\.\d+\.\d+/)?.[0] ?? "0.0.0"}.0`, "--windows-hide-console", "--outfile"];
+run("bun", [...args, join(packageDir, "VylineBackend.exe"), join(root, "Vyline", "backend", "src", "index.ts")]); run("bun", [...args, join(packageDir, "Vyline.exe"), join(root, "scripts", "windows-launcher.ts")]);
+run(findIscc(), [`/DAppVersion=${version}`, `/DSourceDir=${packageDir}`, `/DOutputDir=${releaseDir}`, join(root, "installer", "Vyline.iss")]);

--- a/scripts/linux-launcher.ts
+++ b/scripts/linux-launcher.ts
@@ -1,0 +1,27 @@
+import { mkdir } from "node:fs/promises";
+import { realpathSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+const installDir = dirname(realpathSync(process.execPath));
+const home = process.env.HOME ?? installDir;
+const dataRoot = join(process.env.XDG_DATA_HOME ?? join(home, ".local", "share"), "Vyline");
+const backend = join(installDir, "VylineBackend");
+const port = "18765";
+const url = `http://127.0.0.1:${port}`;
+async function isRunning(): Promise<boolean> { try { return (await fetch(`${url}/healthz`)).ok; } catch { return false; } }
+function openBrowser() { Bun.spawn(["xdg-open", url], { stdin: "ignore", stdout: "ignore", stderr: "ignore" }); }
+await mkdir(dataRoot, { recursive: true });
+if (!(await isRunning())) {
+  const child = Bun.spawn([backend], {
+    cwd: installDir,
+    env: {
+      ...process.env, PORT: port, VYLINE_HOST: "127.0.0.1", VYLINE_CORS_ORIGIN: url,
+      VYLINE_STATIC_DIR: join(installDir, "web"), VYLINE_OPENAPI_PATH: join(installDir, "openapi.yaml"),
+      VYLINE_DATA_DIR: join(dataRoot, "data"), VYLINE_STORAGE_DIR: join(dataRoot, "storage"),
+      VYLINE_LOG_DIR: join(dataRoot, "data", "logs"), VYLINE_CDN_CACHE_DIR: join(dataRoot, "storage", "cache", "cdn-cache"),
+      VYLINE_ICON_CACHE_DIR: join(dataRoot, "storage", "cache", "icons"), VYLINE_MEDIA_STORAGE_DIR: join(dataRoot, "storage", "saved-media"),
+    }, stdin: "ignore", stdout: "ignore", stderr: "ignore",
+  });
+  for (let attempt = 0; attempt < 60; attempt++) { if (await isRunning()) break; if (attempt === 59) throw new Error("Vyline backend did not start"); await Bun.sleep(250); }
+  openBrowser(); await child.exited;
+} else openBrowser();

--- a/scripts/windows-launcher.ts
+++ b/scripts/windows-launcher.ts
@@ -1,0 +1,39 @@
+import { mkdir } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+const installDir = dirname(process.execPath);
+const appData = process.env.APPDATA ?? join(process.env.USERPROFILE ?? installDir, "AppData", "Roaming");
+const dataRoot = join(appData, "Vyline");
+const backend = join(installDir, "VylineBackend.exe");
+const port = "18765";
+const url = `http://127.0.0.1:${port}`;
+
+async function isRunning(): Promise<boolean> {
+  try { return (await fetch(`${url}/healthz`)).ok; } catch { return false; }
+}
+
+function openBrowser() {
+  Bun.spawn(["cmd.exe", "/d", "/c", "start", "", url], { stdin: "ignore", stdout: "ignore", stderr: "ignore", windowsHide: true });
+}
+
+await mkdir(dataRoot, { recursive: true });
+if (!(await isRunning())) {
+  const child = Bun.spawn([backend], {
+    cwd: installDir,
+    env: {
+      ...process.env, PORT: port, VYLINE_HOST: "127.0.0.1", VYLINE_CORS_ORIGIN: url,
+      VYLINE_STATIC_DIR: join(installDir, "web"), VYLINE_OPENAPI_PATH: join(installDir, "openapi.yaml"),
+      VYLINE_DATA_DIR: join(dataRoot, "data"), VYLINE_STORAGE_DIR: join(dataRoot, "storage"),
+      VYLINE_LOG_DIR: join(dataRoot, "data", "logs"), VYLINE_CDN_CACHE_DIR: join(dataRoot, "storage", "cache", "cdn-cache"),
+      VYLINE_ICON_CACHE_DIR: join(dataRoot, "storage", "cache", "icons"), VYLINE_MEDIA_STORAGE_DIR: join(dataRoot, "storage", "saved-media"),
+    },
+    stdin: "ignore", stdout: "ignore", stderr: "ignore", windowsHide: true,
+  });
+  for (let attempt = 0; attempt < 60; attempt++) {
+    if (await isRunning()) break;
+    if (attempt === 59) throw new Error("Vyline backend did not start");
+    await Bun.sleep(250);
+  }
+  openBrowser();
+  await child.exited;
+} else openBrowser();


### PR DESCRIPTION
## Summary

- Add tag-driven Windows installer packaging with Inno Setup
- Add Linux x64 tar.gz packaging and user-level install script
- Publish versioned and latest Docker images to GHCR
- Link the in-app updater directly to the matching Windows installer
- Document Docker, Linux, and Windows distribution/update flows

## Verification

- bun run typecheck: passed
- bunx biome check Vyline/apps Vyline/backend: passed
- bun run package:linux: passed
- bun run lint: existing CRLF formatting failure in Vyline/packages/protocol/biome.json; submodule unchanged
- Docker build: not run locally because Docker Desktop daemon was unavailable