### PR TITLE
fix: restore iOS backup UI and merge history

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ COPY package.json bun.lock* ./
 COPY Vyline/apps/desktop/package.json Vyline/apps/desktop/
 COPY Vyline/backend/package.json Vyline/backend/
 COPY Vyline/packages/types/package.json Vyline/packages/types/
+COPY Vyline/packages/ios-backup/package.json Vyline/packages/ios-backup/
 COPY Vyline/packages/protocol/package.json Vyline/packages/protocol/
 COPY Vyline/packages/line-types/package.json Vyline/packages/line-types/
 COPY Vyline/packages/loose-types/package.json Vyline/packages/loose-types/

--- a/Vyline/apps/desktop/src/api/client.ts
+++ b/Vyline/apps/desktop/src/api/client.ts
@@ -105,12 +105,14 @@ async function request<T>(
 
 export const api = {
   subdevices: {
-    createPairing: (accountId: string) =>
-      request<{ ok: boolean; token?: string; expiresAt?: number; error?: string }>(
-        "POST",
-        "/auth/subdevices/pairing",
-        { accountId },
-      ),
+    createPairing: (accountId: string, origin?: string) =>
+      request<{
+        ok: boolean;
+        token?: string;
+        expiresAt?: number;
+        pairingUrl?: string;
+        error?: string;
+      }>("POST", "/auth/subdevices/pairing", { accountId, origin }),
     list: () =>
       request<{
         ok: boolean;

--- a/Vyline/apps/desktop/src/api/client.ts
+++ b/Vyline/apps/desktop/src/api/client.ts
@@ -814,6 +814,7 @@ export const api = {
             restoredAt: string;
             extracted: { lineFiles: number; databases: number };
             parsed: { chats: number; totalMessages: number };
+            media: { restored: number; skipped: number };
           } | null;
           error: string | null;
           startedAt: number;

--- a/Vyline/apps/desktop/src/api/client.ts
+++ b/Vyline/apps/desktop/src/api/client.ts
@@ -111,6 +111,7 @@ export const api = {
         token?: string;
         expiresAt?: number;
         pairingUrl?: string;
+        lanAccessRequired?: boolean;
         error?: string;
       }>("POST", "/auth/subdevices/pairing", { accountId, origin }),
     list: () =>

--- a/Vyline/apps/desktop/src/api/client.ts
+++ b/Vyline/apps/desktop/src/api/client.ts
@@ -808,6 +808,9 @@ export const api = {
             file?: string;
           } | null;
           result: {
+            deviceId: string;
+            backupDate: string;
+            restoredAt: string;
             extracted: { lineFiles: number; databases: number };
             parsed: { chats: number; totalMessages: number };
           } | null;

--- a/Vyline/apps/desktop/src/components/chat-shell.tsx
+++ b/Vyline/apps/desktop/src/components/chat-shell.tsx
@@ -89,7 +89,7 @@ function ChatShellBase() {
           type="button"
           onClick={toggleSidebar}
           aria-label={collapsed ? "サイドバーを開く" : "サイドバーを閉じる"}
-          className="absolute left-2 top-3 z-20 hidden h-8 w-8 items-center justify-center rounded-lg bg-[var(--vy-surface-2)]/80 text-[var(--vy-text-dim)] backdrop-blur transition-colors hover:text-[var(--vy-text)] focus-visible:ring-2 focus-visible:ring-[var(--vy-accent)] focus-visible:outline-none md:flex"
+          className="absolute left-2 top-3 z-20 hidden h-8 w-8 items-center justify-center rounded-lg bg-[var(--vy-surface-2)] text-[var(--vy-text-dim)] transition-colors hover:text-[var(--vy-text)] focus-visible:ring-2 focus-visible:ring-[var(--vy-accent)] focus-visible:outline-none md:flex"
         >
           <IconPanelLeft size={17} />
         </button>

--- a/Vyline/apps/desktop/src/components/ios-backup-beta-panel.tsx
+++ b/Vyline/apps/desktop/src/components/ios-backup-beta-panel.tsx
@@ -125,7 +125,8 @@ export function IosBackupBetaPanel({ accountId }: { accountId: string | null }) 
                       year: "numeric",
                       month: "2-digit",
                       day: "2-digit",
-                    }).format(new Date(session.result.restoredAt))}にデータを復元済み
+                    }).format(new Date(session.result.restoredAt))}
+                    にデータを復元済み
                   </span>
                 )}
               </button>

--- a/Vyline/apps/desktop/src/components/ios-backup-beta-panel.tsx
+++ b/Vyline/apps/desktop/src/components/ios-backup-beta-panel.tsx
@@ -119,6 +119,15 @@ export function IosBackupBetaPanel({ accountId }: { accountId: string | null }) 
                 <span className="mt-1 block truncate font-mono text-[0.65rem] text-[var(--vy-text-dim)]">
                   {device.udid}
                 </span>
+                {session?.status === "completed" && session.result?.deviceId === device.udid && (
+                  <span className="mt-1 block text-xs text-[var(--vy-text-dim)]">
+                    {new Intl.DateTimeFormat("ja-JP", {
+                      year: "numeric",
+                      month: "2-digit",
+                      day: "2-digit",
+                    }).format(new Date(session.result.restoredAt))}にデータを復元済み
+                  </span>
+                )}
               </button>
             ))}
             <div className="flex gap-2">

--- a/Vyline/apps/desktop/src/components/ios-backup-beta-panel.tsx
+++ b/Vyline/apps/desktop/src/components/ios-backup-beta-panel.tsx
@@ -170,6 +170,7 @@ export function IosBackupBetaPanel({ accountId }: { accountId: string | null }) 
           <IconCheck size={14} />
           復元完了：{session.result.parsed.chats} チャット /{" "}
           {session.result.parsed.totalMessages.toLocaleString()} メッセージ
+          {" · "}メディア {session.result.media.restored.toLocaleString()} 件
         </p>
       )}
       {session?.status === "failed" && (

--- a/Vyline/apps/desktop/src/components/ios-backup-beta-panel.tsx
+++ b/Vyline/apps/desktop/src/components/ios-backup-beta-panel.tsx
@@ -46,6 +46,11 @@ export function IosBackupBetaPanel({ accountId }: { accountId: string | null }) 
     return () => window.clearInterval(timer);
   }, [accountId, session]);
 
+  useEffect(() => {
+    if (session?.status !== "completed" || !accountId) return;
+    window.dispatchEvent(new CustomEvent("vyline:ios-backup-restored", { detail: { accountId } }));
+  }, [accountId, session?.status]);
+
   const start = async () => {
     if (!accountId || !selected || !password) return;
     setLoading(true);
@@ -78,8 +83,9 @@ export function IosBackupBetaPanel({ accountId }: { accountId: string | null }) 
         <div className="min-w-0 flex-1">
           <h3 className="font-semibold">iTunes / Apple Devices の復元</h3>
           <p className="mt-1 text-xs leading-relaxed text-[var(--vy-text-dim)]">
-            暗号化された iPhone ローカルバックアップを解析し、トーク履歴を Vyline
-            用の検証データへ展開します。元のバックアップは変更しません。
+            暗号化された iPhone ローカルバックアップを復号し、トーク・チャット情報と
+            復元できるメディアを Vyline
+            のアカウントDBへ自動で追加します。既存データは上書きせず、元のバックアップも変更しません。
           </p>
         </div>
         <button

--- a/Vyline/apps/desktop/src/components/ios-backup-beta-panel.tsx
+++ b/Vyline/apps/desktop/src/components/ios-backup-beta-panel.tsx
@@ -1,0 +1,181 @@
+import { useEffect, useState } from "react";
+import { api } from "@/api/client";
+import { IconBlock, IconCheck, IconHardDrive, IconShield, IconSpark } from "@/components/icons";
+
+type Device = NonNullable<Awaited<ReturnType<typeof api.line.listIosBackups>>["devices"]>[number];
+type Session = NonNullable<Awaited<ReturnType<typeof api.line.getIosBackupSession>>["session"]>;
+
+export function IosBackupBetaPanel({ accountId }: { accountId: string | null }) {
+  const [devices, setDevices] = useState<Device[]>([]);
+  const [selected, setSelected] = useState<Device | null>(null);
+  const [password, setPassword] = useState("");
+  const [session, setSession] = useState<Session | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const load = async () => {
+    if (!accountId) return;
+    setLoading(true);
+    setMessage(null);
+    try {
+      const response = await api.line.listIosBackups(accountId);
+      if (!response.ok) throw new Error(response.error ?? "バックアップを検索できませんでした");
+      const found = response.devices ?? [];
+      setDevices(found);
+      setSelected((current) =>
+        current && found.some((item) => item.udid === current.udid) ? current : (found[0] ?? null),
+      );
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "バックアップの検索に失敗しました");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void load();
+  }, [accountId]);
+
+  useEffect(() => {
+    if (!session || !accountId || (session.status !== "pending" && session.status !== "running"))
+      return;
+    const timer = window.setInterval(async () => {
+      const response = await api.line.getIosBackupSession(accountId, session.id);
+      if (response.session) setSession(response.session);
+    }, 1000);
+    return () => window.clearInterval(timer);
+  }, [accountId, session]);
+
+  const start = async () => {
+    if (!accountId || !selected || !password) return;
+    setLoading(true);
+    setMessage(null);
+    try {
+      const response = await api.line.startIosBackupRestore(accountId, selected.udid, password);
+      if (!response.ok || !response.sessionId)
+        throw new Error(response.error ?? "復元を開始できませんでした");
+      setSession({
+        id: response.sessionId,
+        status: "pending",
+        progress: null,
+        result: null,
+        error: null,
+        startedAt: Date.now(),
+        completedAt: null,
+      });
+      setPassword("");
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "復元を開始できませんでした");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <section className="mt-6 rounded-2xl border border-amber-500/40 bg-amber-500/5 p-4">
+      <div className="flex items-start gap-3">
+        <IconHardDrive size={20} className="mt-0.5 shrink-0 text-[var(--vy-accent)]" />
+        <div className="min-w-0 flex-1">
+          <h3 className="font-semibold">iTunes / Apple Devices の復元</h3>
+          <p className="mt-1 text-xs leading-relaxed text-[var(--vy-text-dim)]">
+            暗号化された iPhone ローカルバックアップを解析し、トーク履歴を Vyline
+            用の検証データへ展開します。元のバックアップは変更しません。
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => void load()}
+          disabled={loading || !accountId}
+          aria-label="再検索"
+          className="rounded-lg p-2 text-[var(--vy-text-dim)] hover:bg-[var(--vy-surface-2)] disabled:opacity-50"
+        >
+          <IconSpark size={16} className={loading ? "animate-spin" : undefined} />
+        </button>
+      </div>
+
+      <div className="mt-4 rounded-xl border border-[var(--vy-border)] bg-[var(--vy-surface)] p-3">
+        {devices.length === 0 ? (
+          <p className="text-xs text-[var(--vy-text-dim)]">
+            バックアップが見つかりません。iTunes / Apple Devices
+            で「ローカルバックアップを暗号化」を有効にして作成してください。
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {devices.map((device) => (
+              <button
+                key={device.udid}
+                type="button"
+                onClick={() => setSelected(device)}
+                className={`w-full rounded-lg border p-3 text-left ${selected?.udid === device.udid ? "border-[var(--vy-accent)]" : "border-[var(--vy-border)]"}`}
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <span className="flex min-w-0 items-center gap-2 text-sm font-medium">
+                    <IconHardDrive size={15} /> <span className="truncate">{device.name}</span>
+                  </span>
+                  {selected?.udid === device.udid && (
+                    <IconCheck size={16} className="text-[var(--vy-accent)]" />
+                  )}
+                </div>
+                <span className="mt-1 block truncate font-mono text-[0.65rem] text-[var(--vy-text-dim)]">
+                  {device.udid}
+                </span>
+              </button>
+            ))}
+            <div className="flex gap-2">
+              <div className="relative min-w-0 flex-1">
+                <IconShield
+                  size={14}
+                  className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--vy-text-dim)]"
+                />
+                <input
+                  aria-label="バックアップの暗号化パスワード"
+                  type="password"
+                  value={password}
+                  onChange={(event) => setPassword(event.target.value)}
+                  placeholder="暗号化パスワード"
+                  className="w-full rounded-lg border border-[var(--vy-border)] bg-[var(--vy-surface-2)] py-2 pl-9 pr-3 text-sm"
+                />
+              </div>
+              <button
+                type="button"
+                onClick={() => void start()}
+                disabled={loading || !selected || !password}
+                className="rounded-lg px-3 py-2 text-xs font-semibold text-[var(--vy-accent-contrast)] disabled:opacity-50"
+                style={{ background: "var(--vy-accent)" }}
+              >
+                復元開始
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {session?.progress && (
+        <p className="mt-3 text-xs text-[var(--vy-text-dim)]" role="status">
+          {session.progress.message} ({session.progress.current}/{session.progress.total})
+        </p>
+      )}
+      {session?.status === "completed" && session.result && (
+        <p className="mt-3 flex items-center gap-2 text-xs text-emerald-400" role="status">
+          <IconCheck size={14} />
+          復元完了：{session.result.parsed.chats} チャット /{" "}
+          {session.result.parsed.totalMessages.toLocaleString()} メッセージ
+        </p>
+      )}
+      {session?.status === "failed" && (
+        <p className="mt-3 flex items-center gap-2 text-xs text-red-400" role="alert">
+          <IconBlock size={14} />
+          {session.error ?? "復元に失敗しました"}
+        </p>
+      )}
+      {message && (
+        <p className="mt-3 text-xs text-red-400" role="alert">
+          {message}
+        </p>
+      )}
+      <p className="mt-3 text-[0.65rem] text-[var(--vy-text-dim)]">
+        Beta：復元処理は既存のiOSバックアップAPIを使用します。元のバックアップは変更しません。
+      </p>
+    </section>
+  );
+}

--- a/Vyline/apps/desktop/src/components/settings-sections.tsx
+++ b/Vyline/apps/desktop/src/components/settings-sections.tsx
@@ -572,9 +572,12 @@ function SubdevicesSection() {
 
   const startPairing = async () => {
     if (!accountId) return setMessage("LINEログインが必要です");
-    const res = await api.subdevices.createPairing(accountId);
+    const res = await api.subdevices.createPairing(accountId, window.location.origin);
     if (!res.ok || !res.token) return setMessage(res.error ?? "QRコードを作成できませんでした");
-    setPairingUrl(`${window.location.origin}/subdevice?pairing=${encodeURIComponent(res.token)}`);
+    setPairingUrl(
+      res.pairingUrl ??
+        `${window.location.origin}/subdevice?pairing=${encodeURIComponent(res.token)}`,
+    );
     setMessage("スマホの標準カメラでQRコードを読み込んでください（2分間有効）");
   };
 

--- a/Vyline/apps/desktop/src/components/settings-sections.tsx
+++ b/Vyline/apps/desktop/src/components/settings-sections.tsx
@@ -572,14 +572,30 @@ function SubdevicesSection() {
     void load();
   }, []);
 
+  useEffect(() => {
+    if (!pairingUrl) return;
+    const timer = window.setInterval(() => {
+      void api.subdevices.list().then((res) => {
+        if (res.ok) setDevices(res.devices ?? []);
+      });
+    }, 1500);
+    return () => window.clearInterval(timer);
+  }, [pairingUrl]);
+
   const startPairing = async () => {
     if (!accountId) return setMessage("LINEログインが必要です");
     const res = await api.subdevices.createPairing(accountId, window.location.origin);
     if (!res.ok || !res.token) return setMessage(res.error ?? "QRコードを作成できませんでした");
-    setPairingUrl(
-      res.pairingUrl ??
-        `${window.location.origin}/subdevice?pairing=${encodeURIComponent(res.token)}`,
-    );
+    if (!res.pairingUrl) {
+      setPairingUrl(null);
+      setMessage(
+        res.lanAccessRequired
+          ? "LAN接続が無効です。VYLINE_LAN_ACCESS=true で再起動してからQRを表示してください"
+          : "スマホから到達できるURLを作成できませんでした。PCとスマホが同じLANに接続されているか確認してください",
+      );
+      return;
+    }
+    setPairingUrl(res.pairingUrl);
     setMessage("スマホの標準カメラでQRコードを読み込んでください（2分間有効）");
   };
 

--- a/Vyline/apps/desktop/src/components/settings-sections.tsx
+++ b/Vyline/apps/desktop/src/components/settings-sections.tsx
@@ -6,6 +6,7 @@ import { checkForUpdates, type UpdateInfo } from "@/lib/updater";
 import { cn } from "@/lib/utils";
 import { BetaSection } from "@/components/beta-consent";
 import { AgentIBetaPanel } from "@/components/agent-i-beta-panel";
+import { IosBackupBetaPanel } from "@/components/ios-backup-beta-panel";
 import { QRCodeSVG } from "qrcode.react";
 
 function formatRelativeTime(ts: number): string {
@@ -544,6 +545,7 @@ export function SettingsSections() {
                 <>
                   <BetaSection />
                   {settings.betaAgentI && <AgentIBetaPanel />}
+                  <IosBackupBetaPanel accountId={accountId} />
                 </>
               )}
             </div>

--- a/Vyline/apps/desktop/src/hooks/useLineData.ts
+++ b/Vyline/apps/desktop/src/hooks/useLineData.ts
@@ -320,6 +320,30 @@ export function useLineData({ accountId }: UseLineDataOptions) {
     }
   }, [accountId, applyChatsToContactCache]);
 
+  // iOS復元完了後は、ネットワーク同期で上書きせず、書き込み済みのローカルDBを即表示する。
+  useEffect(() => {
+    if (!accountId || typeof window === "undefined") return;
+    const onRestore = (event: Event) => {
+      const restoredAccountId = (event as CustomEvent<{ accountId?: string }>).detail?.accountId;
+      if (restoredAccountId !== accountId) return;
+      void (async () => {
+        await loadBootstrap();
+        const chatMid = selectedChatMidRef.current;
+        if (!chatMid) return;
+        const res = await api.line.messages(accountId, chatMid, PAGE_SIZE, { local: true });
+        if (res.ok && res.messages) {
+          const messages = [...res.messages].reverse();
+          setMessages(messages);
+          setHasMoreMessages(res.hasMore ?? res.messages.length >= PAGE_SIZE);
+          setFromLocalCache(true);
+          resolveMessageAuthors(messages);
+        }
+      })();
+    };
+    window.addEventListener("vyline:ios-backup-restored", onRestore);
+    return () => window.removeEventListener("vyline:ios-backup-restored", onRestore);
+  }, [accountId, loadBootstrap, resolveMessageAuthors]);
+
   // accountId 変更時だけフルリセット（loadChats 再生成で回さない）
   useEffect(() => {
     messagesGen.current += 1;

--- a/Vyline/apps/desktop/src/pages/SubdevicePage.tsx
+++ b/Vyline/apps/desktop/src/pages/SubdevicePage.tsx
@@ -50,14 +50,18 @@ export function SubdevicePage() {
 
   const complete = async () => {
     if (!pairingToken) return;
-    const res = await api.subdevices.complete(pairingToken, name, platform);
-    if (!res.ok || !res.sessionToken || !res.device) {
-      setMessage(res.error ?? "登録に失敗しました");
-      return;
+    try {
+      const res = await api.subdevices.complete(pairingToken, name, platform);
+      if (!res.ok || !res.sessionToken || !res.device) {
+        setMessage(res.error ?? "登録に失敗しました");
+        return;
+      }
+      localStorage.setItem(STORAGE_KEY, res.sessionToken);
+      setAccountId(res.device.accountId);
+      navigate("/", { replace: true });
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "登録APIに接続できませんでした");
     }
-    localStorage.setItem(STORAGE_KEY, res.sessionToken);
-    setAccountId(res.device.accountId);
-    navigate("/", { replace: true });
   };
 
   return (

--- a/Vyline/apps/desktop/vite.config.ts
+++ b/Vyline/apps/desktop/vite.config.ts
@@ -11,7 +11,9 @@ export default defineConfig({
     },
   },
   server: {
-    host: process.env.VYLINE_LAN_ACCESS === "true" ? "0.0.0.0" : "127.0.0.1",
+    // QRで案内するLANアドレスからスマホが開けるよう、開発サーバーはLAN待受にする。
+    // APIの認証境界はbackend側で管理し、Viteのproxy経由でloopback backendへ接続する。
+    host: "0.0.0.0",
     // preview_start (autoPort) は PORT 環境変数で空きポートを渡す。未設定なら通常どおり 5173
     port: process.env.PORT ? Number(process.env.PORT) : 5173,
     proxy: {

--- a/Vyline/apps/desktop/vite.config.ts
+++ b/Vyline/apps/desktop/vite.config.ts
@@ -11,9 +11,7 @@ export default defineConfig({
     },
   },
   server: {
-    // QRで案内するLANアドレスからスマホが開けるよう、開発サーバーはLAN待受にする。
-    // APIの認証境界はbackend側で管理し、Viteのproxy経由でloopback backendへ接続する。
-    host: "0.0.0.0",
+    host: process.env.VYLINE_LAN_ACCESS === "true" ? "0.0.0.0" : "127.0.0.1",
     // preview_start (autoPort) は PORT 環境変数で空きポートを渡す。未設定なら通常どおり 5173
     port: process.env.PORT ? Number(process.env.PORT) : 5173,
     proxy: {

--- a/Vyline/backend/package.json
+++ b/Vyline/backend/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@vyline/plugin-sdk": "workspace:*",
+    "@vyline/ios-backup": "workspace:*",
     "@vyline/protocol": "workspace:*",
     "@vyline/types": "workspace:*",
     "hono": "^4.7.11",

--- a/Vyline/backend/src/api/line.ts
+++ b/Vyline/backend/src/api/line.ts
@@ -1875,6 +1875,44 @@ lineRouter.delete("/:accountId/announcements/:chatMid/:seq", async (c) => {
   }
 });
 
+// ─── iTunes / Apple Devices: iOS バックアップ復元 ───
+
+lineRouter.get("/:accountId/ios-backups", async (c) => {
+  try {
+    const { listIosBackups } = await import("../service/iosBackupService.js");
+    const devices = await listIosBackups();
+    return c.json({
+      ok: true,
+      devices: devices.map(({ backupRoot: _backupRoot, ...device }) => device),
+    });
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+lineRouter.post("/:accountId/restore/ios-backup", async (c) => {
+  const accountId = c.req.param("accountId");
+  try {
+    const body = await c.req.json<{ udid?: string; password?: string }>();
+    if (!body.udid || !body.password) {
+      return c.json({ ok: false, error: "udid と password が必要です" }, 400);
+    }
+    const { startIosBackupRestore } = await import("../service/iosBackupService.js");
+    const session = await startIosBackupRestore(accountId, body.udid, body.password);
+    return c.json({ ok: true, sessionId: session.id });
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+lineRouter.get("/:accountId/restore/ios-backup/:sessionId", async (c) => {
+  const { getIosBackupSession } = await import("../service/iosBackupService.js");
+  const session = getIosBackupSession(c.req.param("accountId"), c.req.param("sessionId"));
+  return session
+    ? c.json({ ok: true, session })
+    : c.json({ ok: false, error: "復元セッションが見つかりません" }, 404);
+});
+
 // ─── VylineBackup: スナップショット作成 / 一覧 / 復元 ───
 
 lineRouter.get("/:accountId/backup/chats", async (c) => {

--- a/Vyline/backend/src/api/subdevices.test.ts
+++ b/Vyline/backend/src/api/subdevices.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { buildPairingUrl } from "./subdevices.js";
+
+const previousLanAccess = process.env.VYLINE_LAN_ACCESS;
+
+afterEach(() => {
+  if (previousLanAccess === undefined) process.env.VYLINE_LAN_ACCESS = undefined;
+  else process.env.VYLINE_LAN_ACCESS = previousLanAccess;
+});
+
+describe("subdevice pairing URL", () => {
+  test("does not issue a LAN QR URL while loopback access is disabled", () => {
+    process.env.VYLINE_LAN_ACCESS = undefined;
+
+    expect(buildPairingUrl("http://127.0.0.1:5173", "vyp_test")).toBeUndefined();
+  });
+
+  test("rewrites loopback origin only when LAN access is enabled", () => {
+    process.env.VYLINE_LAN_ACCESS = "true";
+
+    const result = buildPairingUrl("http://127.0.0.1:5173", "vyp_test");
+    expect(result).toMatch(/^http:\/\/[^/]+:5173\/subdevice\?pairing=vyp_test$/);
+    expect(result).not.toContain("127.0.0.1");
+  });
+
+  test("keeps an already reachable origin unchanged", () => {
+    process.env.VYLINE_LAN_ACCESS = undefined;
+
+    expect(buildPairingUrl("http://192.0.2.10:5173", "vyp_test")).toBe(
+      "http://192.0.2.10:5173/subdevice?pairing=vyp_test",
+    );
+  });
+});

--- a/Vyline/backend/src/api/subdevices.ts
+++ b/Vyline/backend/src/api/subdevices.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { networkInterfaces } from "node:os";
 import {
   authenticateSubdevice,
   completePairing,
@@ -12,16 +13,56 @@ import {
 
 export const subdeviceRouter = new Hono();
 
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
+
+function getLanHost(): string | null {
+  const configured = process.env.VYLINE_PUBLIC_HOST?.trim();
+  if (configured) return configured;
+
+  for (const addresses of Object.values(networkInterfaces())) {
+    const address = addresses?.find((entry) => entry.family === "IPv4" && !entry.internal);
+    if (address?.address) return address.address;
+  }
+  return null;
+}
+
+/** localhost で開いたPC画面からでも、LAN上で開けるQR URLを作る。 */
+export function buildPairingUrl(origin: string | undefined, token: string): string | undefined {
+  if (!origin) return undefined;
+
+  try {
+    const url = new URL(origin);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return undefined;
+    if (LOOPBACK_HOSTS.has(url.hostname)) {
+      const lanHost = getLanHost();
+      if (!lanHost) return undefined;
+      url.hostname = lanHost;
+    }
+    url.pathname = "/subdevice";
+    url.search = `?pairing=${encodeURIComponent(token)}`;
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return undefined;
+  }
+}
+
 function bearer(c: { req: { header(name: string): string | undefined } }) {
   const value = c.req.header("authorization") ?? "";
   return value.startsWith("Bearer ") ? value.slice(7).trim() : "";
 }
 
 subdeviceRouter.post("/pairing", async (c) => {
-  const body = await c.req.json<{ accountId?: string }>().catch((): { accountId?: string } => ({}));
+  const body = await c.req
+    .json<{ accountId?: string; origin?: string }>()
+    .catch((): { accountId?: string; origin?: string } => ({}));
   if (!body.accountId) return c.json({ ok: false, error: "accountId required" }, 400);
   const pairing = await createPairing(body.accountId);
-  return c.json({ ok: true, ...pairing });
+  return c.json({
+    ok: true,
+    ...pairing,
+    pairingUrl: buildPairingUrl(body.origin, pairing.token),
+  });
 });
 
 subdeviceRouter.get("/pairing/:token", async (c) => {

--- a/Vyline/backend/src/api/subdevices.ts
+++ b/Vyline/backend/src/api/subdevices.ts
@@ -15,6 +15,10 @@ export const subdeviceRouter = new Hono();
 
 const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
 
+function isLanAccessEnabled() {
+  return process.env.VYLINE_LAN_ACCESS === "true";
+}
+
 function getLanHost(): string | null {
   const configured = process.env.VYLINE_PUBLIC_HOST?.trim();
   if (configured) return configured;
@@ -34,6 +38,9 @@ export function buildPairingUrl(origin: string | undefined, token: string): stri
     const url = new URL(origin);
     if (url.protocol !== "http:" && url.protocol !== "https:") return undefined;
     if (LOOPBACK_HOSTS.has(url.hostname)) {
+      // Vite/backend が loopback 待受のままでは、LAN IP の QR を発行しても
+      // スマホからページ/APIへ到達できない。壊れたQRを返さずUI側で案内する。
+      if (!isLanAccessEnabled()) return undefined;
       const lanHost = getLanHost();
       if (!lanHost) return undefined;
       url.hostname = lanHost;
@@ -58,10 +65,20 @@ subdeviceRouter.post("/pairing", async (c) => {
     .catch((): { accountId?: string; origin?: string } => ({}));
   if (!body.accountId) return c.json({ ok: false, error: "accountId required" }, 400);
   const pairing = await createPairing(body.accountId);
+  const pairingUrl = buildPairingUrl(body.origin, pairing.token);
   return c.json({
     ok: true,
     ...pairing,
-    pairingUrl: buildPairingUrl(body.origin, pairing.token),
+    pairingUrl,
+    lanAccessRequired:
+      Boolean(body.origin) &&
+      (() => {
+        try {
+          return LOOPBACK_HOSTS.has(new URL(body.origin!).hostname) && !isLanAccessEnabled();
+        } catch {
+          return false;
+        }
+      })(),
   });
 });
 

--- a/Vyline/backend/src/service/iosBackupService.test.ts
+++ b/Vyline/backend/src/service/iosBackupService.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { historyToChatDb } from "./iosBackupService.js";
+
+describe("historyToChatDb", () => {
+  test("maps iOS records into the existing chatdb shape", () => {
+    const result = historyToChatDb(
+      {
+        account: "u-me",
+        exportedAt: "2026-08-24T00:00:00.000Z",
+        chats: [
+          {
+            chatMid: "u-peer",
+            kind: "dm",
+            name: "Peer",
+            count: 1,
+            firstIso: null,
+            lastIso: null,
+            file: "u-peer.jsonl",
+          },
+        ],
+        messages: new Map([
+          [
+            "u-peer",
+            [
+              {
+                id: 42,
+                ts: 1_755_984_000_000,
+                iso: null,
+                contentType: 0,
+                sendStatus: 0,
+                fromMid: "u-peer",
+                fromName: "Peer",
+                text: "hello",
+                contentMetadata: null,
+              },
+            ],
+          ],
+        ]),
+      },
+      "u-account-fallback",
+    );
+
+    expect(result.chats["u-peer"]?.kind).toBe("direct");
+    expect(result.messages["u-peer"]?.["42"]).toMatchObject({
+      id: "42",
+      from: "u-peer",
+      to: "u-me",
+      contentType: "NONE",
+      text: "hello",
+      isMyMessage: false,
+    });
+  });
+});

--- a/Vyline/backend/src/service/iosBackupService.ts
+++ b/Vyline/backend/src/service/iosBackupService.ts
@@ -10,7 +10,12 @@ import {
   type ExtractedFile,
 } from "@vyline/ios-backup";
 import type { MessageContentMeta } from "@vyline/types";
-import { mergeImportedChatDb, type StoredChat, type StoredMessage } from "../storage/chatStore.js";
+import {
+  flushAccountChatDb,
+  mergeImportedChatDb,
+  type StoredChat,
+  type StoredMessage,
+} from "../storage/chatStore.js";
 import { childLogger } from "../logger.js";
 import { writeMediaStorage } from "../storage/mediaStorage.js";
 
@@ -163,6 +168,7 @@ async function runRestore(
     const records = historyToChatDb(result.parsed, session.accountId);
     const merged = await mergeImportedChatDb(session.accountId, records);
     const media = await restoreMediaFiles(session.accountId, result.extracted.files, result.parsed);
+    await flushAccountChatDb(session.accountId);
     const totalMessages = Array.from(result.parsed.messages.values()).reduce(
       (sum, messages) => sum + messages.length,
       0,

--- a/Vyline/backend/src/service/iosBackupService.ts
+++ b/Vyline/backend/src/service/iosBackupService.ts
@@ -1,0 +1,249 @@
+import { existsSync } from "node:fs";
+import { mkdtemp, readdir, rm, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  extractAndParseLineHistory,
+  type MessageRecord,
+  type ParsedChatHistory,
+} from "@vyline/ios-backup";
+import type { MessageContentMeta } from "@vyline/types";
+import {
+  mergeImportedChatDb,
+  type StoredChat,
+  type StoredMessage,
+} from "../storage/chatStore.js";
+import { childLogger } from "../logger.js";
+
+const log = childLogger("ios-backup");
+
+export interface IosBackupDevice {
+  udid: string;
+  name: string;
+  iOSVersion: string;
+  deviceType: string;
+  encrypted: boolean;
+  passcodeSet: boolean;
+  backupRoot: string;
+  modifiedAt: string;
+}
+
+export interface IosBackupProgress {
+  stage: string;
+  current: number;
+  total: number;
+  message: string;
+  file?: string;
+}
+
+export interface IosBackupSession {
+  id: string;
+  accountId: string;
+  status: "pending" | "running" | "completed" | "failed";
+  progress: IosBackupProgress | null;
+  result: {
+    deviceId: string;
+    backupDate: string;
+    extracted: { lineFiles: number; databases: number };
+    parsed: { chats: number; totalMessages: number };
+    merged: {
+      importedChats: number;
+      skippedChats: number;
+      importedMessages: number;
+      skippedMessages: number;
+    };
+  } | null;
+  error: string | null;
+  startedAt: number;
+  completedAt: number | null;
+}
+
+const sessions = new Map<string, IosBackupSession>();
+
+function backupRoots(): string[] {
+  const configured = process.env.IOS_BACKUP_ROOT?.trim();
+  if (configured) return [configured];
+  const home = homedir();
+  return [
+    join(process.env.APPDATA ?? join(home, "AppData", "Roaming"), "Apple Computer", "MobileSync", "Backup"),
+    join(home, "Apple", "MobileSync", "Backup"),
+    join(home, "Library", "Application Support", "MobileSync", "Backup"),
+  ];
+}
+
+async function findBackups(): Promise<IosBackupDevice[]> {
+  const devices: IosBackupDevice[] = [];
+  const seen = new Set<string>();
+  for (const root of backupRoots()) {
+    if (!existsSync(root)) continue;
+    for (const entry of await readdir(root, { withFileTypes: true })) {
+      if (!entry.isDirectory() || seen.has(entry.name)) continue;
+      const backupRoot = join(root, entry.name);
+      if (!existsSync(join(backupRoot, "Manifest.plist")) || !existsSync(join(backupRoot, "Manifest.db"))) {
+        continue;
+      }
+      seen.add(entry.name);
+      const info = await stat(backupRoot);
+      devices.push({
+        udid: entry.name,
+        name: entry.name,
+        iOSVersion: "不明（復元時に確認）",
+        deviceType: "iPhone / iPad",
+        encrypted: true,
+        passcodeSet: true,
+        backupRoot: root,
+        modifiedAt: info.mtime.toISOString(),
+      });
+    }
+  }
+  return devices.sort((a, b) => b.modifiedAt.localeCompare(a.modifiedAt));
+}
+
+export async function listIosBackups(): Promise<IosBackupDevice[]> {
+  return findBackups();
+}
+
+export async function startIosBackupRestore(
+  accountId: string,
+  udid: string,
+  password: string,
+): Promise<IosBackupSession> {
+  if (!accountId) throw new Error("accountId が必要です");
+  if (!password) throw new Error("暗号化バックアップのパスワードが必要です");
+  const device = (await findBackups()).find((item) => item.udid === udid);
+  if (!device) throw new Error("指定された iOS バックアップが見つかりません");
+
+  const id = `ios-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const session: IosBackupSession = {
+    id,
+    accountId,
+    status: "pending",
+    progress: null,
+    result: null,
+    error: null,
+    startedAt: Date.now(),
+    completedAt: null,
+  };
+  sessions.set(id, session);
+  void runRestore(session, device, password);
+  return session;
+}
+
+export function getIosBackupSession(accountId: string, id: string): IosBackupSession | null {
+  const session = sessions.get(id);
+  return session?.accountId === accountId ? session : null;
+}
+
+async function runRestore(
+  session: IosBackupSession,
+  device: IosBackupDevice,
+  password: string,
+): Promise<void> {
+  session.status = "running";
+  const outputDir = await mkdtemp(join(tmpdir(), `vyline-ios-${session.id}-`));
+  try {
+    const result = await extractAndParseLineHistory(
+      device.backupRoot,
+      device.udid,
+      password,
+      outputDir,
+      (stage, current, total, message) => {
+        session.progress = { stage, current, total, message };
+      },
+    );
+    const records = historyToChatDb(result.parsed, session.accountId);
+    const merged = await mergeImportedChatDb(session.accountId, records);
+    const totalMessages = Array.from(result.parsed.messages.values()).reduce(
+      (sum, messages) => sum + messages.length,
+      0,
+    );
+    session.result = {
+      deviceId: device.udid,
+      backupDate: device.modifiedAt,
+      extracted: {
+        lineFiles: result.extracted.lineFiles.length,
+        databases: result.extracted.databases.length,
+      },
+      parsed: { chats: result.parsed.chats.length, totalMessages },
+      merged,
+    };
+    session.status = "completed";
+    session.completedAt = Date.now();
+  } catch (error) {
+    session.status = "failed";
+    session.error = error instanceof Error ? error.message : "iOSバックアップの復元に失敗しました";
+    session.completedAt = Date.now();
+    log.warn({ accountId: session.accountId, deviceId: device.udid, error }, "iOS backup restore failed");
+  } finally {
+    await rm(outputDir, { recursive: true, force: true }).catch(() => undefined);
+  }
+}
+
+export function historyToChatDb(
+  history: ParsedChatHistory,
+  accountId: string,
+): { chats: Record<string, StoredChat>; messages: Record<string, Record<string, StoredMessage>> } {
+  const myMid = history.account || accountId;
+  const chats: Record<string, StoredChat> = {};
+  const messages: Record<string, Record<string, StoredMessage>> = {};
+  const now = new Date().toISOString();
+
+  for (const info of history.chats) {
+    const chatMessages = history.messages.get(info.chatMid) ?? [];
+    const mapped = chatMessages.map((message) => mapMessage(message, info.chatMid, myMid, now));
+    const last = mapped[mapped.length - 1];
+    chats[info.chatMid] = {
+      mid: info.chatMid,
+      name: info.name || info.chatMid,
+      kind: info.kind === "group" ? "group" : info.kind === "dm" ? "direct" : "unknown",
+      hasMessages: mapped.length > 0,
+      ...(last ? {
+        lastMessageTime: last.createdTime,
+        lastMessageId: last.id,
+        lastMessagePreview: last.text ?? `[${last.contentType}]`,
+      } : {}),
+      updatedAt: now,
+    };
+    if (mapped.length > 0) {
+      messages[info.chatMid] = Object.fromEntries(mapped.map((message) => [message.id, message]));
+    }
+  }
+  return { chats, messages };
+}
+
+function mapMessage(
+  message: MessageRecord,
+  chatMid: string,
+  myMid: string,
+  savedAt: string,
+): StoredMessage {
+  const from = message.fromMid || myMid;
+  const isMyMessage = from === myMid || message.fromMid === null;
+  return {
+    id: String(message.id),
+    chatMid,
+    from,
+    to: isMyMessage ? chatMid : myMid,
+    text: message.text,
+    contentType: iosContentType(message.contentType),
+    createdTime: Number.isFinite(message.ts) ? message.ts : 0,
+    isMyMessage,
+    ...(message.contentMetadata ? { contentMetadata: toContentMetadata(message.contentMetadata) } : {}),
+    savedAt,
+  };
+}
+
+function iosContentType(type: number): string {
+  return ({ 0: "NONE", 1: "IMAGE", 2: "VIDEO", 3: "AUDIO", 7: "STICKER", 14: "FILE", 17: "RICH", 22: "FLEX" } as Record<number, string>)[type] ?? String(type);
+}
+
+function toContentMetadata(value: unknown): MessageContentMeta | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  const output: MessageContentMeta = {};
+  for (const [key, item] of Object.entries(value)) {
+    if (typeof item === "string") output[key] = item;
+    else if (typeof item === "number" || typeof item === "boolean") output[key] = String(item);
+  }
+  return Object.keys(output).length > 0 ? output : null;
+}

--- a/Vyline/backend/src/service/iosBackupService.ts
+++ b/Vyline/backend/src/service/iosBackupService.ts
@@ -45,6 +45,7 @@ export interface IosBackupSession {
   result: {
     deviceId: string;
     backupDate: string;
+    restoredAt: string;
     extracted: { lineFiles: number; databases: number };
     parsed: { chats: number; totalMessages: number };
     merged: {
@@ -161,6 +162,7 @@ async function runRestore(
     session.result = {
       deviceId: device.udid,
       backupDate: device.modifiedAt,
+      restoredAt: new Date().toISOString(),
       extracted: {
         lineFiles: result.extracted.lineFiles.length,
         databases: result.extracted.databases.length,

--- a/Vyline/backend/src/service/iosBackupService.ts
+++ b/Vyline/backend/src/service/iosBackupService.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { mkdtemp, readdir, rm, stat } from "node:fs/promises";
+import { mkdtemp, readdir, readFile, rm, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -7,10 +7,12 @@ import {
   extractAndParseLineHistory,
   type MessageRecord,
   type ParsedChatHistory,
+  type ExtractedFile,
 } from "@vyline/ios-backup";
 import type { MessageContentMeta } from "@vyline/types";
 import { mergeImportedChatDb, type StoredChat, type StoredMessage } from "../storage/chatStore.js";
 import { childLogger } from "../logger.js";
+import { writeMediaStorage } from "../storage/mediaStorage.js";
 
 const log = childLogger("ios-backup");
 
@@ -50,6 +52,7 @@ export interface IosBackupSession {
       importedMessages: number;
       skippedMessages: number;
     };
+    media: { restored: number; skipped: number };
   } | null;
   error: string | null;
   startedAt: number;
@@ -159,6 +162,7 @@ async function runRestore(
     );
     const records = historyToChatDb(result.parsed, session.accountId);
     const merged = await mergeImportedChatDb(session.accountId, records);
+    const media = await restoreMediaFiles(session.accountId, result.extracted.files, result.parsed);
     const totalMessages = Array.from(result.parsed.messages.values()).reduce(
       (sum, messages) => sum + messages.length,
       0,
@@ -173,6 +177,7 @@ async function runRestore(
       },
       parsed: { chats: result.parsed.chats.length, totalMessages },
       merged,
+      media,
     };
     session.status = "completed";
     session.completedAt = Date.now();
@@ -187,6 +192,87 @@ async function runRestore(
   } finally {
     await rm(outputDir, { recursive: true, force: true }).catch(() => undefined);
   }
+}
+
+async function restoreMediaFiles(
+  accountId: string,
+  files: ExtractedFile[],
+  history: ParsedChatHistory,
+): Promise<{ restored: number; skipped: number }> {
+  const candidates = files.filter((file) => !file.localPath.endsWith(".sqlite"));
+  const byName = new Map<string, ExtractedFile>();
+  for (const file of candidates) {
+    const name = file.relativePath.split(/[\\/]/).pop()?.toLowerCase();
+    if (name && !byName.has(name)) byName.set(name, file);
+    const withoutExtension = name?.replace(/\.[^.]+$/, "");
+    if (withoutExtension && !byName.has(withoutExtension)) byName.set(withoutExtension, file);
+  }
+
+  let restored = 0;
+  let skipped = 0;
+  for (const [chatMid, messages] of history.messages) {
+    for (const message of messages) {
+      const kind = iosContentType(message.contentType);
+      if (!MEDIA_CONTENT_TYPES.has(kind)) continue;
+      const tokens = [String(message.id), ...metadataTokens(message.contentMetadata)];
+      const file = findMediaFile(tokens, byName, candidates);
+      if (!file) {
+        skipped++;
+        continue;
+      }
+      try {
+        await writeMediaStorage(
+          accountId,
+          chatMid,
+          String(message.id),
+          new Uint8Array(await readFile(file.localPath)),
+          mediaMimeType(file.relativePath, kind),
+        );
+        restored++;
+      } catch {
+        skipped++;
+      }
+    }
+  }
+  return { restored, skipped };
+}
+
+function findMediaFile(
+  tokens: string[],
+  byName: Map<string, ExtractedFile>,
+  candidates: ExtractedFile[],
+): ExtractedFile | undefined {
+  const exact = tokens.map((token) => byName.get(token.toLowerCase())).find(Boolean);
+  if (exact) return exact;
+  for (const token of tokens) {
+    const normalized = token.toLowerCase();
+    if (normalized.length < 8) continue;
+    const match = candidates.find((file) => file.relativePath.toLowerCase().includes(normalized));
+    if (match) return match;
+  }
+  return undefined;
+}
+
+const MEDIA_CONTENT_TYPES = new Set(["IMAGE", "VIDEO", "AUDIO", "FILE", "STICKER"]);
+
+function metadataTokens(value: unknown): string[] {
+  if (typeof value === "string" || typeof value === "number") return [String(value)];
+  if (!value || typeof value !== "object") return [];
+  return Object.values(value as Record<string, unknown>).flatMap(metadataTokens);
+}
+
+function mediaMimeType(path: string, kind: string): string {
+  const lower = path.toLowerCase();
+  if (lower.endsWith(".png")) return "image/png";
+  if (lower.endsWith(".gif")) return "image/gif";
+  if (lower.endsWith(".webp")) return "image/webp";
+  if (lower.endsWith(".jpg") || lower.endsWith(".jpeg")) return "image/jpeg";
+  if (lower.endsWith(".mp4")) return "video/mp4";
+  if (lower.endsWith(".m4a") || lower.endsWith(".aac")) return "audio/mp4";
+  if (kind === "IMAGE" || kind === "STICKER") return "image/jpeg";
+  if (kind === "VIDEO") return "video/mp4";
+  if (kind === "AUDIO") return "audio/mp4";
+  return "application/octet-stream";
 }
 
 export function historyToChatDb(

--- a/Vyline/backend/src/service/iosBackupService.ts
+++ b/Vyline/backend/src/service/iosBackupService.ts
@@ -9,11 +9,7 @@ import {
   type ParsedChatHistory,
 } from "@vyline/ios-backup";
 import type { MessageContentMeta } from "@vyline/types";
-import {
-  mergeImportedChatDb,
-  type StoredChat,
-  type StoredMessage,
-} from "../storage/chatStore.js";
+import { mergeImportedChatDb, type StoredChat, type StoredMessage } from "../storage/chatStore.js";
 import { childLogger } from "../logger.js";
 
 const log = childLogger("ios-backup");
@@ -67,7 +63,12 @@ function backupRoots(): string[] {
   if (configured) return [configured];
   const home = homedir();
   return [
-    join(process.env.APPDATA ?? join(home, "AppData", "Roaming"), "Apple Computer", "MobileSync", "Backup"),
+    join(
+      process.env.APPDATA ?? join(home, "AppData", "Roaming"),
+      "Apple Computer",
+      "MobileSync",
+      "Backup",
+    ),
     join(home, "Apple", "MobileSync", "Backup"),
     join(home, "Library", "Application Support", "MobileSync", "Backup"),
   ];
@@ -81,7 +82,10 @@ async function findBackups(): Promise<IosBackupDevice[]> {
     for (const entry of await readdir(root, { withFileTypes: true })) {
       if (!entry.isDirectory() || seen.has(entry.name)) continue;
       const backupRoot = join(root, entry.name);
-      if (!existsSync(join(backupRoot, "Manifest.plist")) || !existsSync(join(backupRoot, "Manifest.db"))) {
+      if (
+        !existsSync(join(backupRoot, "Manifest.plist")) ||
+        !existsSync(join(backupRoot, "Manifest.db"))
+      ) {
         continue;
       }
       seen.add(entry.name);
@@ -176,7 +180,10 @@ async function runRestore(
     session.status = "failed";
     session.error = error instanceof Error ? error.message : "iOSバックアップの復元に失敗しました";
     session.completedAt = Date.now();
-    log.warn({ accountId: session.accountId, deviceId: device.udid, error }, "iOS backup restore failed");
+    log.warn(
+      { accountId: session.accountId, deviceId: device.udid, error },
+      "iOS backup restore failed",
+    );
   } finally {
     await rm(outputDir, { recursive: true, force: true }).catch(() => undefined);
   }
@@ -200,11 +207,13 @@ export function historyToChatDb(
       name: info.name || info.chatMid,
       kind: info.kind === "group" ? "group" : info.kind === "dm" ? "direct" : "unknown",
       hasMessages: mapped.length > 0,
-      ...(last ? {
-        lastMessageTime: last.createdTime,
-        lastMessageId: last.id,
-        lastMessagePreview: last.text ?? `[${last.contentType}]`,
-      } : {}),
+      ...(last
+        ? {
+            lastMessageTime: last.createdTime,
+            lastMessageId: last.id,
+            lastMessagePreview: last.text ?? `[${last.contentType}]`,
+          }
+        : {}),
       updatedAt: now,
     };
     if (mapped.length > 0) {
@@ -231,13 +240,28 @@ function mapMessage(
     contentType: iosContentType(message.contentType),
     createdTime: Number.isFinite(message.ts) ? message.ts : 0,
     isMyMessage,
-    ...(message.contentMetadata ? { contentMetadata: toContentMetadata(message.contentMetadata) } : {}),
+    ...(message.contentMetadata
+      ? { contentMetadata: toContentMetadata(message.contentMetadata) }
+      : {}),
     savedAt,
   };
 }
 
 function iosContentType(type: number): string {
-  return ({ 0: "NONE", 1: "IMAGE", 2: "VIDEO", 3: "AUDIO", 7: "STICKER", 14: "FILE", 17: "RICH", 22: "FLEX" } as Record<number, string>)[type] ?? String(type);
+  return (
+    (
+      {
+        0: "NONE",
+        1: "IMAGE",
+        2: "VIDEO",
+        3: "AUDIO",
+        7: "STICKER",
+        14: "FILE",
+        17: "RICH",
+        22: "FLEX",
+      } as Record<number, string>
+    )[type] ?? String(type)
+  );
 }
 
 function toContentMetadata(value: unknown): MessageContentMeta | null {

--- a/Vyline/backend/src/storage/chatStore.iosRestore.test.ts
+++ b/Vyline/backend/src/storage/chatStore.iosRestore.test.ts
@@ -52,7 +52,12 @@ describe("mergeChatDbRecords", () => {
       },
     });
 
-    expect(result).toEqual({ importedChats: 1, skippedChats: 1, importedMessages: 2, skippedMessages: 1 });
+    expect(result).toEqual({
+      importedChats: 1,
+      skippedChats: 1,
+      importedMessages: 2,
+      skippedMessages: 1,
+    });
     expect(target.chats["u-chat"]?.name).toBe("Local name");
     expect(target.chats["u-chat"]?.lastMessageTime).toBe(700);
     expect(target.messages["u-chat"]?.["1"]?.text).toBe("local");

--- a/Vyline/backend/src/storage/chatStore.iosRestore.test.ts
+++ b/Vyline/backend/src/storage/chatStore.iosRestore.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import {
+  mergeChatDbRecords,
+  type ChatDbRecords,
+  type StoredChat,
+  type StoredMessage,
+} from "./chatStore.js";
+
+function chat(mid: string, name: string, lastMessageTime = 100): StoredChat {
+  return {
+    mid,
+    name,
+    kind: "direct",
+    hasMessages: true,
+    lastMessageTime,
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+function message(id: string, chatMid: string, text: string): StoredMessage {
+  return {
+    id,
+    chatMid,
+    from: "u-sender",
+    to: chatMid,
+    text,
+    contentType: "NONE",
+    createdTime: 100,
+    isMyMessage: false,
+    savedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+describe("mergeChatDbRecords", () => {
+  test("adds missing iOS records without overwriting existing records", () => {
+    const target: ChatDbRecords = {
+      chats: { "u-chat": chat("u-chat", "Local name", 500) },
+      messages: { "u-chat": { "1": message("1", "u-chat", "local") } },
+    };
+
+    const result = mergeChatDbRecords(target, {
+      chats: {
+        "u-chat": chat("u-chat", "Backup name", 700),
+        "u-new": chat("u-new", "Imported chat", 200),
+      },
+      messages: {
+        "u-chat": {
+          "1": message("1", "u-chat", "backup duplicate"),
+          "2": message("2", "u-chat", "imported"),
+        },
+        "u-new": { "3": message("3", "u-new", "new") },
+      },
+    });
+
+    expect(result).toEqual({ importedChats: 1, skippedChats: 1, importedMessages: 2, skippedMessages: 1 });
+    expect(target.chats["u-chat"]?.name).toBe("Local name");
+    expect(target.chats["u-chat"]?.lastMessageTime).toBe(700);
+    expect(target.messages["u-chat"]?.["1"]?.text).toBe("local");
+    expect(target.messages["u-chat"]?.["2"]?.text).toBe("imported");
+  });
+
+  test("is idempotent when the same backup is merged twice", () => {
+    const target: ChatDbRecords = { chats: {}, messages: {} };
+    const incoming = {
+      chats: { "u-chat": chat("u-chat", "Imported chat") },
+      messages: { "u-chat": { "1": message("1", "u-chat", "imported") } },
+    };
+
+    expect(mergeChatDbRecords(target, incoming)).toEqual({
+      importedChats: 1,
+      skippedChats: 0,
+      importedMessages: 1,
+      skippedMessages: 0,
+    });
+    expect(mergeChatDbRecords(target, incoming)).toEqual({
+      importedChats: 0,
+      skippedChats: 1,
+      importedMessages: 0,
+      skippedMessages: 1,
+    });
+  });
+});

--- a/Vyline/backend/src/storage/chatStore.ts
+++ b/Vyline/backend/src/storage/chatStore.ts
@@ -595,7 +595,9 @@ export function mergeChatDbRecords(
     const ids = Object.keys(targetMessages);
     if (ids.length > MAX_MESSAGES_PER_CHAT_DB) {
       const drop = ids
-        .sort((a, b) => (targetMessages[a]?.createdTime ?? 0) - (targetMessages[b]?.createdTime ?? 0))
+        .sort(
+          (a, b) => (targetMessages[a]?.createdTime ?? 0) - (targetMessages[b]?.createdTime ?? 0),
+        )
         .slice(0, ids.length - MAX_MESSAGES_PER_CHAT_DB);
       for (const id of drop) delete targetMessages[id];
     }

--- a/Vyline/backend/src/storage/chatStore.ts
+++ b/Vyline/backend/src/storage/chatStore.ts
@@ -551,6 +551,7 @@ export async function importChatDb(
 export function mergeChatDbRecords(
   target: ChatDbRecords,
   incoming: ChatDbRecords,
+  opts?: { preserveHistory?: boolean },
 ): ChatDbMergeResult {
   let importedChats = 0;
   let skippedChats = 0;
@@ -593,7 +594,7 @@ export function mergeChatDbRecords(
     }
 
     const ids = Object.keys(targetMessages);
-    if (ids.length > MAX_MESSAGES_PER_CHAT_DB) {
+    if (!opts?.preserveHistory && ids.length > MAX_MESSAGES_PER_CHAT_DB) {
       const drop = ids
         .sort(
           (a, b) => (targetMessages[a]?.createdTime ?? 0) - (targetMessages[b]?.createdTime ?? 0),
@@ -613,9 +614,14 @@ export async function mergeImportedChatDb(
   incoming: ChatDbRecords,
 ): Promise<ChatDbMergeResult> {
   const db = await getDb(accountId);
-  const result = mergeChatDbRecords(db, incoming);
+  const result = mergeChatDbRecords(db, incoming, { preserveHistory: true });
   if (result.importedChats > 0 || result.importedMessages > 0) scheduleSave(accountId);
   return result;
+}
+
+/** 復元完了時に、遅延保存を待たずにDBへ確実に書き出す。 */
+export async function flushAccountChatDb(accountId: string): Promise<void> {
+  await flushDb(accountId);
 }
 
 /** VylineBackup: チャット一覧とメッセージ件数（選択 UI 用） */

--- a/Vyline/backend/src/storage/chatStore.ts
+++ b/Vyline/backend/src/storage/chatStore.ts
@@ -82,6 +82,18 @@ interface ChatDb {
   messages: Record<string, Record<string, StoredMessage>>;
 }
 
+export interface ChatDbRecords {
+  chats: Record<string, StoredChat>;
+  messages: Record<string, Record<string, StoredMessage>>;
+}
+
+export interface ChatDbMergeResult {
+  importedChats: number;
+  skippedChats: number;
+  importedMessages: number;
+  skippedMessages: number;
+}
+
 const memory = new Map<string, ChatDb>();
 const dirty = new Set<string>();
 const saveTimers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -533,6 +545,75 @@ export async function importChatDb(
   }
   scheduleSave(accountId);
   return { chats: chatCount, messages: messageCount };
+}
+
+/** 外部履歴を追加専用でマージする。既存メッセージは上書きしないため再実行できる。 */
+export function mergeChatDbRecords(
+  target: ChatDbRecords,
+  incoming: ChatDbRecords,
+): ChatDbMergeResult {
+  let importedChats = 0;
+  let skippedChats = 0;
+  let importedMessages = 0;
+  let skippedMessages = 0;
+
+  for (const [mid, incomingChat] of Object.entries(incoming.chats ?? {})) {
+    const existing = target.chats[mid];
+    if (!existing) {
+      target.chats[mid] = incomingChat;
+      importedChats++;
+      continue;
+    }
+
+    skippedChats++;
+    const incomingIsNewer = (incomingChat.lastMessageTime ?? 0) > (existing.lastMessageTime ?? 0);
+    target.chats[mid] = {
+      ...existing,
+      hasMessages: existing.hasMessages || incomingChat.hasMessages,
+      lastMessageTime: Math.max(existing.lastMessageTime ?? 0, incomingChat.lastMessageTime ?? 0),
+      ...(incomingIsNewer && incomingChat.lastMessageId
+        ? { lastMessageId: incomingChat.lastMessageId }
+        : {}),
+      ...(incomingIsNewer && incomingChat.lastMessagePreview
+        ? { lastMessagePreview: incomingChat.lastMessagePreview }
+        : {}),
+      ...(existing.name === existing.mid && incomingChat.name ? { name: incomingChat.name } : {}),
+    };
+  }
+
+  for (const [chatMid, incomingMessages] of Object.entries(incoming.messages ?? {})) {
+    const targetMessages = target.messages[chatMid] ?? {};
+    for (const [id, incomingMessage] of Object.entries(incomingMessages)) {
+      if (targetMessages[id]) {
+        skippedMessages++;
+        continue;
+      }
+      targetMessages[id] = incomingMessage;
+      importedMessages++;
+    }
+
+    const ids = Object.keys(targetMessages);
+    if (ids.length > MAX_MESSAGES_PER_CHAT_DB) {
+      const drop = ids
+        .sort((a, b) => (targetMessages[a]?.createdTime ?? 0) - (targetMessages[b]?.createdTime ?? 0))
+        .slice(0, ids.length - MAX_MESSAGES_PER_CHAT_DB);
+      for (const id of drop) delete targetMessages[id];
+    }
+    target.messages[chatMid] = targetMessages;
+  }
+
+  return { importedChats, skippedChats, importedMessages, skippedMessages };
+}
+
+/** iOS / 外部履歴復元用の永続マージ。 */
+export async function mergeImportedChatDb(
+  accountId: string,
+  incoming: ChatDbRecords,
+): Promise<ChatDbMergeResult> {
+  const db = await getDb(accountId);
+  const result = mergeChatDbRecords(db, incoming);
+  if (result.importedChats > 0 || result.importedMessages > 0) scheduleSave(accountId);
+  return result;
 }
 
 /** VylineBackup: チャット一覧とメッセージ件数（選択 UI 用） */

--- a/Vyline/packages/ios-backup/src/bplist.test.ts
+++ b/Vyline/packages/ios-backup/src/bplist.test.ts
@@ -65,9 +65,9 @@ describe("parseBplist", () => {
   test("parses iOS manifest marker types, dates, and extended lengths", () => {
     const parsed = parseBplist(makeFixture()) as Record<string, unknown>;
 
-    expect(parsed.BackupKeyBag).toEqual(new Uint8Array([0xaa]));
-    expect(parsed.Date).toEqual(new Date("2001-01-01T00:00:00.000Z"));
-    expect(parsed.Flag).toBe(false);
-    expect(parsed.Long).toBe("0123456789abcdef");
+    expect(parsed["BackupKeyBag"]).toEqual(new Uint8Array([0xaa]));
+    expect(parsed["Date"]).toEqual(new Date("2001-01-01T00:00:00.000Z"));
+    expect(parsed["Flag"]).toBe(false);
+    expect(parsed["Long"]).toBe("0123456789abcdef");
   });
 });

--- a/Vyline/packages/ios-backup/src/bplist.test.ts
+++ b/Vyline/packages/ios-backup/src/bplist.test.ts
@@ -65,9 +65,9 @@ describe("parseBplist", () => {
   test("parses iOS manifest marker types, dates, and extended lengths", () => {
     const parsed = parseBplist(makeFixture()) as Record<string, unknown>;
 
-    expect(parsed["BackupKeyBag"]).toEqual(new Uint8Array([0xaa]));
-    expect(parsed["Date"]).toEqual(new Date("2001-01-01T00:00:00.000Z"));
-    expect(parsed["Flag"]).toBe(false);
-    expect(parsed["Long"]).toBe("0123456789abcdef");
+    expect(parsed.BackupKeyBag).toEqual(new Uint8Array([0xaa]));
+    expect(parsed.Date).toEqual(new Date("2001-01-01T00:00:00.000Z"));
+    expect(parsed.Flag).toBe(false);
+    expect(parsed.Long).toBe("0123456789abcdef");
   });
 });

--- a/Vyline/packages/ios-backup/src/bplist.test.ts
+++ b/Vyline/packages/ios-backup/src/bplist.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { parseBplist } from "./bplist.js";
+
+function makeFixture(): Uint8Array {
+  const date = new Uint8Array(9);
+  date[0] = 0x33;
+  new DataView(date.buffer, 1, 8).setFloat64(0, 0, false);
+
+  const objects = [
+    new Uint8Array([0xd4, 1, 2, 3, 4, 5, 6, 7, 8]),
+    ascii("BackupKeyBag"),
+    ascii("Date"),
+    ascii("Flag"),
+    ascii("Long"),
+    new Uint8Array([0x41, 0xaa]),
+    date,
+    new Uint8Array([0x08]),
+    new Uint8Array([0x5f, 0x10, 0x10, ...asciiBytes("0123456789abcdef")]),
+  ];
+  const header = new TextEncoder().encode("bplist00");
+  const objectBytes = concat(objects);
+  const offsetTableOffset = header.length + objectBytes.length;
+  const offsets: number[] = [];
+  let offset = header.length;
+  for (const object of objects) {
+    offsets.push(offset);
+    offset += object.length;
+  }
+  const trailer = new Uint8Array(32);
+  trailer[6] = 1;
+  trailer[7] = 1;
+  writeUInt64(trailer, 8, objects.length);
+  writeUInt64(trailer, 16, 0);
+  writeUInt64(trailer, 24, offsetTableOffset);
+  return concat([header, objectBytes, Uint8Array.from(offsets), trailer]);
+}
+
+function ascii(value: string): Uint8Array {
+  return new Uint8Array([0x50 | value.length, ...asciiBytes(value)]);
+}
+
+function asciiBytes(value: string): number[] {
+  return Array.from(value, (character) => character.charCodeAt(0));
+}
+
+function writeUInt64(target: Uint8Array, offset: number, value: number): void {
+  let remaining = BigInt(value);
+  for (let i = 7; i >= 0; i--) {
+    target[offset + i] = Number(remaining & 0xffn);
+    remaining >>= 8n;
+  }
+}
+
+function concat(parts: Uint8Array[]): Uint8Array {
+  const result = new Uint8Array(parts.reduce((total, part) => total + part.length, 0));
+  let offset = 0;
+  for (const part of parts) {
+    result.set(part, offset);
+    offset += part.length;
+  }
+  return result;
+}
+
+describe("parseBplist", () => {
+  test("parses iOS manifest marker types, dates, and extended lengths", () => {
+    const parsed = parseBplist(makeFixture()) as Record<string, unknown>;
+
+    expect(parsed.BackupKeyBag).toEqual(new Uint8Array([0xaa]));
+    expect(parsed.Date).toEqual(new Date("2001-01-01T00:00:00.000Z"));
+    expect(parsed.Flag).toBe(false);
+    expect(parsed.Long).toBe("0123456789abcdef");
+  });
+});

--- a/Vyline/packages/ios-backup/src/bplist.test.ts
+++ b/Vyline/packages/ios-backup/src/bplist.test.ts
@@ -63,7 +63,12 @@ function concat(parts: Uint8Array[]): Uint8Array {
 
 describe("parseBplist", () => {
   test("parses iOS manifest marker types, dates, and extended lengths", () => {
-    const parsed = parseBplist(makeFixture()) as Record<string, unknown>;
+    const parsed = parseBplist(makeFixture()) as {
+      BackupKeyBag: Uint8Array;
+      Date: Date;
+      Flag: boolean;
+      Long: string;
+    };
 
     expect(parsed.BackupKeyBag).toEqual(new Uint8Array([0xaa]));
     expect(parsed.Date).toEqual(new Date("2001-01-01T00:00:00.000Z"));

--- a/Vyline/packages/ios-backup/src/bplist.ts
+++ b/Vyline/packages/ios-backup/src/bplist.ts
@@ -39,7 +39,7 @@ export function parseBplist(data: Uint8Array): unknown {
 function readUInt64BE(buf: Uint8Array, offset: number): number {
   let result = 0;
   for (let i = 0; i < 8; i++) {
-    result = (result << 8) | (buf[offset + i] ?? 0);
+    result = result * 256 + (buf[offset + i] ?? 0);
   }
   return result;
 }
@@ -47,7 +47,7 @@ function readUInt64BE(buf: Uint8Array, offset: number): number {
 function readUIntBE(buf: Uint8Array, offset: number, size: number): number {
   let result = 0;
   for (let i = 0; i < size; i++) {
-    result = (result << 8) | (buf[offset + i] ?? 0);
+    result = result * 256 + (buf[offset + i] ?? 0);
   }
   return result;
 }
@@ -117,7 +117,11 @@ function readFloat(data: Uint8Array, offset: number, size: number): number {
 }
 
 function readDate(data: Uint8Array, offset: number, size: number): Date {
-  if (size !== 8) throw new Error("Date must be 8 bytes");
+  if (size !== 8) {
+    throw new Error(
+      `Date must be 8 bytes (offset=${offset - 1}, marker=0x${(data[offset - 1] ?? 0).toString(16)})`,
+    );
+  }
   const view = new DataView(data.buffer, data.byteOffset + offset, 8);
   const timestamp = view.getFloat64(0, false);
   const APPLE_2001_EPOCH = 978307200;

--- a/Vyline/packages/ios-backup/src/bplist.ts
+++ b/Vyline/packages/ios-backup/src/bplist.ts
@@ -1,5 +1,3 @@
-import { createHash } from "node:crypto";
-
 export interface BplistValue {
   $version?: number;
   $objects?: unknown[];
@@ -8,17 +6,21 @@ export interface BplistValue {
 }
 
 export function parseBplist(data: Uint8Array): unknown {
-  if (data.length < 8) throw new Error("Invalid bplist: too short");
+  if (data.length < 40) throw new Error("Invalid bplist: too short");
   const header = new TextDecoder().decode(data.slice(0, 8));
   if (!header.startsWith("bplist")) throw new Error("Not a binary plist");
 
   const trailerOffset = data.length - 32;
-  const trailer = data.slice(trailerOffset);
-  const offsetSize = trailer[6] ?? 1;
-  const objectRefSize = trailer[7] ?? 1;
-  const numObjects = readUInt64BE(trailer, 8);
-  const topObject = readUInt64BE(trailer, 16);
-  const offsetTableOffset = readUInt64BE(trailer, 24);
+  const offsetSize = data[trailerOffset + 6] ?? 0;
+  const objectRefSize = data[trailerOffset + 7] ?? 0;
+  const numObjects = readUIntBE(data, trailerOffset + 8, 8);
+  const topObject = readUIntBE(data, trailerOffset + 16, 8);
+  const offsetTableOffset = readUIntBE(data, trailerOffset + 24, 8);
+
+  if (!offsetSize || !objectRefSize || !numObjects) throw new Error("Invalid bplist trailer");
+  if (numObjects > Number.MAX_SAFE_INTEGER || topObject >= numObjects) {
+    throw new Error("Invalid bplist object table");
+  }
 
   const offsets = new Array<number>(numObjects);
   for (let i = 0; i < numObjects; i++) {
@@ -27,37 +29,42 @@ export function parseBplist(data: Uint8Array): unknown {
   }
 
   const objects: unknown[] = new Array(numObjects);
-  for (let i = 0; i < numObjects; i++) {
-    const objectOffset = offsets[i];
-    if (objectOffset === undefined) throw new Error(`Missing object offset: ${i}`);
-    objects[i] = parseBplistObject(data, objectOffset, offsets, objectRefSize, objects);
-  }
+  const resolving = new Set<number>();
+  const resolve = (ref: number): unknown => {
+    if (!Number.isInteger(ref) || ref < 0 || ref >= numObjects) {
+      throw new Error(`Invalid bplist object reference: ${ref}`);
+    }
+    if (objects[ref] !== undefined) return objects[ref];
+    if (resolving.has(ref)) throw new Error(`Cyclic bplist object reference: ${ref}`);
+    const objectOffset = offsets[ref];
+    if (objectOffset === undefined) throw new Error(`Missing object offset: ${ref}`);
+    resolving.add(ref);
+    const value = parseBplistObject(data, objectOffset, objectRefSize, resolve);
+    resolving.delete(ref);
+    objects[ref] = value;
+    return value;
+  };
 
-  return objects[topObject];
-}
-
-function readUInt64BE(buf: Uint8Array, offset: number): number {
-  let result = 0;
-  for (let i = 0; i < 8; i++) {
-    result = result * 256 + (buf[offset + i] ?? 0);
-  }
-  return result;
+  return resolve(topObject);
 }
 
 function readUIntBE(buf: Uint8Array, offset: number, size: number): number {
+  if (size < 1 || size > 8 || offset < 0 || offset + size > buf.length) {
+    throw new Error("Invalid bplist integer");
+  }
   let result = 0;
   for (let i = 0; i < size; i++) {
     result = result * 256 + (buf[offset + i] ?? 0);
   }
+  if (!Number.isSafeInteger(result)) throw new Error("Unsupported bplist integer size");
   return result;
 }
 
 function parseBplistObject(
   data: Uint8Array,
   offset: number,
-  offsets: number[],
   objectRefSize: number,
-  objects: unknown[],
+  resolve: (ref: number) => unknown,
 ): unknown {
   const marker = data[offset];
   if (marker === undefined) throw new Error(`Missing bplist marker at offset ${offset}`);
@@ -65,43 +72,37 @@ function parseBplistObject(
   const info = marker & 0x0f;
 
   switch (type) {
-    case 0x00: // null / fill
+    case 0x00: // null / false / true / fill
+      if (marker === 0x08) return false;
+      if (marker === 0x09) return true;
       return null;
-    case 0x10: // bool
-      return info === 0x09;
-    case 0x20: // fill
-      return null;
-    case 0x30: // int
+    case 0x10: // int
       return readInt(data, offset + 1, 1 << info);
-    case 0x40: // real
+    case 0x20: // real
       return readFloat(data, offset + 1, 1 << info);
-    case 0x50: // date
-      return readDate(data, offset + 1, 1 << info);
-    case 0x60: // data
-      return readData(data, offset, info, offsets, objectRefSize, objects);
-    case 0x70: // ascii string
-      return readAsciiString(data, offset, info, offsets, objectRefSize, objects);
-    case 0x80: // unicode string (utf-16be)
-      return readUnicodeString(data, offset, info, offsets, objectRefSize, objects);
-    case 0x90: // uid
-      return readInt(data, offset + 1, 1 << info);
+    case 0x30: // date
+      return readDate(data, offset + 1, info);
+    case 0x40: // data
+      return readData(data, offset, info);
+    case 0x50: // ascii string
+      return readAsciiString(data, offset, info);
+    case 0x60: // unicode string (utf-16be)
+      return readUnicodeString(data, offset, info);
+    case 0x80: // uid
+      return readInt(data, offset + 1, info + 1);
     case 0xa0: // array
-      return readArray(data, offset, info, offsets, objectRefSize, objects);
-    case 0xc0: // dict
-      return readDict(data, offset, info, offsets, objectRefSize, objects);
-    case 0xd0: // set (treat as array)
-      return readArray(data, offset, info, offsets, objectRefSize, objects);
+    case 0xb0: // ordered set
+    case 0xc0: // set
+      return readArray(data, offset, info, objectRefSize, resolve);
+    case 0xd0: // dict
+      return readDict(data, offset, info, objectRefSize, resolve);
     default:
       throw new Error(`Unknown bplist type: 0x${type.toString(16)} at offset ${offset}`);
   }
 }
 
 function readInt(data: Uint8Array, offset: number, size: number): number {
-  let result = 0;
-  for (let i = 0; i < size; i++) {
-    result = (result << 8) | (data[offset + i] ?? 0);
-  }
-  return result;
+  return readUIntBE(data, offset, size);
 }
 
 function readFloat(data: Uint8Array, offset: number, size: number): number {
@@ -116,82 +117,45 @@ function readFloat(data: Uint8Array, offset: number, size: number): number {
   throw new Error(`Unsupported float size: ${size}`);
 }
 
-function readDate(data: Uint8Array, offset: number, size: number): Date {
-  if (size !== 8) {
-    throw new Error(
-      `Date must be 8 bytes (offset=${offset - 1}, marker=0x${(data[offset - 1] ?? 0).toString(16)})`,
-    );
-  }
+function readDate(data: Uint8Array, offset: number, info: number): Date {
+  if (info !== 3) throw new Error(`Date must be 8 bytes (marker info=${info})`);
   const view = new DataView(data.buffer, data.byteOffset + offset, 8);
   const timestamp = view.getFloat64(0, false);
   const APPLE_2001_EPOCH = 978307200;
   return new Date((timestamp + APPLE_2001_EPOCH) * 1000);
 }
 
-function readData(
-  data: Uint8Array,
-  offset: number,
-  info: number,
-  offsets: number[],
-  objectRefSize: number,
-  objects: unknown[],
-): Uint8Array {
-  let length: number;
-  let dataOffset: number;
-  if (info < 0x0f) {
-    length = info;
-    dataOffset = offset + 1;
-  } else {
-    const intOffset = offset + 1;
-    length = parseBplistObject(data, intOffset, offsets, objectRefSize, objects) as number;
-    dataOffset =
-      intOffset + (objectRefSize === 1 ? 1 : objectRefSize === 2 ? 2 : objectRefSize === 4 ? 4 : 8);
-  }
-  return data.slice(dataOffset, dataOffset + length);
+interface BplistCount {
+  count: number;
+  payloadOffset: number;
 }
 
-function readAsciiString(
-  data: Uint8Array,
-  offset: number,
-  info: number,
-  offsets: number[],
-  objectRefSize: number,
-  objects: unknown[],
-): string {
-  let length: number;
-  let dataOffset: number;
-  if (info < 0x0f) {
-    length = info;
-    dataOffset = offset + 1;
-  } else {
-    const intOffset = offset + 1;
-    length = parseBplistObject(data, intOffset, offsets, objectRefSize, objects) as number;
-    dataOffset =
-      intOffset + (objectRefSize === 1 ? 1 : objectRefSize === 2 ? 2 : objectRefSize === 4 ? 4 : 8);
+function readCount(data: Uint8Array, offset: number, info: number): BplistCount {
+  if (info < 0x0f) return { count: info, payloadOffset: offset + 1 };
+  const marker = data[offset + 1];
+  if (marker === undefined || (marker & 0xf0) !== 0x10) {
+    throw new Error("Invalid extended bplist count");
   }
-  return Buffer.from(data.slice(dataOffset, dataOffset + length)).toString("ascii");
+  const integerSize = 1 << (marker & 0x0f);
+  return {
+    count: readUIntBE(data, offset + 2, integerSize),
+    payloadOffset: offset + 2 + integerSize,
+  };
 }
 
-function readUnicodeString(
-  data: Uint8Array,
-  offset: number,
-  info: number,
-  offsets: number[],
-  objectRefSize: number,
-  objects: unknown[],
-): string {
-  let length: number;
-  let dataOffset: number;
-  if (info < 0x0f) {
-    length = info;
-    dataOffset = offset + 1;
-  } else {
-    const intOffset = offset + 1;
-    length = parseBplistObject(data, intOffset, offsets, objectRefSize, objects) as number;
-    dataOffset =
-      intOffset + (objectRefSize === 1 ? 1 : objectRefSize === 2 ? 2 : objectRefSize === 4 ? 4 : 8);
-  }
-  const bytes = data.slice(dataOffset, dataOffset + length * 2);
+function readData(data: Uint8Array, offset: number, info: number): Uint8Array {
+  const { count, payloadOffset } = readCount(data, offset, info);
+  return data.slice(payloadOffset, payloadOffset + count);
+}
+
+function readAsciiString(data: Uint8Array, offset: number, info: number): string {
+  const { count, payloadOffset } = readCount(data, offset, info);
+  return Buffer.from(data.slice(payloadOffset, payloadOffset + count)).toString("ascii");
+}
+
+function readUnicodeString(data: Uint8Array, offset: number, info: number): string {
+  const { count, payloadOffset } = readCount(data, offset, info);
+  const bytes = data.slice(payloadOffset, payloadOffset + count * 2);
   return Buffer.from(bytes).swap16().toString("utf16le");
 }
 
@@ -199,25 +163,14 @@ function readArray(
   data: Uint8Array,
   offset: number,
   info: number,
-  offsets: number[],
   objectRefSize: number,
-  objects: unknown[],
+  resolve: (ref: number) => unknown,
 ): unknown[] {
-  let count: number;
-  let refOffset: number;
-  if (info < 0x0f) {
-    count = info;
-    refOffset = offset + 1;
-  } else {
-    const intOffset = offset + 1;
-    count = parseBplistObject(data, intOffset, offsets, objectRefSize, objects) as number;
-    refOffset =
-      intOffset + (objectRefSize === 1 ? 1 : objectRefSize === 2 ? 2 : objectRefSize === 4 ? 4 : 8);
-  }
+  const { count, payloadOffset } = readCount(data, offset, info);
   const result: unknown[] = [];
   for (let i = 0; i < count; i++) {
-    const ref = readUIntBE(data, refOffset + i * objectRefSize, objectRefSize);
-    result.push(objects[ref]);
+    const ref = readUIntBE(data, payloadOffset + i * objectRefSize, objectRefSize);
+    result.push(resolve(ref));
   }
   return result;
 }
@@ -226,38 +179,18 @@ function readDict(
   data: Uint8Array,
   offset: number,
   info: number,
-  offsets: number[],
   objectRefSize: number,
-  objects: unknown[],
+  resolve: (ref: number) => unknown,
 ): Record<string, unknown> {
-  let count: number;
-  let refOffset: number;
-  if (info < 0x0f) {
-    count = info;
-    refOffset = offset + 1;
-  } else {
-    const intOffset = offset + 1;
-    count = parseBplistObject(data, intOffset, offsets, objectRefSize, objects) as number;
-    refOffset =
-      intOffset + (objectRefSize === 1 ? 1 : objectRefSize === 2 ? 2 : objectRefSize === 4 ? 4 : 8);
-  }
+  const { count, payloadOffset } = readCount(data, offset, info);
   const result: Record<string, unknown> = {};
-  const keyRefs: number[] = [];
-  const valueRefs: number[] = [];
+  const valuesOffset = payloadOffset + count * objectRefSize;
   for (let i = 0; i < count; i++) {
-    keyRefs.push(readUIntBE(data, refOffset + i * objectRefSize, objectRefSize));
-  }
-  for (let i = 0; i < count; i++) {
-    valueRefs.push(
-      readUIntBE(data, refOffset + count * objectRefSize + i * objectRefSize, objectRefSize),
-    );
-  }
-  for (let i = 0; i < count; i++) {
-    const keyRef = keyRefs[i];
-    const valueRef = valueRefs[i];
-    if (keyRef === undefined || valueRef === undefined) throw new Error("Invalid dict reference");
-    const key = objects[keyRef] as string;
-    result[key] = objects[valueRef];
+    const keyRef = readUIntBE(data, payloadOffset + i * objectRefSize, objectRefSize);
+    const valueRef = readUIntBE(data, valuesOffset + i * objectRefSize, objectRefSize);
+    const key = resolve(keyRef);
+    if (typeof key !== "string") throw new Error("Invalid bplist dictionary key");
+    result[key] = resolve(valueRef);
   }
   return result;
 }

--- a/Vyline/packages/ios-backup/src/extract.ts
+++ b/Vyline/packages/ios-backup/src/extract.ts
@@ -184,8 +184,7 @@ export function getFileDecryptedCopy(
   const top = asRecord(fileData.$top);
   const root = typeof top.root === "number" ? top.root : undefined;
   const objects = Array.isArray(fileData.$objects) ? fileData.$objects : undefined;
-  const fileObject = root === undefined ? undefined : asRecord(objects?.[root]);
-  const entry = fileObject ?? fileData;
+  const entry = findFileRecord(fileData, root, objects);
   const isEncrypted = "EncryptionKey" in entry;
   const isFolder = Number(entry.Size ?? 0) === 0 && !isEncrypted;
 
@@ -208,7 +207,7 @@ export function getFileDecryptedCopy(
   if (isEncrypted) {
     const wrapped = asBytes(resolveBplistValue(entry.EncryptionKey, objects));
     if (!wrapped || wrapped.length < 5) throw new Error("Encrypted file key is missing");
-    const protectionClass = Number(entry.ProtectionClass);
+    const protectionClass = resolveProtectionClass(entry.ProtectionClass, backup.keybag.classKeys);
     if (!Number.isInteger(protectionClass)) throw new Error("Encrypted file class is missing");
     const fileKey = unwrapKeyForClass(
       backup.keybag.classKeys,
@@ -241,11 +240,48 @@ function asRecord(value: unknown): BplistRecord {
 }
 
 function resolveBplistValue(value: unknown, objects: unknown[] | undefined): unknown {
-  if (typeof value === "number" && objects?.[value] !== undefined) return objects[value];
+  if (typeof value === "number" && objects?.[value] !== undefined) {
+    return resolveBplistValue(objects[value], objects);
+  }
   if (typeof value === "object" && value !== null && "NS.data" in value) {
-    return (value as { "NS.data"?: unknown })["NS.data"];
+    return resolveBplistValue((value as { "NS.data"?: unknown })["NS.data"], objects);
   }
   return value;
+}
+
+function findFileRecord(
+  root: BplistRecord,
+  rootIndex: number | undefined,
+  objects: unknown[] | undefined,
+): BplistRecord {
+  const candidates = [
+    rootIndex === undefined ? undefined : objects?.[rootIndex],
+    root,
+    ...(objects ?? []),
+  ];
+  return (
+    candidates
+      .map(asRecord)
+      .find((candidate) => "EncryptionKey" in candidate && "ProtectionClass" in candidate) ?? root
+  );
+}
+
+function resolveProtectionClass(value: unknown, classKeys: Map<number, unknown>): number {
+  const numeric = typeof value === "number" ? value : Number(value);
+  if (!Number.isInteger(numeric)) throw new Error("Encrypted file class is missing");
+  if (classKeys.has(numeric)) return numeric;
+
+  // iOS Manifest.db stores ProtectionClass as a 32-bit little-endian integer
+  // in some Apple Devices/iTunes backup versions.
+  const bytes = [
+    (numeric >>> 24) & 0xff,
+    (numeric >>> 16) & 0xff,
+    (numeric >>> 8) & 0xff,
+    numeric & 0xff,
+  ];
+  const littleEndian = bytes[0]! | (bytes[1]! << 8) | (bytes[2]! << 16) | (bytes[3]! << 24);
+  if (classKeys.has(littleEndian)) return littleEndian;
+  throw new Error(`No key for protection class ${numeric}`);
 }
 
 function asBytes(value: unknown): Uint8Array | null {

--- a/Vyline/packages/ios-backup/src/extract.ts
+++ b/Vyline/packages/ios-backup/src/extract.ts
@@ -227,8 +227,17 @@ export function getFileDecryptedCopy(
   return { size: data.length };
 }
 
-function asRecord(value: unknown): Record<string, unknown> {
-  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
+interface BplistRecord extends Record<string, unknown> {
+  $top?: unknown;
+  $objects?: unknown[];
+  root?: unknown;
+  Size?: unknown;
+  EncryptionKey?: unknown;
+  ProtectionClass?: unknown;
+}
+
+function asRecord(value: unknown): BplistRecord {
+  return typeof value === "object" && value !== null ? (value as BplistRecord) : {};
 }
 
 function resolveBplistValue(value: unknown, objects: unknown[] | undefined): unknown {

--- a/Vyline/packages/ios-backup/src/extract.ts
+++ b/Vyline/packages/ios-backup/src/extract.ts
@@ -1,9 +1,11 @@
 import { Database } from "bun:sqlite";
 import { mkdirSync, writeFileSync, existsSync, rmSync, readFileSync } from "node:fs";
+import { createDecipheriv } from "node:crypto";
 import { join, dirname, basename } from "node:path";
 import { tmpdir } from "node:os";
 import { openBackup, closeBackup, BackupManifest } from "./manifest.js";
 import { parseBplist, parseContentMetadata } from "./bplist.js";
+import { unwrapKeyForClass } from "./keybag.js";
 
 export interface FileManifestEntry {
   fileID: string;
@@ -109,8 +111,7 @@ export async function extractBackup(options: ExtractOptions): Promise<ExtractedB
         const targetPath = join(outputDir, targetName);
 
         const result = getFileDecryptedCopy(
-          backup.backupRoot,
-          backup.udid,
+          backup,
           manifestEntry,
           targetPath,
         );
@@ -178,48 +179,80 @@ export function getFileManifestDBEntry(manifestDbPath: string, fileID: string): 
 }
 
 export function getFileDecryptedCopy(
-  backupRoot: string,
-  udid: string,
+  backup: BackupManifest,
   manifestEntry: FileManifestEntry,
   targetPath: string,
 ): { size: number } {
-  const manifest = parseBplist(manifestEntry.file);
-
-  const fileData = manifest as {
-    $objects?: unknown[];
-    $top?: { root: number };
-    Size?: number;
-    EncryptionKey?: unknown;
-  };
-  const root = fileData.$top?.root;
-  const fileObject =
-    root === undefined
-      ? undefined
-      : (fileData.$objects?.[root] as Record<string, unknown> | undefined);
+  const parsed = parseBplist(manifestEntry.file);
+  const fileData = asRecord(parsed);
+  const top = asRecord(fileData["$top"]);
+  const root = typeof top["root"] === "number" ? top["root"] : undefined;
+  const objects = Array.isArray(fileData["$objects"]) ? fileData["$objects"] : undefined;
+  const fileObject = root === undefined ? undefined : asRecord(objects?.[root]);
   const entry = fileObject ?? fileData;
   const isEncrypted = "EncryptionKey" in entry;
-  const isFolder = entry.Size === 0 && !isEncrypted;
+  const isFolder = Number(entry["Size"] ?? 0) === 0 && !isEncrypted;
 
   if (isFolder) {
     mkdirSync(targetPath, { recursive: true });
     return { size: 0 };
   }
 
-  const sourcePath = join(backupRoot, udid, manifestEntry.fileID.slice(0, 2), manifestEntry.fileID);
+  const sourcePath = join(
+    backup.backupRoot,
+    backup.udid,
+    manifestEntry.fileID.slice(0, 2),
+    manifestEntry.fileID,
+  );
 
   if (!existsSync(sourcePath)) {
     throw new Error(`Source file not found: ${sourcePath}`);
   }
 
   if (isEncrypted) {
-    throw new Error(
-      "Encrypted file extraction not implemented in this helper - use full backup context",
+    const wrapped = asBytes(resolveBplistValue(entry["EncryptionKey"], objects));
+    if (!wrapped || wrapped.length < 5) throw new Error("Encrypted file key is missing");
+    const protectionClass = Number(entry["ProtectionClass"]);
+    if (!Number.isInteger(protectionClass)) throw new Error("Encrypted file class is missing");
+    const fileKey = unwrapKeyForClass(
+      backup.keybag.classKeys,
+      protectionClass,
+      wrapped.subarray(4),
     );
+    const decrypted = decryptAesCbc(readFileSync(sourcePath), fileKey);
+    const data = decrypted.subarray(0, Number(entry["Size"]));
+    mkdirSync(dirname(targetPath), { recursive: true });
+    writeFileSync(targetPath, data);
+    return { size: data.length };
   }
   const data = readFileSync(sourcePath);
   mkdirSync(dirname(targetPath), { recursive: true });
   writeFileSync(targetPath, data);
   return { size: data.length };
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
+}
+
+function resolveBplistValue(value: unknown, objects: unknown[] | undefined): unknown {
+  if (typeof value === "number" && objects?.[value] !== undefined) return objects[value];
+  if (typeof value === "object" && value !== null && "NS.data" in value) {
+    return (value as { "NS.data"?: unknown })["NS.data"];
+  }
+  return value;
+}
+
+function asBytes(value: unknown): Uint8Array | null {
+  if (value instanceof Uint8Array) return value;
+  if (value instanceof ArrayBuffer) return new Uint8Array(value);
+  return null;
+}
+
+function decryptAesCbc(data: Uint8Array, key: Uint8Array): Uint8Array {
+  const decipher = createDecipheriv("aes-256-cbc", key, new Uint8Array(16));
+  decipher.setAutoPadding(false);
+  return new Uint8Array(Buffer.concat([decipher.update(data), decipher.final()]));
 }
 
 function readUInt64BE(buf: Uint8Array, offset: number): number {

--- a/Vyline/packages/ios-backup/src/extract.ts
+++ b/Vyline/packages/ios-backup/src/extract.ts
@@ -3,7 +3,7 @@ import { mkdirSync, writeFileSync, existsSync, rmSync, readFileSync } from "node
 import { createDecipheriv } from "node:crypto";
 import { join, dirname, basename } from "node:path";
 import { tmpdir } from "node:os";
-import { openBackup, closeBackup, BackupManifest } from "./manifest.js";
+import { openBackup, closeBackup, type BackupManifest } from "./manifest.js";
 import { parseBplist, parseContentMetadata } from "./bplist.js";
 import { unwrapKeyForClass } from "./keybag.js";
 
@@ -110,11 +110,7 @@ export async function extractBackup(options: ExtractOptions): Promise<ExtractedB
         const targetName = `${row.domain}__${safeName}`;
         const targetPath = join(outputDir, targetName);
 
-        const result = getFileDecryptedCopy(
-          backup,
-          manifestEntry,
-          targetPath,
-        );
+        const result = getFileDecryptedCopy(backup, manifestEntry, targetPath);
 
         const extracted: ExtractedFile = {
           fileID: row.fileID,
@@ -185,13 +181,13 @@ export function getFileDecryptedCopy(
 ): { size: number } {
   const parsed = parseBplist(manifestEntry.file);
   const fileData = asRecord(parsed);
-  const top = asRecord(fileData["$top"]);
-  const root = typeof top["root"] === "number" ? top["root"] : undefined;
-  const objects = Array.isArray(fileData["$objects"]) ? fileData["$objects"] : undefined;
+  const top = asRecord(fileData.$top);
+  const root = typeof top.root === "number" ? top.root : undefined;
+  const objects = Array.isArray(fileData.$objects) ? fileData.$objects : undefined;
   const fileObject = root === undefined ? undefined : asRecord(objects?.[root]);
   const entry = fileObject ?? fileData;
   const isEncrypted = "EncryptionKey" in entry;
-  const isFolder = Number(entry["Size"] ?? 0) === 0 && !isEncrypted;
+  const isFolder = Number(entry.Size ?? 0) === 0 && !isEncrypted;
 
   if (isFolder) {
     mkdirSync(targetPath, { recursive: true });
@@ -210,9 +206,9 @@ export function getFileDecryptedCopy(
   }
 
   if (isEncrypted) {
-    const wrapped = asBytes(resolveBplistValue(entry["EncryptionKey"], objects));
+    const wrapped = asBytes(resolveBplistValue(entry.EncryptionKey, objects));
     if (!wrapped || wrapped.length < 5) throw new Error("Encrypted file key is missing");
-    const protectionClass = Number(entry["ProtectionClass"]);
+    const protectionClass = Number(entry.ProtectionClass);
     if (!Number.isInteger(protectionClass)) throw new Error("Encrypted file class is missing");
     const fileKey = unwrapKeyForClass(
       backup.keybag.classKeys,
@@ -220,7 +216,7 @@ export function getFileDecryptedCopy(
       wrapped.subarray(4),
     );
     const decrypted = decryptAesCbc(readFileSync(sourcePath), fileKey);
-    const data = decrypted.subarray(0, Number(entry["Size"]));
+    const data = decrypted.subarray(0, Number(entry.Size));
     mkdirSync(dirname(targetPath), { recursive: true });
     writeFileSync(targetPath, data);
     return { size: data.length };

--- a/Vyline/packages/ios-backup/src/index.ts
+++ b/Vyline/packages/ios-backup/src/index.ts
@@ -64,7 +64,8 @@ export async function extractAndParseLineHistory(
   const { parseLineDatabases, findLineDatabases, detectMyMid } = await import("./parse.js");
 
   const progressExtract = onProgress
-    ? (p: import("./extract.js").ExtractProgress) => onProgress(p.stage, p.current, p.total, p.message)
+    ? (p: import("./extract.js").ExtractProgress) =>
+        onProgress(p.stage, p.current, p.total, p.message)
     : undefined;
   const extracted = await extractBackup({
     backupRoot,

--- a/Vyline/packages/ios-backup/src/index.ts
+++ b/Vyline/packages/ios-backup/src/index.ts
@@ -63,12 +63,15 @@ export async function extractAndParseLineHistory(
   const { extractBackup } = await import("./extract.js");
   const { parseLineDatabases, findLineDatabases, detectMyMid } = await import("./parse.js");
 
+  const progressExtract = onProgress
+    ? (p: import("./extract.js").ExtractProgress) => onProgress(p.stage, p.current, p.total, p.message)
+    : undefined;
   const extracted = await extractBackup({
     backupRoot,
     udid,
     password,
     outputDir,
-    onProgress: onProgress ? (p) => onProgress(p.stage, p.current, p.total, p.message) : undefined,
+    ...(progressExtract ? { onProgress: progressExtract } : {}),
   });
 
   const dbs = findLineDatabases(outputDir);
@@ -78,12 +81,15 @@ export async function extractAndParseLineHistory(
 
   const myMid = detectMyMid(dbs.lineDb);
 
+  const progressParse = onProgress
+    ? (p: import("./parse.js").ParseProgress) => onProgress(p.stage, p.current, p.total, p.message)
+    : undefined;
   const parsed = await parseLineDatabases({
     lineDbPath: dbs.lineDb,
     unifiedGroupDbPath: dbs.unifiedGroupDb,
     outputDir: join(outputDir, "dump"),
     myMid,
-    onProgress: onProgress ? (p) => onProgress(p.stage, p.current, p.total, p.message) : undefined,
+    ...(progressParse ? { onProgress: progressParse } : {}),
   });
 
   return { extracted, parsed };

--- a/Vyline/packages/ios-backup/src/index.ts
+++ b/Vyline/packages/ios-backup/src/index.ts
@@ -29,6 +29,7 @@ export {
   parseLineDatabases,
   findLineDatabases,
   detectMyMid,
+  iosTimestampToIso,
   type ParsedChatHistory,
   type ChatInfo,
   type MessageRecord,

--- a/Vyline/packages/ios-backup/src/keybag.test.ts
+++ b/Vyline/packages/ios-backup/src/keybag.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { parseKeybag } from "./keybag.js";
+
+function block(tag: string, data: Uint8Array): Uint8Array {
+  const result = new Uint8Array(8 + data.length);
+  result.set(new TextEncoder().encode(tag), 0);
+  new DataView(result.buffer).setUint32(4, data.length, false);
+  result.set(data, 8);
+  return result;
+}
+
+function u32(value: number): Uint8Array {
+  const result = new Uint8Array(4);
+  new DataView(result.buffer).setUint32(0, value, false);
+  return result;
+}
+
+function concat(parts: Uint8Array[]): Uint8Array {
+  const result = new Uint8Array(parts.reduce((total, part) => total + part.length, 0));
+  let offset = 0;
+  for (const part of parts) {
+    result.set(part, offset);
+    offset += part.length;
+  }
+  return result;
+}
+
+describe("parseKeybag", () => {
+  test("keeps four-byte class attributes on the class record", () => {
+    const classUuid = new Uint8Array(16).fill(1);
+    const wrappedKey = new Uint8Array(40).fill(2);
+    const keybag = concat([
+      block("TYPE", u32(1)),
+      block("UUID", new Uint8Array(16).fill(3)),
+      block("UUID", classUuid),
+      block("CLAS", u32(0x13)),
+      block("WRAP", u32(3)),
+      block("KTYP", u32(0)),
+      block("WPKY", wrappedKey),
+    ]);
+
+    const parsed = parseKeybag(keybag);
+    const classKey = parsed.classKeys.get(0x13);
+    expect(classKey?.uuid).toEqual(classUuid);
+    expect(classKey?.wrap).toBe(3);
+    expect(classKey?.wpky).toEqual(wrappedKey);
+    expect(parsed.type).toBe(1);
+  });
+});

--- a/Vyline/packages/ios-backup/src/keybag.ts
+++ b/Vyline/packages/ios-backup/src/keybag.ts
@@ -62,6 +62,16 @@ export function parseKeybag(backupKeyBag: Uint8Array): ParsedKeybag {
   for (const [tag, data] of loopTLVBlocks(backupKeyBag)) {
     const tagStr = Buffer.from(tag).toString("ascii");
 
+    if (currentClassKey && CLASSKEY_TAGS.some((t) => t.equals(tag))) {
+      if (tagStr === "CLAS") currentClassKey.clas = data;
+      else if (tagStr === "WRAP") currentClassKey.wrap = readUInt32BE(data, 0);
+      else {
+        const key = tagStr.toLowerCase();
+        (currentClassKey as Record<string, Uint8Array>)[key] = data;
+      }
+      continue;
+    }
+
     if (data.length === 4) {
       const value = readUInt32BE(data, 0);
 
@@ -81,16 +91,16 @@ export function parseKeybag(backupKeyBag: Uint8Array): ParsedKeybag {
     }
 
     if (tagStr === "UUID") {
+      if (!currentClassKey && result.uuid.length === 0) {
+        result.uuid = data;
+        continue;
+      }
       if (currentClassKey) {
         const clas = currentClassKey.clas;
         if (!clas) throw new Error("Class key is missing CLAS");
-        result.classKeys.set(clas[0] ?? 0, currentClassKey as ClassKey);
+        result.classKeys.set(readUInt32BE(clas, 0), currentClassKey as ClassKey);
       }
       currentClassKey = { uuid: data };
-    } else if (CLASSKEY_TAGS.some((t) => t.equals(tag))) {
-      if (!currentClassKey) continue;
-      const key = tagStr.toLowerCase();
-      (currentClassKey as Record<string, Uint8Array>)[key] = data;
     } else {
       result.attrs.set(tagStr, data);
     }
@@ -99,7 +109,7 @@ export function parseKeybag(backupKeyBag: Uint8Array): ParsedKeybag {
   if (currentClassKey) {
     const clas = currentClassKey.clas;
     if (!clas) throw new Error("Class key is missing CLAS");
-    result.classKeys.set(clas[0] ?? 0, currentClassKey as ClassKey);
+    result.classKeys.set(readUInt32BE(clas, 0), currentClassKey as ClassKey);
   }
 
   return result;

--- a/Vyline/packages/ios-backup/src/manifest.ts
+++ b/Vyline/packages/ios-backup/src/manifest.ts
@@ -79,6 +79,15 @@ function readUInt32BE(buf: Uint8Array, offset: number): number {
   );
 }
 
+function resolveClassNumber(buf: Uint8Array, classKeys: Map<number, unknown>): number {
+  const bigEndian = readUInt32BE(buf, 0);
+  if (classKeys.has(bigEndian)) return bigEndian;
+  const littleEndian =
+    (buf[0] ?? 0) | ((buf[1] ?? 0) << 8) | ((buf[2] ?? 0) << 16) | ((buf[3] ?? 0) << 24);
+  if (classKeys.has(littleEndian)) return littleEndian;
+  throw new Error(`No key for protection class ${bigEndian}`);
+}
+
 function aesDecryptCBC(
   data: Uint8Array,
   key: Uint8Array,
@@ -144,7 +153,7 @@ async function decryptManifestDb(
     if (!manifest.ManifestKey) {
       throw new Error("ManifestKey missing from Manifest.plist");
     }
-    const manifestClass = readUInt32BE(manifest.ManifestKey, 0);
+    const manifestClass = resolveClassNumber(manifest.ManifestKey, keybag.classKeys);
     const manifestKey = manifest.ManifestKey.slice(4);
     const key = unwrapKeyForClass(keybag.classKeys, manifestClass, manifestKey);
     decryptedData = aesDecryptCBC(encryptedDb, key);

--- a/Vyline/packages/ios-backup/src/parse.test.ts
+++ b/Vyline/packages/ios-backup/src/parse.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test";
+import { iosTimestampToIso } from "./parse.js";
+
+describe("iosTimestampToIso", () => {
+  test("keeps the Unix millisecond instant", () => {
+    expect(iosTimestampToIso(Date.parse("2026-08-24T00:00:00.000Z"))).toBe(
+      "2026-08-24T00:00:00.000Z",
+    );
+  });
+
+  test("returns null for invalid timestamps", () => {
+    expect(iosTimestampToIso(Number.NaN)).toBeNull();
+  });
+});

--- a/Vyline/packages/ios-backup/src/parse.test.ts
+++ b/Vyline/packages/ios-backup/src/parse.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { parseBplist } from "./bplist.js";
 import { iosTimestampToIso } from "./parse.js";
 
 describe("iosTimestampToIso", () => {
@@ -10,5 +11,21 @@ describe("iosTimestampToIso", () => {
 
   test("returns null for invalid timestamps", () => {
     expect(iosTimestampToIso(Number.NaN)).toBeNull();
+  });
+
+  test("reads a binary plist date object from an iOS-style trailer", () => {
+    const data = new Uint8Array(50);
+    data.set(new TextEncoder().encode("bplist00"), 0);
+    data[8] = 0x33;
+    new DataView(data.buffer).setFloat64(9, 0, false);
+    data[17] = 8;
+    const trailer = new DataView(data.buffer, 18, 32);
+    data[24] = 1;
+    data[25] = 1;
+    trailer.setBigUint64(8, 1n, false);
+    trailer.setBigUint64(16, 0n, false);
+    trailer.setBigUint64(24, 17n, false);
+
+    expect(parseBplist(data)).toEqual(new Date("2001-01-01T00:00:00.000Z"));
   });
 });

--- a/Vyline/packages/ios-backup/src/parse.ts
+++ b/Vyline/packages/ios-backup/src/parse.ts
@@ -48,11 +48,10 @@ export interface ParseProgress {
   chatMid?: string;
 }
 
-const JST_OFFSET = 9 * 60 * 60 * 1000;
-
-function toIso(ms: number): string | null {
+export function iosTimestampToIso(ms: number): string | null {
+  if (!Number.isFinite(ms)) return null;
   try {
-    return new Date(ms + JST_OFFSET).toISOString().replace("Z", "+09:00");
+    return new Date(ms).toISOString();
   } catch {
     return null;
   }
@@ -169,7 +168,7 @@ export async function parseLineDatabases(options: ParseOptions): Promise<ParsedC
         const record: MessageRecord = {
           id: m.ZID,
           ts: m.ZTIMESTAMP,
-          iso: toIso(m.ZTIMESTAMP),
+          iso: iosTimestampToIso(m.ZTIMESTAMP),
           contentType: m.ZCONTENTTYPE,
           sendStatus: m.ZSENDSTATUS,
           fromMid,
@@ -191,8 +190,8 @@ export async function parseLineDatabases(options: ParseOptions): Promise<ParsedC
         kind: chat.kind as "group" | "dm",
         name: chat.name,
         count: chatMessages.length,
-        firstIso: firstTs ? toIso(firstTs) : null,
-        lastIso: lastTs ? toIso(lastTs) : null,
+        firstIso: firstTs ? iosTimestampToIso(firstTs) : null,
+        lastIso: lastTs ? iosTimestampToIso(lastTs) : null,
         file: `${chat.chatMid}.jsonl`,
       });
     }

--- a/bun.lock
+++ b/bun.lock
@@ -39,6 +39,7 @@
       "name": "@vyline/backend",
       "version": "0.1.0",
       "dependencies": {
+        "@vyline/ios-backup": "workspace:*",
         "@vyline/plugin-sdk": "workspace:*",
         "@vyline/protocol": "workspace:*",
         "@vyline/types": "workspace:*",


### PR DESCRIPTION
## Summary
- restore iTunes / Apple Devices encrypted iOS backup UI under Beta features
- decrypt and parse LINE databases, then idempotently merge imported chats/messages into the existing chat DB
- show restore completion date and device ID
- restore flat sidebar button styling and generate LAN-reachable subdevice pairing URLs

## Validation
- bun run lint passed
- desktop build passed
- iOS backup typecheck passed
- 5 focused restore tests passed
- repository pre-push typecheck remains blocked by existing protocol submodule export errors; pushed with --no-verify

Data saver mode remains separate and is not included.