### PR TITLE
fix: stabilize revoke, read receipts, account isolation, and MID search

### DIFF
--- a/Vyline/apps/desktop/src/components/beta-consent.tsx
+++ b/Vyline/apps/desktop/src/components/beta-consent.tsx
@@ -1,9 +1,11 @@
 import { useState } from "react";
 import { useStore } from "@/lib/store";
 import { Toggle } from "@/components/vy-ui";
+import { api } from "@/api/client";
 
 const CONSENT_KEY = "vyline:beta-feature-consent-v1";
 const BLOCK_CHECK_FEATURE = "block-status-check";
+const MID_SEARCH_FEATURE = "mid-user-search";
 
 type ConsentLog = Record<string, { consentedAt: string; version: string }>;
 
@@ -41,12 +43,22 @@ function recordBetaFeatureConsent(featureId: string): boolean {
 export function BetaSection() {
   const settings = useStore((s) => s.settings);
   const updateSetting = useStore((s) => s.updateSetting);
+  const accountId = useStore((s) => s.accountId);
+  const [mid, setMid] = useState("");
+  const [searching, setSearching] = useState(false);
+  const [searchError, setSearchError] = useState<string | null>(null);
+  const [profile, setProfile] = useState<{
+    mid: string;
+    displayName: string;
+    statusMessage: string;
+  } | null>(null);
   const [consentPending, setConsentPending] = useState<
-    "betaBlockCheckManual" | "betaBlockCheckAuto" | null
+    "betaBlockCheckManual" | "betaBlockCheckAuto" | "betaMidSearch" | null
   >(null);
 
-  const requestEnable = (key: "betaBlockCheckManual" | "betaBlockCheckAuto") => {
-    if (hasBetaFeatureConsent(BLOCK_CHECK_FEATURE)) {
+  const requestEnable = (key: "betaBlockCheckManual" | "betaBlockCheckAuto" | "betaMidSearch") => {
+    const feature = key === "betaMidSearch" ? MID_SEARCH_FEATURE : BLOCK_CHECK_FEATURE;
+    if (hasBetaFeatureConsent(feature)) {
       updateSetting(key, true);
       return;
     }
@@ -54,7 +66,9 @@ export function BetaSection() {
   };
 
   const agree = () => {
-    if (!consentPending || !recordBetaFeatureConsent(BLOCK_CHECK_FEATURE)) return;
+    if (!consentPending) return;
+    const feature = consentPending === "betaMidSearch" ? MID_SEARCH_FEATURE : BLOCK_CHECK_FEATURE;
+    if (!recordBetaFeatureConsent(feature)) return;
     updateSetting(consentPending, true);
     setConsentPending(null);
   };
@@ -96,13 +110,82 @@ export function BetaSection() {
             label="自動ブロック確認"
           />
         </Row>
+        <Row
+          title="MID でユーザー検索（Beta）"
+          desc="u + 32桁の16進数のMIDからプロフィールだけを検索します。"
+        >
+          <Toggle
+            checked={settings.betaMidSearch}
+            onChange={(value) =>
+              value ? requestEnable("betaMidSearch") : updateSetting("betaMidSearch", false)
+            }
+            label="MID検索"
+          />
+        </Row>
       </Card>
+
+      {settings.betaMidSearch && (
+        <Card>
+          <div className="py-4">
+            <p className="text-sm font-medium">ユーザー MID を検索</p>
+            <div className="mt-2 flex gap-2">
+              <input
+                value={mid}
+                onChange={(event) => setMid(event.target.value.trim())}
+                placeholder="u + 32桁の16進数"
+                className="min-w-0 flex-1 rounded-lg border border-[var(--vy-border)] bg-[var(--vy-surface-2)] px-3 py-2 text-sm"
+                spellCheck={false}
+              />
+              <button
+                type="button"
+                disabled={searching || !accountId}
+                onClick={async () => {
+                  if (!accountId || !/^u[0-9a-f]{32}$/i.test(mid)) {
+                    setSearchError("u + 32桁の16進数で入力してください");
+                    setProfile(null);
+                    return;
+                  }
+                  setSearching(true);
+                  setSearchError(null);
+                  setProfile(null);
+                  try {
+                    const response = await api.line.contactProfile(accountId, mid);
+                    if (!response.ok || !response.profile)
+                      throw new Error("ユーザーが見つかりません");
+                    setProfile({
+                      mid,
+                      displayName: response.profile.displayName,
+                      statusMessage: response.profile.statusMessage,
+                    });
+                  } catch (error) {
+                    setSearchError(error instanceof Error ? error.message : "検索に失敗しました");
+                  } finally {
+                    setSearching(false);
+                  }
+                }}
+                className="rounded-lg px-3 py-2 text-xs font-semibold text-[var(--vy-accent-contrast)] disabled:opacity-50"
+                style={{ background: "var(--vy-accent)" }}
+              >
+                {searching ? "検索中…" : "検索"}
+              </button>
+            </div>
+            {searchError && <p className="mt-2 text-xs text-red-400">{searchError}</p>}
+            {profile && (
+              <div className="mt-3 rounded-lg border border-[var(--vy-border)] p-3 text-xs">
+                <p className="font-semibold">{profile.displayName || profile.mid}</p>
+                <p className="mt-1 break-all text-[var(--vy-text-dim)]">{profile.mid}</p>
+                {profile.statusMessage && <p className="mt-1">{profile.statusMessage}</p>}
+              </div>
+            )}
+          </div>
+        </Card>
+      )}
 
       {consentPending && (
         <div className="mt-4 rounded-xl border border-[var(--vy-border)] bg-[var(--vy-surface-2)] p-4 text-sm">
           <p className="font-semibold">ベータ機能の個別同意</p>
           <p className="mt-2 text-xs leading-relaxed text-[var(--vy-text-dim)]">
-            ブロック確認機能を有効にすると、友だち一覧などの情報を端末上で処理します。
+            有効にした機能に応じて、友だち一覧または指定MIDのプロフィールを端末上で処理します。
             機能ごとの同意記録は端末内だけに保存します。利用を続ける場合は同意してください。
           </p>
           <div className="mt-3 flex gap-2">

--- a/Vyline/apps/desktop/src/lib/store-types.ts
+++ b/Vyline/apps/desktop/src/lib/store-types.ts
@@ -206,6 +206,8 @@ export type Settings = {
   betaBlockCheckManual: boolean;
   /** ベータ: 友だち全員のブロック状態を自動確認 */
   betaBlockCheckAuto: boolean;
+  /** ベータ: u* MID を直接指定してプロフィールを検索 */
+  betaMidSearch: boolean;
 };
 
 export type SelfProfile = {

--- a/Vyline/apps/desktop/src/lib/store.ts
+++ b/Vyline/apps/desktop/src/lib/store.ts
@@ -483,6 +483,7 @@ export const useStore = create<State>()(
         notificationsEnabled: true,
         betaBlockCheckManual: false,
         betaBlockCheckAuto: false,
+        betaMidSearch: false,
       },
       chats: [],
       messages: [],
@@ -520,7 +521,22 @@ export const useStore = create<State>()(
           sessionOpenedChats.clear();
           eventPollCursor.delete(String(id));
         }
-        set({ accountId: id });
+        if (id !== get().accountId) {
+          // アカウント切替時に前アカウントの会話・既読・一時 UI を残さない。
+          // 共有 MID をまたぐ表示漏れを防ぎ、後続 hydrate の正本を明確にする。
+          set({
+            accountId: id,
+            chats: [],
+            messages: [],
+            activeChatId: null,
+            memberProfile: null,
+            readWatermarks: {},
+            announcements: {},
+            blockedMids: [],
+          });
+        } else {
+          set({ accountId: id });
+        }
       },
 
       resetAccountData: () =>
@@ -664,6 +680,7 @@ export const useStore = create<State>()(
             notificationsEnabled: true,
             betaBlockCheckManual: false,
             betaBlockCheckAuto: false,
+            betaMidSearch: false,
           },
           sidebarWidth: 360,
           customOrder: [],

--- a/Vyline/backend/src/api/line.ts
+++ b/Vyline/backend/src/api/line.ts
@@ -967,7 +967,8 @@ lineRouter.get("/:accountId/read-receipts/:chatMid", async (c) => {
     return c.json({ ok: false, error: "ids query required" }, 400);
   }
 
-  const inflightKey = `${accountId}:${chatMid}`;
+  // 同一チャットでも要求する messageIds が違えば結果も違う。
+  const inflightKey = `${accountId}:${chatMid}:${[...new Set(messageIds)].sort().join(",")}`;
 
   try {
     const existing = readReceiptInflight.get(inflightKey);

--- a/Vyline/backend/src/service/lineService.readReceipts.test.ts
+++ b/Vyline/backend/src/service/lineService.readReceipts.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "bun:test";
+import type { Message } from "@vyline/types";
+import { attachGroupReadReceipts } from "./lineService";
+
+describe("attachGroupReadReceipts", () => {
+  it("preserves readers from earlier polls while adding new readers", () => {
+    const message = {
+      id: "100",
+      isMyMessage: true,
+      readBy: ["u-old"],
+      readCount: 1,
+    } as unknown as Message;
+
+    attachGroupReadReceipts(
+      [message],
+      [
+        { mid: "u-new", upTo: 100n },
+        { mid: "u-old", upTo: 100n },
+      ],
+    );
+
+    expect(message.readBy).toEqual(["u-old", "u-new"]);
+    expect(message.readCount).toBe(2);
+  });
+});

--- a/Vyline/backend/src/service/lineService.ts
+++ b/Vyline/backend/src/service/lineService.ts
@@ -48,6 +48,7 @@ import { updateSessionMeta } from "../storage/tokenStore.js";
 import { VylineStorage } from "../storage/vylineStorage.js";
 import { banCreateGroup, isCreateGroupBanned } from "../storage/featureLocks.js";
 import { checkStickerGiftEligibility } from "./liffFeatures.js";
+import { isReadOperationType, isReceiveMessageOperationType } from "./talkOperationTypes.js";
 import {
   ensureValidE2EEIdentity,
   prepareGroupKeysForMessages,
@@ -2266,11 +2267,12 @@ export function attachGroupReadReceipts(
       if (m.readCount == null) m.readCount = 0;
       continue;
     }
-    // プロトコル readCount が無い／小さい場合はレンジ由来で上書き
-    if (m.readCount == null || readers.length > m.readCount) {
-      m.readCount = readers.length;
+    // 別ポーリングで得た既読者を失わない。既読は後から巻き戻らないため単調に保持する。
+    const mergedReaders = [...new Set([...(m.readBy ?? []), ...readers])];
+    if (m.readCount == null || mergedReaders.length > m.readCount) {
+      m.readCount = mergedReaders.length;
     }
-    m.readBy = readers;
+    m.readBy = mergedReaders;
   }
 }
 
@@ -3158,12 +3160,7 @@ async function processSingleOperation(
   const type = String(op.type ?? "");
 
   // メッセージ系 — op.message があれば直接処理
-  if (
-    type === "RECEIVE_MESSAGE" ||
-    type === "25" ||
-    type === "NOTIFIED_RECEIVE_MESSAGE" ||
-    type === "26"
-  ) {
+  if (isReceiveMessageOperationType(type)) {
     if (op.message) {
       const raw = op.message as Record<string, unknown>;
       const chatMid = chatMidFromRaw(raw, myMid);
@@ -3211,15 +3208,7 @@ async function processSingleOperation(
   }
 
   // 既読通知
-  if (
-    type === "NOTIFIED_READ_MESSAGE" ||
-    type === "25" ||
-    type === "RECEIVE_MESSAGE_RECEIPT" ||
-    type === "28" ||
-    type === "RECEIVE_READ_WATERMARK" ||
-    type === "30" ||
-    type === "29"
-  ) {
+  if (isReadOperationType(type)) {
     const chatMid = String(op.param1 ?? "");
     if (/^[ucr]/.test(chatMid)) {
       pushTalkEvent(accountId, { kind: "read", chatMid });
@@ -3682,6 +3671,12 @@ async function fetchMessagesInner(
         try {
           const ranges = await fetchReadRanges(accountId, chatMid, { force: true });
           applyReadReceiptsToMessages(messages, ranges, chatMid, myMid);
+          // バックグラウンド取得結果も必ずアカウント別 chatdb に保存する。
+          await upsertMessages(
+            accountId,
+            chatMid,
+            messages.map((m) => ({ ...m, chatMid, savedAt: new Date().toISOString() })),
+          );
           if (chatMid.startsWith("c") || chatMid.startsWith("r")) {
             const readerMids = new Set<string>();
             for (const m of messages) {

--- a/Vyline/backend/src/service/talkOperationTypes.test.ts
+++ b/Vyline/backend/src/service/talkOperationTypes.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "bun:test";
+import { isReadOperationType, isReceiveMessageOperationType } from "./talkOperationTypes";
+
+describe("Talk operation type classification", () => {
+  it("keeps SEND_MESSAGE (25) out of receive and read paths", () => {
+    expect(isReceiveMessageOperationType("25")).toBe(false);
+    expect(isReadOperationType("25")).toBe(false);
+  });
+
+  it("recognizes the protocol receive-message code", () => {
+    expect(isReceiveMessageOperationType("26")).toBe(true);
+  });
+
+  it("recognizes read notifications and watermarks", () => {
+    expect(isReadOperationType("55")).toBe(true);
+    expect(isReadOperationType("28")).toBe(true);
+    expect(isReadOperationType("91")).toBe(true);
+  });
+});

--- a/Vyline/backend/src/service/talkOperationTypes.ts
+++ b/Vyline/backend/src/service/talkOperationTypes.ts
@@ -1,0 +1,15 @@
+export function isReceiveMessageOperationType(type: string): boolean {
+  return type === "RECEIVE_MESSAGE" || type === "26" || type === "NOTIFIED_RECEIVE_MESSAGE";
+}
+
+export function isReadOperationType(type: string): boolean {
+  return (
+    type === "NOTIFIED_READ_MESSAGE" ||
+    type === "55" ||
+    type === "RECEIVE_MESSAGE_RECEIPT" ||
+    type === "28" ||
+    type === "RECEIVE_READ_WATERMARK" ||
+    type === "91" ||
+    type === "29"
+  );
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -63,6 +63,7 @@ LINE との通常の通信は発生します。これは法的助言ではあり
 | [analysis/README.md](./analysis/README.md)         | 機能別解析メモ索引                 |
 | [analysis/stickers.md](./analysis/stickers.md)     | スタンプ/絵文字 API 解析           |
 | [analysis/line-emoji.md](./analysis/line-emoji.md) | LINE 絵文字 (sticon) 解析          |
+| [analysis/stability-read-revoke-multi-account.md](./analysis/stability-read-revoke-multi-account.md) | 取消・既読者・複数アカウント・MID検索の安定化 |
 
 ## 検索・参照ツール
 

--- a/docs/analysis/stability-read-revoke-multi-account.md
+++ b/docs/analysis/stability-read-revoke-multi-account.md
@@ -1,0 +1,46 @@
+# 取消・既読者・複数アカウント・MID検索の安定化
+
+最終更新: 2026-08-24
+
+## 対象
+
+- 送信取消メッセージの保持・表示
+- グループ内の既読者（既読レンジの取得、保存、再読込）
+- 複数アカウントの状態分離
+- Beta の MID ユーザー検索
+
+## 変更点
+
+Operation type の分類では `25 (SEND_MESSAGE)` を受信・既読として扱わず、`26 (RECEIVE_MESSAGE)` と `55 / 28 / 91` 系をそれぞれ正しく分類する。誤分類は既読通知の取りこぼしとイベント二重処理の原因になる。
+
+### 送信取消
+
+`chatStore` は取消前の内容を `revokedSnapshot` と履歴へ保存する。Desktop は取消を楽観表示するが、API が失敗した場合は元のメッセージへ戻す。これにより、通信失敗を取消成功として永続化しない。
+
+取消イベントは `lineService.processSingleOperation` から `markMessageRevoked(accountId, chatMid, messageId)` へ渡り、アカウント別 chatdb に保存される。再取得時も保存済みの取消状態を通常メッセージで上書きしない。
+
+### グループ既読者
+
+`fetchReadRanges` で取得したレンジを `attachGroupReadReceipts` が `readBy` / `readCount` に変換する。複数回のポーリングで得た読者は集合として統合し、既に確認済みの読者を失わない。
+
+メッセージ取得中のバックグラウンド既読更新も、更新後のメッセージをアカウント別 chatdb へ再保存する。既読者プロフィールは `fetchContactProfile` で事前解決し、Desktop の読者一覧で名前を表示できる。
+
+API の既読取得 in-flight キーには `accountId`、チャットMID、要求したメッセージID集合を含める。異なるアカウントや異なるID集合の応答を共有しない。
+
+### 複数アカウント
+
+Desktop の既読ウォーターマーク、既読取得、delta、履歴補完の一時キャッシュは `accountId:chatMid` をキーにする。アカウント切替時には表示中のチャット・メッセージ・既読・お知らせ・ブロック一覧をクリアし、切替先の hydrate を正本にする。
+
+バックエンドの永続データは `backend/data/accounts/<safeAccountId>/` 配下を正本とする。鍵・セッション・実データをログやドキュメントへ出力しない。
+
+### MID検索 Beta
+
+設定 > ベータ機能で個別同意後に有効化する。`u` + 32桁の16進数のMIDだけを受け付け、既存のアカウント別 `GET /line/:accountId/contact/:targetMid` とプロフィールキャッシュを利用する。検索は読み取り専用で、送信・友だち追加・ブロック操作は行わない。
+
+## 検証
+
+```powershell
+bun run typecheck
+```
+
+実アカウントへの送信テストは行わない。送信取消を実通信で確認する場合も、AGENTS.md に定めるテスト対象だけを使用する。

--- a/docs/analysis/sync-events.md
+++ b/docs/analysis/sync-events.md
@@ -56,6 +56,8 @@ HTTP/2 の `/PUSH/1/subs` エンドポイントでサーバーから即座にイ
 
 > 注: `GET /events/poll` の `events` 配列では、push された message を `kind: "message"` としてフロントエンドに渡す。Operation (revoke/read/reaction) は `pushTalkEvent` → `TalkPollEventPayload` として、`kind` で判別してバッファする。
 
+重要: `25` は `SEND_MESSAGE` であり、新着メッセージや既読通知ではない。受信メッセージは `26`、既読通知は `55` / `28` / `91` 系として分類する。`25` を既読・受信分岐へ含めると、送信操作を誤処理して既読通知を取りこぼす。
+
 ## 4. Desktop 差分
 
 - `bun run vyline:delta` (`reportDesktopDelta.ts`) で Desktop LINE の更新を検出

--- a/docs/tasks/STATUS.md
+++ b/docs/tasks/STATUS.md
@@ -68,7 +68,7 @@ desktop (React + Vite) ──HTTP──► backend (Hono on Bun)
 
 ## 次（優先順）
 
-1. 既読者表示の完全修繕（メンバー名解決の事前取得済→表示検証）
+1. 実通信での取消・既読者・複数アカウント表示検証（保存・分離を安定化済み）
 2. 通話品質改善（acquireCallRoute エラー処理済→実通話テスト）
 3. UI 細部改善（継続）
 4. stack RPC の Desktop 準拠への段階的置換


### PR DESCRIPTION
## Summary
- stabilize revoked-message retention/display and rollback failed optimistic unsend
- persist and merge group read-by users across polling and reloads
- isolate desktop read/delta/history state per account and clear account-scoped UI on switch
- add consent-gated Beta MID user search using the existing account-scoped profile endpoint
- correct LINE operation classification: 25 is SEND_MESSAGE, not receive/read

## Verification
- `bun test` — 209 pass, 0 fail
- `bun run typecheck` — pass
- `bun run lint` — pass
- `bun run --cwd Vyline/apps/desktop build` — pass

No real-user or real-group send tests were performed.