### PR TITLE
fix: prevent recursive Bun typecheck processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.6.1-beta] — 2026-08-24 — 重大な型チェック再帰バグ修正
+
+### 修正
+
+- **重大修正** — `typecheck` 実行時に Bun の Windows shim が同じ typecheck コマンドを再帰起動し、Bun プロセスが大量増殖する問題を修正
+- protocol / backend / desktop / ios-backup の TypeScript 起動を Bun shim から Node に変更し、再帰起動経路を排除
+
 ## [0.5.1-beta] — 2026-08-21 — メッセージ編集UI + プッシュ通知切替 + PIN/パスワードデュアルモード
 
 ### 新機能

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <p align="center">
-  <img alt="version" src="https://img.shields.io/badge/version-0.6.0--beta-a78bfa?style=flat-square" />
+  <img alt="version" src="https://img.shields.io/badge/version-0.6.1--beta-a78bfa?style=flat-square" />
   <img alt="license" src="https://img.shields.io/badge/license-MIT-22c55e?style=flat-square" />
   <img alt="runtime" src="https://img.shields.io/badge/runtime-Bun-f472b6?style=flat-square" />
   <img alt="backend" src="https://img.shields.io/badge/backend-Hono-e879f9?style=flat-square" />

--- a/Vyline/apps/desktop/package.json
+++ b/Vyline/apps/desktop/package.json
@@ -7,7 +7,7 @@
     "dev": "bun ./node_modules/vite/bin/vite.js",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "node ./node_modules/typescript/bin/tsc --noEmit"
   },
   "dependencies": {
     "@vyline/themes": "workspace:*",

--- a/Vyline/apps/desktop/package.json
+++ b/Vyline/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vyline/desktop",
-  "version": "0.6.0-beta",
+  "version": "0.6.1-beta",
   "private": true,
   "type": "module",
   "scripts": {

--- a/Vyline/apps/desktop/src/lib/store.ts
+++ b/Vyline/apps/desktop/src/lib/store.ts
@@ -281,16 +281,11 @@ function messagePreview(m: Message): string {
 }
 
 export const UPDATE_NOTES = {
-  version: "0.6.0-beta",
-  title: "Vyline 0.6.0-beta — Backup & ログ & セルフホスト",
+  version: "0.6.1-beta",
+  title: "Vyline 0.6.1-beta — 重大な型チェック再帰バグ修正",
   items: [
-    "VylineBackup: トーク履歴・メディアのスナップショット作成/復元/削除",
-    "チャット詳細ログ（JSONL）を追加（設定 > 詳細・復元 > デバッグログ）",
-    "セルフホスト対応（Docker Compose）+ メディアのサーバー側永続保存",
-    "複数画像の同時送信とグルーピング表示、FILE メッセージ描画",
-    "Keepメモ、プロフィール背景表示、通話中バッジ、リアクションキャッシュ高速化",
-    "リブランディング: @vyline/protocol（旧 @vyline/nezuline）、Nezu* → Vyline*",
-    "利用規約・免責同意ゲートをログイン直後に追加",
+    "重大修正: typecheck 実行時に Bun プロセスが再帰増殖する問題を修正",
+    "protocol / backend / desktop / ios-backup の TypeScript 起動を安定化",
   ],
 };
 

--- a/Vyline/backend/package.json
+++ b/Vyline/backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "bun --watch src/index.ts",
     "start": "bun src/index.ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "node ./node_modules/typescript/bin/tsc --noEmit"
   },
   "dependencies": {
     "@vyline/plugin-sdk": "workspace:*",

--- a/Vyline/packages/ios-backup/package.json
+++ b/Vyline/packages/ios-backup/package.json
@@ -12,7 +12,7 @@
     "dev": "bun run src/cli.ts",
     "test": "bun test",
     "lint": "eslint src --ext .ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "node ./node_modules/typescript/bin/tsc --noEmit"
   },
   "dependencies": {},
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vyline",
-  "version": "0.6.0-beta",
+  "version": "0.6.1-beta",
   "private": true,
   "engines": {
     "bun": ">=1.4.0"


### PR DESCRIPTION
## Summary
- invoke TypeScript directly with Node instead of Bun's Windows executable shim
- apply the fix to protocol, backend, desktop, and ios-backup typecheck scripts

## Verification
- bun run --cwd Vyline/packages/protocol typecheck passes
- root bun run typecheck reaches the existing backend API/type errors without spawning recursive Bun processes
- monitored protocol typecheck Bun process counts: 1,1,0,0,0,0,0,0

## Dependency
- Merge protocol PR #5 first: https://github.com/nezumi0627/vyline-api/pull/5

## Known pre-existing issue
The repository pre-push typecheck still fails on existing backend/protocol API mismatches (loadSbcBackupKeyDumps, @vyline/protocol/sbc). Those are outside this narrow process-recursion fix.