### PR TITLE
fix: stop member profile background flicker

### DIFF
--- a/Vyline/apps/desktop/src/components/member-profile.tsx
+++ b/Vyline/apps/desktop/src/components/member-profile.tsx
@@ -91,7 +91,7 @@ export function MemberProfilePopover({ chat }: { chat: Chat }) {
       .commonGroups(accountId, member.id, chat.id)
       .then((res) => {
         if (cancelled || !res.ok || !res.groups) return;
-        const byId = new Map(chats.map((c) => [c.id, c]));
+        const byId = new Map(useStore.getState().chats.map((c) => [c.id, c]));
         setApiCommonGroups(
           res.groups.map((g) => {
             const local = byId.get(g.chatMid);
@@ -114,7 +114,7 @@ export function MemberProfilePopover({ chat }: { chat: Chat }) {
     return () => {
       cancelled = true;
     };
-  }, [accountId, member?.id, chat.id, streamerMode, chats]);
+  }, [accountId, member?.id, chat.id, streamerMode]);
 
   if (!member) return null;
 


### PR DESCRIPTION
## Summary
- prevent member profile fetch effect from resetting rich profile state on every chats update
- keep the latest chat list lookup without making it an effect dependency

## Root cause
The effect updated chats while also depending on the chats array. That retriggered the effect, cleared 
ich, removed the background, then restored it after the profile request completed.

## Verification
- Biome check: passed for Vyline/apps/desktop/src/components/member-profile.tsx
- Desktop typecheck could not run in the isolated worktree because the pre-push typecheck hook recursively re-invoked itself and hit the Windows job-object limit (AssignProcessToJobObject: (50)).