### PR TITLE
fix: make restored chat history complete and ordered

### DIFF
--- a/Vyline/apps/desktop/src/api/client.ts
+++ b/Vyline/apps/desktop/src/api/client.ts
@@ -814,6 +814,7 @@ export const api = {
             restoredAt: string;
             extracted: { lineFiles: number; databases: number };
             parsed: { chats: number; totalMessages: number };
+            restoredChatMids: string[];
             media: { restored: number; skipped: number };
           } | null;
           error: string | null;

--- a/Vyline/apps/desktop/src/components/chat-area.tsx
+++ b/Vyline/apps/desktop/src/components/chat-area.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useMemo, useRef, useState, useCallback } from "react";
+import { memo, useEffect, useMemo, useRef, useState, useCallback, type UIEvent } from "react";
 import { useStore, displayName, type Message } from "@/lib/store";
 import { cn } from "@/lib/utils";
 import { useCall } from "@/hooks/useCall";
@@ -247,6 +247,18 @@ function ChatAreaBase() {
     scrollToKey,
     scrollToBottom,
   } = useVirtualList<MsgRow>({ rows, estimateHeight: estimateMsgHeight });
+
+  const handleMessageScroll = useCallback(
+    (event: UIEvent<HTMLDivElement>) => {
+      onScroll(event);
+      if (event.currentTarget.scrollTop <= 160 && activeChatId) {
+        window.dispatchEvent(
+          new CustomEvent("vyline:load-older-messages", { detail: { chatMid: activeChatId } }),
+        );
+      }
+    },
+    [activeChatId, onScroll],
+  );
 
   const prevLen = useRef(chatMessages.length);
   const prevChat = useRef(activeChatId);
@@ -553,7 +565,7 @@ function ChatAreaBase() {
         {/* messages */}
         <div
           ref={containerRef}
-          onScroll={onScroll}
+          onScroll={handleMessageScroll}
           onContextMenu={(e) => {
             e.preventDefault();
             setPanel({ x: e.clientX, y: e.clientY });

--- a/Vyline/apps/desktop/src/components/chat-area.tsx
+++ b/Vyline/apps/desktop/src/components/chat-area.tsx
@@ -73,6 +73,18 @@ function shouldGroupAdjacentImages(left: Message, right: Message): boolean {
   );
 }
 
+function compareMessagesOldestFirst(left: Message, right: Message): number {
+  const byTime = left.createdAt - right.createdAt;
+  if (byTime) return byTime;
+  try {
+    const leftId = BigInt(left.id);
+    const rightId = BigInt(right.id);
+    return leftId === rightId ? 0 : leftId < rightId ? -1 : 1;
+  } catch {
+    return left.id.localeCompare(right.id);
+  }
+}
+
 function ChatAreaBase() {
   const activeChatId = useStore((s) => s.activeChatId);
   const chats = useStore((s) => s.chats);
@@ -102,6 +114,7 @@ function ChatAreaBase() {
   const [panel, setPanel] = useState<{ x: number; y: number } | null>(null);
   const [groupCallOnline, setGroupCallOnline] = useState(false);
   const [agentPrompt, setAgentPrompt] = useState<string | null>(null);
+  const [olderState, setOlderState] = useState({ hasMore: true, loading: false });
 
   const chat = chats.find((c) => c.id === activeChatId) ?? null;
 
@@ -160,8 +173,7 @@ function ChatAreaBase() {
   }, [endCall]);
 
   const chatMessages = useMemo(
-    () =>
-      messages.filter((m) => m.chatId === activeChatId).sort((a, b) => a.createdAt - b.createdAt),
+    () => messages.filter((m) => m.chatId === activeChatId).sort(compareMessagesOldestFirst),
     [messages, activeChatId],
   );
 
@@ -259,6 +271,30 @@ function ChatAreaBase() {
     },
     [activeChatId, onScroll],
   );
+
+  const requestOlderMessages = useCallback(() => {
+    if (!activeChatId || olderState.loading || !olderState.hasMore) return;
+    window.dispatchEvent(
+      new CustomEvent("vyline:load-older-messages", { detail: { chatMid: activeChatId } }),
+    );
+  }, [activeChatId, olderState]);
+
+  useEffect(() => {
+    setOlderState({ hasMore: true, loading: false });
+    const onOlderState = (event: Event) => {
+      const detail = (
+        event as CustomEvent<{
+          chatMid?: string;
+          hasMore?: boolean;
+          loading?: boolean;
+        }>
+      ).detail;
+      if (detail?.chatMid !== activeChatId) return;
+      setOlderState({ hasMore: detail.hasMore ?? false, loading: detail.loading ?? false });
+    };
+    window.addEventListener("vyline:older-messages-state", onOlderState);
+    return () => window.removeEventListener("vyline:older-messages-state", onOlderState);
+  }, [activeChatId]);
 
   const prevLen = useRef(chatMessages.length);
   const prevChat = useRef(activeChatId);
@@ -576,11 +612,24 @@ function ChatAreaBase() {
         >
           <div className="mx-auto flex w-full max-w-3xl flex-col">
             <div className="mb-4 flex justify-center">
-              <span className="rounded-xl bg-[color-mix(in_oklab,var(--vy-text)_10%,transparent)] px-4 py-2 text-center text-xs leading-relaxed text-[var(--vy-text-dim)]">
-                {chat.type === "group"
-                  ? "▲ ここがトークの一番上です"
-                  : "▲ ここから会話が始まります"}
-              </span>
+              {olderState.hasMore ? (
+                <button
+                  type="button"
+                  onClick={requestOlderMessages}
+                  disabled={olderState.loading}
+                  className="rounded-xl bg-[color-mix(in_oklab,var(--vy-text)_10%,transparent)] px-4 py-2 text-center text-xs leading-relaxed text-[var(--vy-text-dim)] transition-colors hover:text-[var(--vy-text)] disabled:cursor-wait disabled:opacity-70"
+                >
+                  {olderState.loading
+                    ? "過去のメッセージを読み込み中…"
+                    : "↑ 過去のメッセージを読み込む"}
+                </button>
+              ) : (
+                <span className="rounded-xl bg-[color-mix(in_oklab,var(--vy-text)_10%,transparent)] px-4 py-2 text-center text-xs leading-relaxed text-[var(--vy-text-dim)]">
+                  {chat.type === "group"
+                    ? "▲ ここがトークの一番上です"
+                    : "▲ ここから会話が始まります"}
+                </span>
+              )}
             </div>
             {topSpacer > 0 && <div style={{ height: topSpacer }} aria-hidden />}
             {visibleRows.map(({ key, item }) =>

--- a/Vyline/apps/desktop/src/components/chat-area.tsx
+++ b/Vyline/apps/desktop/src/components/chat-area.tsx
@@ -260,6 +260,23 @@ function ChatAreaBase() {
     scrollToBottom,
   } = useVirtualList<MsgRow>({ rows, estimateHeight: estimateMsgHeight });
 
+  // 先頭に居続けているときは、ページ追加後も次のローカル履歴を連続して取得する。
+  useEffect(() => {
+    const onOlderLoaded = (event: Event) => {
+      const chatMid = (event as CustomEvent<{ chatMid?: string }>).detail?.chatMid;
+      if (chatMid !== activeChatId) return;
+      const container = containerRef.current;
+      if (!container || container.scrollTop > 160) return;
+      window.requestAnimationFrame(() => {
+        window.dispatchEvent(
+          new CustomEvent("vyline:load-older-messages", { detail: { chatMid: activeChatId } }),
+        );
+      });
+    };
+    window.addEventListener("vyline:older-messages-loaded", onOlderLoaded);
+    return () => window.removeEventListener("vyline:older-messages-loaded", onOlderLoaded);
+  }, [activeChatId, containerRef]);
+
   const handleMessageScroll = useCallback(
     (event: UIEvent<HTMLDivElement>) => {
       onScroll(event);

--- a/Vyline/apps/desktop/src/components/ios-backup-beta-panel.tsx
+++ b/Vyline/apps/desktop/src/components/ios-backup-beta-panel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { api } from "@/api/client";
 import { IconBlock, IconCheck, IconHardDrive, IconShield, IconSpark } from "@/components/icons";
+import { markRestoredChatMids } from "@/utils/dismissedChats";
 
 type Device = NonNullable<Awaited<ReturnType<typeof api.line.listIosBackups>>["devices"]>[number];
 type Session = NonNullable<Awaited<ReturnType<typeof api.line.getIosBackupSession>>["session"]>;
@@ -53,6 +54,7 @@ export function IosBackupBetaPanel({ accountId }: { accountId: string | null }) 
 
   useEffect(() => {
     if (session?.status !== "completed" || !accountId) return;
+    markRestoredChatMids(accountId, session.result?.restoredChatMids ?? []);
     window.dispatchEvent(
       new CustomEvent("vyline:ios-backup-restored", {
         detail: { accountId, chatMids: session.result?.restoredChatMids ?? [] },

--- a/Vyline/apps/desktop/src/components/ios-backup-beta-panel.tsx
+++ b/Vyline/apps/desktop/src/components/ios-backup-beta-panel.tsx
@@ -167,9 +167,29 @@ export function IosBackupBetaPanel({ accountId }: { accountId: string | null }) 
       </div>
 
       {session?.progress && (
-        <p className="mt-3 text-xs text-[var(--vy-text-dim)]" role="status">
-          {session.progress.message} ({session.progress.current}/{session.progress.total})
-        </p>
+        <div className="mt-3 space-y-1.5" role="status" aria-live="polite">
+          <div className="flex items-center justify-between gap-3 text-xs text-[var(--vy-text-dim)]">
+            <span>{session.progress.message}</span>
+            <span className="shrink-0 font-mono">
+              {session.progress.current}/{session.progress.total}
+            </span>
+          </div>
+          <div
+            className="h-1.5 overflow-hidden rounded-full bg-[var(--vy-surface-2)]"
+            role="progressbar"
+            aria-label="iOSバックアップ復元の進捗"
+            aria-valuemin={0}
+            aria-valuemax={session.progress.total}
+            aria-valuenow={session.progress.current}
+          >
+            <div
+              className="h-full rounded-full bg-[var(--vy-accent)] transition-[width] duration-300"
+              style={{
+                width: `${session.progress.total > 0 ? Math.min(100, (session.progress.current / session.progress.total) * 100) : 0}%`,
+              }}
+            />
+          </div>
+        </div>
       )}
       {session?.status === "completed" && session.result && (
         <p className="mt-3 flex items-center gap-2 text-xs text-emerald-400" role="status">

--- a/Vyline/apps/desktop/src/components/ios-backup-beta-panel.tsx
+++ b/Vyline/apps/desktop/src/components/ios-backup-beta-panel.tsx
@@ -53,7 +53,11 @@ export function IosBackupBetaPanel({ accountId }: { accountId: string | null }) 
 
   useEffect(() => {
     if (session?.status !== "completed" || !accountId) return;
-    window.dispatchEvent(new CustomEvent("vyline:ios-backup-restored", { detail: { accountId } }));
+    window.dispatchEvent(
+      new CustomEvent("vyline:ios-backup-restored", {
+        detail: { accountId, chatMids: session.result?.restoredChatMids ?? [] },
+      }),
+    );
   }, [accountId, session?.status]);
 
   const start = async () => {

--- a/Vyline/apps/desktop/src/components/ios-backup-beta-panel.tsx
+++ b/Vyline/apps/desktop/src/components/ios-backup-beta-panel.tsx
@@ -37,7 +37,12 @@ export function IosBackupBetaPanel({ accountId }: { accountId: string | null }) 
   }, [accountId]);
 
   useEffect(() => {
-    if (!session || !accountId || (session.status !== "pending" && session.status !== "running"))
+    if (
+      !session ||
+      !session.id ||
+      !accountId ||
+      (session.status !== "pending" && session.status !== "running")
+    )
       return;
     const timer = window.setInterval(async () => {
       const response = await api.line.getIosBackupSession(accountId, session.id);
@@ -55,6 +60,20 @@ export function IosBackupBetaPanel({ accountId }: { accountId: string | null }) 
     if (!accountId || !selected || !password) return;
     setLoading(true);
     setMessage(null);
+    setSession({
+      id: "",
+      status: "pending",
+      progress: {
+        stage: "starting",
+        current: 0,
+        total: 1,
+        message: "復元処理を開始しています",
+      },
+      result: null,
+      error: null,
+      startedAt: Date.now(),
+      completedAt: null,
+    });
     try {
       const response = await api.line.startIosBackupRestore(accountId, selected.udid, password);
       if (!response.ok || !response.sessionId)
@@ -62,7 +81,12 @@ export function IosBackupBetaPanel({ accountId }: { accountId: string | null }) 
       setSession({
         id: response.sessionId,
         status: "pending",
-        progress: null,
+        progress: {
+          stage: "starting",
+          current: 0,
+          total: 1,
+          message: "バックアップを準備しています",
+        },
         result: null,
         error: null,
         startedAt: Date.now(),
@@ -70,6 +94,7 @@ export function IosBackupBetaPanel({ accountId }: { accountId: string | null }) 
       });
       setPassword("");
     } catch (error) {
+      setSession(null);
       setMessage(error instanceof Error ? error.message : "復元を開始できませんでした");
     } finally {
       setLoading(false);

--- a/Vyline/apps/desktop/src/components/profile-drawer.tsx
+++ b/Vyline/apps/desktop/src/components/profile-drawer.tsx
@@ -402,7 +402,6 @@ export function ProfileDrawer({ chat }: { chat: Chat }) {
 
   const conversationText = messages
     .filter((m) => m.chatId === chat.id && m.text?.trim())
-    .slice(-120)
     .map((m) => `${m.authorId === "me" ? "自分" : name}: ${m.text!.trim().slice(0, 800)}`)
     .join("\n");
 

--- a/Vyline/apps/desktop/src/hooks/useHiddenChats.ts
+++ b/Vyline/apps/desktop/src/hooks/useHiddenChats.ts
@@ -7,6 +7,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 const STORAGE_KEY = "vyline:hiddenChatsByAccount";
+const CHANGE_EVENT = "vyline:hidden-chats-changed";
 
 export function loadHiddenChats(): Record<string, string[]> {
   try {
@@ -19,6 +20,7 @@ export function loadHiddenChats(): Record<string, string[]> {
 
 export function saveHiddenChats(data: Record<string, string[]>): void {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  window.dispatchEvent(new Event(CHANGE_EVENT));
 }
 
 export function setHiddenForAccount(accountId: string, chatMid: string, hidden: boolean): void {
@@ -32,13 +34,18 @@ export function setHiddenForAccount(accountId: string, chatMid: string, hidden: 
 export function useHiddenChats(accountId: string | null) {
   const [hiddenByAccount, setHiddenByAccount] = useState<Record<string, string[]>>(loadHiddenChats);
 
-  // 別タブ/ウィンドウの変更を同期
+  // 別タブ/ウィンドウと同一タブ内のストア変更を同期
   useEffect(() => {
     const handler = (e: StorageEvent) => {
       if (e.key === STORAGE_KEY) setHiddenByAccount(loadHiddenChats());
     };
+    const localHandler = () => setHiddenByAccount(loadHiddenChats());
     window.addEventListener("storage", handler);
-    return () => window.removeEventListener("storage", handler);
+    window.addEventListener(CHANGE_EVENT, localHandler);
+    return () => {
+      window.removeEventListener("storage", handler);
+      window.removeEventListener(CHANGE_EVENT, localHandler);
+    };
   }, []);
 
   const hiddenSet = useMemo<Set<string>>(() => {

--- a/Vyline/apps/desktop/src/hooks/useLineData.ts
+++ b/Vyline/apps/desktop/src/hooks/useLineData.ts
@@ -19,7 +19,7 @@ import {
   vylineClientToContactMap,
 } from "../lib/vyline-cache.js";
 import { useStore } from "../lib/store.js";
-import { restoreDismissedChatMid } from "../utils/dismissedChats.js";
+import { getRestoredChatMids, restoreDismissedChatMid } from "../utils/dismissedChats.js";
 
 interface UseLineDataOptions {
   accountId: string | null;
@@ -329,10 +329,18 @@ export function useLineData({ accountId }: UseLineDataOptions) {
       if (restoredAccountId !== accountId) return;
       const restoredChatMids =
         (event as CustomEvent<{ chatMids?: string[] }>).detail?.chatMids ?? [];
-      for (const chatMid of restoredChatMids) restoreDismissedChatMid(accountId, chatMid);
+      for (const chatMid of restoredChatMids) {
+        restoreDismissedChatMid(accountId, chatMid);
+        useStore.getState().setHidden(chatMid, false);
+      }
+      const restoreTarget = restoredChatMids[0];
+      if (restoreTarget) {
+        setSelectedChatMid(restoreTarget);
+        useStore.setState({ activeChatId: restoreTarget, screen: "chat" });
+      }
       void (async () => {
         await loadBootstrap();
-        const chatMid = selectedChatMidRef.current;
+        const chatMid = restoreTarget ?? selectedChatMidRef.current;
         if (!chatMid) return;
         const res = await api.line.messages(accountId, chatMid, PAGE_SIZE, { local: true });
         if (res.ok && res.messages) {
@@ -362,6 +370,10 @@ export function useLineData({ accountId }: UseLineDataOptions) {
     if (!accountId) {
       setContactCache(new Map());
       return;
+    }
+    for (const chatMid of getRestoredChatMids(accountId)) {
+      restoreDismissedChatMid(accountId, chatMid);
+      useStore.getState().setHidden(chatMid, false);
     }
 
     // Vyline ローカルキャッシュを即 hydrate（mid 生出し回避）

--- a/Vyline/apps/desktop/src/hooks/useLineData.ts
+++ b/Vyline/apps/desktop/src/hooks/useLineData.ts
@@ -306,6 +306,16 @@ export function useLineData({ accountId }: UseLineDataOptions) {
     return () => window.removeEventListener("vyline:load-older-messages", onLoadOlder);
   }, [loadOlderMessages]);
 
+  // 先頭のUIは残件・読み込み中を正しく表示する。
+  useEffect(() => {
+    if (!selectedChatMid || typeof window === "undefined") return;
+    window.dispatchEvent(
+      new CustomEvent("vyline:older-messages-state", {
+        detail: { chatMid: selectedChatMid, hasMore: hasMoreMessages, loading: loadingOlder },
+      }),
+    );
+  }, [hasMoreMessages, loadingOlder, selectedChatMid]);
+
   const loadBootstrap = useCallback(async () => {
     if (!accountId || inFlight.current.bootstrap) return;
     inFlight.current.bootstrap = true;

--- a/Vyline/apps/desktop/src/hooks/useLineData.ts
+++ b/Vyline/apps/desktop/src/hooks/useLineData.ts
@@ -19,7 +19,6 @@ import {
   vylineClientToContactMap,
 } from "../lib/vyline-cache.js";
 import { useStore } from "../lib/store.js";
-import { getRestoredChatMids, restoreDismissedChatMid } from "../utils/dismissedChats.js";
 
 interface UseLineDataOptions {
   accountId: string | null;
@@ -329,10 +328,6 @@ export function useLineData({ accountId }: UseLineDataOptions) {
       if (restoredAccountId !== accountId) return;
       const restoredChatMids =
         (event as CustomEvent<{ chatMids?: string[] }>).detail?.chatMids ?? [];
-      for (const chatMid of restoredChatMids) {
-        restoreDismissedChatMid(accountId, chatMid);
-        useStore.getState().setHidden(chatMid, false);
-      }
       const restoreTarget = restoredChatMids[0];
       if (restoreTarget) {
         setSelectedChatMid(restoreTarget);
@@ -371,11 +366,6 @@ export function useLineData({ accountId }: UseLineDataOptions) {
       setContactCache(new Map());
       return;
     }
-    for (const chatMid of getRestoredChatMids(accountId)) {
-      restoreDismissedChatMid(accountId, chatMid);
-      useStore.getState().setHidden(chatMid, false);
-    }
-
     // Vyline ローカルキャッシュを即 hydrate（mid 生出し回避）
     setContactCache(vylineClientToContactMap(accountId));
 

--- a/Vyline/apps/desktop/src/hooks/useLineData.ts
+++ b/Vyline/apps/desktop/src/hooks/useLineData.ts
@@ -269,6 +269,7 @@ export function useLineData({ accountId }: UseLineDataOptions) {
         const res = await api.line.messages(accountId, chatMid, PAGE_SIZE, {
           beforeMessageId: oldest.id,
           beforeDeliveredTime: oldest.createdTime,
+          local: true,
         });
         if (gen !== messagesGen.current) return;
         if (selectedChatMidRef.current !== chatMid) return;
@@ -293,6 +294,17 @@ export function useLineData({ accountId }: UseLineDataOptions) {
     },
     [accountId, hasMoreMessages, resolveMessageAuthors],
   );
+
+  // ChatArea の仮想スクロールが先頭に到達したら、古い履歴を追加取得する。
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const onLoadOlder = (event: Event) => {
+      const chatMid = (event as CustomEvent<{ chatMid?: string }>).detail?.chatMid;
+      if (chatMid) void loadOlderMessages(chatMid);
+    };
+    window.addEventListener("vyline:load-older-messages", onLoadOlder);
+    return () => window.removeEventListener("vyline:load-older-messages", onLoadOlder);
+  }, [loadOlderMessages]);
 
   const loadBootstrap = useCallback(async () => {
     if (!accountId || inFlight.current.bootstrap) return;

--- a/Vyline/apps/desktop/src/hooks/useLineData.ts
+++ b/Vyline/apps/desktop/src/hooks/useLineData.ts
@@ -19,6 +19,7 @@ import {
   vylineClientToContactMap,
 } from "../lib/vyline-cache.js";
 import { useStore } from "../lib/store.js";
+import { restoreDismissedChatMid } from "../utils/dismissedChats.js";
 
 interface UseLineDataOptions {
   accountId: string | null;
@@ -326,6 +327,9 @@ export function useLineData({ accountId }: UseLineDataOptions) {
     const onRestore = (event: Event) => {
       const restoredAccountId = (event as CustomEvent<{ accountId?: string }>).detail?.accountId;
       if (restoredAccountId !== accountId) return;
+      const restoredChatMids =
+        (event as CustomEvent<{ chatMids?: string[] }>).detail?.chatMids ?? [];
+      for (const chatMid of restoredChatMids) restoreDismissedChatMid(accountId, chatMid);
       void (async () => {
         await loadBootstrap();
         const chatMid = selectedChatMidRef.current;

--- a/Vyline/apps/desktop/src/hooks/useLineData.ts
+++ b/Vyline/apps/desktop/src/hooks/useLineData.ts
@@ -24,7 +24,7 @@ interface UseLineDataOptions {
   accountId: string | null;
 }
 
-const PAGE_SIZE = 50;
+const PAGE_SIZE = 100;
 
 export function useLineData({ accountId }: UseLineDataOptions) {
   const [profile, setProfile] = useState<LineProfile | null>(null);
@@ -263,6 +263,7 @@ export function useLineData({ accountId }: UseLineDataOptions) {
       if (!oldest) return;
 
       const gen = messagesGen.current;
+      let shouldContinue = false;
       olderInFlight.current = true;
       setLoadingOlder(true);
       try {
@@ -285,11 +286,19 @@ export function useLineData({ accountId }: UseLineDataOptions) {
           return;
         }
         setMessages((prev) => [...fresh, ...prev]);
-        setHasMoreMessages(res.hasMore ?? res.messages.length >= PAGE_SIZE);
+        shouldContinue = res.hasMore ?? res.messages.length >= PAGE_SIZE;
+        setHasMoreMessages(shouldContinue);
         resolveMessageAuthors(fresh);
       } finally {
         olderInFlight.current = false;
         if (gen === messagesGen.current) setLoadingOlder(false);
+      }
+      if (shouldContinue && gen === messagesGen.current && selectedChatMidRef.current === chatMid) {
+        window.requestAnimationFrame(() => {
+          window.dispatchEvent(
+            new CustomEvent("vyline:older-messages-loaded", { detail: { chatMid } }),
+          );
+        });
       }
     },
     [accountId, hasMoreMessages, resolveMessageAuthors],

--- a/Vyline/apps/desktop/src/lib/store.ts
+++ b/Vyline/apps/desktop/src/lib/store.ts
@@ -78,7 +78,6 @@ const sessionOpenedChats = new Set<string>();
 
 const accountChatKey = (accountId: string, chatId: string) => `${accountId}:${chatId}`;
 
-const MAX_MESSAGES_PER_CHAT = 120;
 // push が機能しない環境でもアクティブチャットの受信を保証するための間隔
 const DELTA_POLL_MIN_MS = 10_000;
 
@@ -1869,11 +1868,8 @@ export const useStore = create<State>()(
                 if (!mergedMap.has(m.id)) mergedMap.set(m.id, m);
               }
               const forChat = [...mergedMap.values()].sort((a, b) => a.createdAt - b.createdAt);
-              return {
-                messages: [
-                  ...st.messages.filter((m) => m.chatId !== chatId),
-                  ...forChat.slice(-MAX_MESSAGES_PER_CHAT),
-                ],
+                return {
+                  messages: [...st.messages.filter((m) => m.chatId !== chatId), ...forChat],
                 chats: st.chats.map((c) =>
                   c.id === chatId && c.type === "group"
                     ? {
@@ -2155,7 +2151,7 @@ export const useStore = create<State>()(
             : st.messages;
           const merged = [...withUpdates, ...fresh].sort((a, b) => a.createdAt - b.createdAt);
           const trimmed = merged.filter((m) => m.chatId !== chatId);
-          const forChat = merged.filter((m) => m.chatId === chatId).slice(-MAX_MESSAGES_PER_CHAT);
+          const forChat = merged.filter((m) => m.chatId === chatId);
           return {
             messages: [...trimmed, ...forChat],
             chats: st.chats.map((c) => {

--- a/Vyline/apps/desktop/src/lib/store.ts
+++ b/Vyline/apps/desktop/src/lib/store.ts
@@ -1868,8 +1868,8 @@ export const useStore = create<State>()(
                 if (!mergedMap.has(m.id)) mergedMap.set(m.id, m);
               }
               const forChat = [...mergedMap.values()].sort((a, b) => a.createdAt - b.createdAt);
-                return {
-                  messages: [...st.messages.filter((m) => m.chatId !== chatId), ...forChat],
+              return {
+                messages: [...st.messages.filter((m) => m.chatId !== chatId), ...forChat],
                 chats: st.chats.map((c) =>
                   c.id === chatId && c.type === "group"
                     ? {

--- a/Vyline/apps/desktop/src/lib/store.ts
+++ b/Vyline/apps/desktop/src/lib/store.ts
@@ -31,7 +31,7 @@ import {
   setCombinationStickerPreview,
   type CombinationStickerPlacement,
 } from "../utils/combinationStickers.js";
-import { getDismissedChatMids } from "../utils/dismissedChats.js";
+import { getDismissedChatMids, getRestoredChatMids } from "../utils/dismissedChats.js";
 import { parseMentions, type MentionDraft } from "../utils/mention.js";
 import { compressImageFile } from "../utils/compressImage.js";
 import { setHiddenForAccount } from "../hooks/useHiddenChats.js";
@@ -720,8 +720,9 @@ export const useStore = create<State>()(
         const accountId = get().accountId;
         const activeChatId = get().activeChatId;
         const dismissed = accountId ? getDismissedChatMids(accountId) : new Set<string>();
+        const restored = accountId ? new Set(getRestoredChatMids(accountId)) : new Set<string>();
         const mappedChats = chats
-          .filter((c) => !dismissed.has(c.mid) && !c.left)
+          .filter((c) => (!dismissed.has(c.mid) || restored.has(c.mid)) && !c.left)
           .map((c) => {
             const base = mapChat(c, hiddenMids.has(c.mid), contactCache);
             const cached = contactCache.get(c.mid);
@@ -753,7 +754,7 @@ export const useStore = create<State>()(
         });
 
         const chatId =
-          activeChatId && !dismissed.has(activeChatId)
+          activeChatId && (!dismissed.has(activeChatId) || restored.has(activeChatId))
             ? activeChatId
             : (mappedChats[0]?.id ?? null);
         // 1on1 の受信メッセージは from=相手(chatId)/to=自分 になるため、from 側も対象に含める
@@ -769,7 +770,7 @@ export const useStore = create<State>()(
 
         set((st) => ({
           chats: mappedChats
-            .filter((c) => !dismissed.has(c.id))
+            .filter((c) => !dismissed.has(c.id) || restored.has(c.id))
             .map((c) => {
               const prev = st.chats.find((p) => p.id === c.id);
               const mergedName =
@@ -1669,9 +1670,10 @@ export const useStore = create<State>()(
                 .map((c) => c.id),
             );
             const dismissed = getDismissedChatMids(accountId);
+            const restored = new Set(getRestoredChatMids(accountId));
             set((st) => ({
               chats: res
-                .chats!.filter((c) => !dismissed.has(c.mid))
+                .chats!.filter((c) => !dismissed.has(c.mid) || restored.has(c.mid))
                 .map((c) => {
                   const base = mapChat(c, hidden.has(c.mid));
                   const prev = st.chats.find((p) => p.id === c.mid);

--- a/Vyline/apps/desktop/src/utils/dismissedChats.ts
+++ b/Vyline/apps/desktop/src/utils/dismissedChats.ts
@@ -30,6 +30,15 @@ export function dismissChatMid(accountId: string, chatMid: string): void {
   save(data);
 }
 
+export function restoreDismissedChatMid(accountId: string, chatMid: string): void {
+  const data = load();
+  const next = (data[accountId] ?? []).filter((mid) => mid !== chatMid);
+  if (next.length === (data[accountId] ?? []).length) return;
+  if (next.length > 0) data[accountId] = next;
+  else delete data[accountId];
+  save(data);
+}
+
 export function isChatDismissed(accountId: string, chatMid: string): boolean {
   return getDismissedChatMids(accountId).has(chatMid);
 }

--- a/Vyline/apps/desktop/src/utils/dismissedChats.ts
+++ b/Vyline/apps/desktop/src/utils/dismissedChats.ts
@@ -4,6 +4,7 @@
  */
 
 const STORAGE_KEY = "vyline:dismissedChatsByAccount";
+const RESTORED_KEY = "vyline:restoredChatMidsByAccount";
 
 function load(): Record<string, string[]> {
   try {
@@ -37,6 +38,28 @@ export function restoreDismissedChatMid(accountId: string, chatMid: string): voi
   if (next.length > 0) data[accountId] = next;
   else delete data[accountId];
   save(data);
+}
+
+export function markRestoredChatMids(accountId: string, chatMids: string[]): void {
+  if (chatMids.length === 0) return;
+  try {
+    const raw = localStorage.getItem(RESTORED_KEY);
+    const data = raw ? (JSON.parse(raw) as Record<string, string[]>) : {};
+    data[accountId] = [...new Set([...(data[accountId] ?? []), ...chatMids])];
+    localStorage.setItem(RESTORED_KEY, JSON.stringify(data));
+  } catch {
+    /* localStorage may be unavailable in a restricted browser context */
+  }
+}
+
+export function getRestoredChatMids(accountId: string): string[] {
+  try {
+    const raw = localStorage.getItem(RESTORED_KEY);
+    const data = raw ? (JSON.parse(raw) as Record<string, string[]>) : {};
+    return data[accountId] ?? [];
+  } catch {
+    return [];
+  }
 }
 
 export function isChatDismissed(accountId: string, chatMid: string): boolean {

--- a/Vyline/backend/src/api/line.ts
+++ b/Vyline/backend/src/api/line.ts
@@ -25,6 +25,7 @@ import { Hono } from "hono";
 import type { Context } from "hono";
 import { childLogger } from "../logger.js";
 import { readMediaStorage, writeMediaStorage } from "../storage/mediaStorage.js";
+import { rebuildAccountChatDb } from "../storage/chatStore.js";
 import { getProxyConfig, setProxyConfig } from "../proxyConfig.js";
 import { getFeatureLocks, unbanCreateGroup } from "../storage/featureLocks.js";
 import { getPluginStates, listPlugins, setPluginState } from "../line/pluginManager.js";
@@ -402,6 +403,17 @@ lineRouter.get("/:accountId/messages/:chatMid", async (c) => {
     ) {
       return c.json({ ok: true, messages: [], hasMore: false, timedOut: true });
     }
+    return handleError(err, c);
+  }
+});
+
+// ─── POST /line/:accountId/chatdb/rebuild ────
+// 既存DBを退避して、復元・同期混在後の時系列と最新チャット要約を正規化する。
+lineRouter.post("/:accountId/chatdb/rebuild", async (c) => {
+  const accountId = c.req.param("accountId");
+  try {
+    return c.json({ ok: true, ...(await rebuildAccountChatDb(accountId)) });
+  } catch (err) {
     return handleError(err, c);
   }
 });

--- a/Vyline/backend/src/service/iosBackupService.ts
+++ b/Vyline/backend/src/service/iosBackupService.ts
@@ -165,9 +165,39 @@ async function runRestore(
         session.progress = { stage, current, total, message };
       },
     );
+    session.progress = {
+      stage: "merge",
+      current: 0,
+      total: 1,
+      message: "チャット履歴をVylineのDBへ取り込んでいます",
+    };
     const records = historyToChatDb(result.parsed, session.accountId);
     const merged = await mergeImportedChatDb(session.accountId, records);
-    const media = await restoreMediaFiles(session.accountId, result.extracted.files, result.parsed);
+    session.progress = {
+      stage: "media",
+      current: 0,
+      total: 1,
+      message: "復元したメディアをDBへ紐付けています",
+    };
+    const media = await restoreMediaFiles(
+      session.accountId,
+      result.extracted.files,
+      result.parsed,
+      (current, total) => {
+        session.progress = {
+          stage: "media",
+          current,
+          total,
+          message: "復元したメディアをDBへ紐付けています",
+        };
+      },
+    );
+    session.progress = {
+      stage: "save",
+      current: 1,
+      total: 1,
+      message: "復元結果をDBへ保存しています",
+    };
     await flushAccountChatDb(session.accountId);
     const totalMessages = Array.from(result.parsed.messages.values()).reduce(
       (sum, messages) => sum + messages.length,
@@ -204,6 +234,7 @@ async function restoreMediaFiles(
   accountId: string,
   files: ExtractedFile[],
   history: ParsedChatHistory,
+  onProgress?: (current: number, total: number) => void,
 ): Promise<{ restored: number; skipped: number }> {
   const candidates = files.filter((file) => !file.localPath.endsWith(".sqlite"));
   const byName = new Map<string, ExtractedFile>();
@@ -216,6 +247,12 @@ async function restoreMediaFiles(
 
   let restored = 0;
   let skipped = 0;
+  const mediaMessages = [...history.messages.values()]
+    .flat()
+    .filter((message) => MEDIA_CONTENT_TYPES.has(iosContentType(message.contentType)));
+  const total = mediaMessages.length;
+  let current = 0;
+  onProgress?.(0, total);
   for (const [chatMid, messages] of history.messages) {
     for (const message of messages) {
       const kind = iosContentType(message.contentType);
@@ -224,6 +261,8 @@ async function restoreMediaFiles(
       const file = findMediaFile(tokens, byName, candidates);
       if (!file) {
         skipped++;
+        current++;
+        onProgress?.(current, total);
         continue;
       }
       try {
@@ -238,6 +277,8 @@ async function restoreMediaFiles(
       } catch {
         skipped++;
       }
+      current++;
+      onProgress?.(current, total);
     }
   }
   return { restored, skipped };

--- a/Vyline/backend/src/service/iosBackupService.ts
+++ b/Vyline/backend/src/service/iosBackupService.ts
@@ -51,6 +51,7 @@ export interface IosBackupSession {
     restoredAt: string;
     extracted: { lineFiles: number; databases: number };
     parsed: { chats: number; totalMessages: number };
+    restoredChatMids: string[];
     merged: {
       importedChats: number;
       skippedChats: number;
@@ -218,6 +219,7 @@ async function runRestore(
         databases: result.extracted.databases.length,
       },
       parsed: { chats: result.parsed.chats.length, totalMessages },
+      restoredChatMids: records.chats ? Object.keys(records.chats) : [],
       merged,
       media,
     };

--- a/Vyline/backend/src/service/iosBackupService.ts
+++ b/Vyline/backend/src/service/iosBackupService.ts
@@ -154,6 +154,12 @@ async function runRestore(
   password: string,
 ): Promise<void> {
   session.status = "running";
+  session.progress = {
+    stage: "starting",
+    current: 0,
+    total: 1,
+    message: "バックアップを準備しています",
+  };
   const outputDir = await mkdtemp(join(tmpdir(), `vyline-ios-${session.id}-`));
   try {
     const result = await extractAndParseLineHistory(

--- a/Vyline/backend/src/service/lineService.ts
+++ b/Vyline/backend/src/service/lineService.ts
@@ -75,6 +75,7 @@ import {
   messageSyncAgeMs,
   upsertChats,
   upsertMessages,
+  compareMessagesNewestFirst,
   markMessageRevoked,
   restoreRevokedMessage,
   getMessageHistory,
@@ -3418,10 +3419,13 @@ export async function fetchMessages(
   const isSpecial = opts?.lite || opts?.delta;
 
   if (opts?.localOnly) {
-    return getStoredMessages(accountId, chatMid, limit, {
-      beforeMessageId: opts.beforeMessageId,
-      beforeDeliveredTime: opts.beforeDeliveredTime,
-    });
+    const localOptions = {
+      ...(opts.beforeMessageId ? { beforeMessageId: opts.beforeMessageId } : {}),
+      ...(opts.beforeDeliveredTime != null
+        ? { beforeDeliveredTime: opts.beforeDeliveredTime }
+        : {}),
+    };
+    return getStoredMessages(accountId, chatMid, limit, localOptions);
   }
 
   if (!opts?.force && !isPagination && !isSpecial) {
@@ -3723,7 +3727,7 @@ async function fetchMessagesInner(
     }
     byId.set(m.id, combined);
   }
-  const out = [...byId.values()].sort((a, b) => b.createdTime - a.createdTime).slice(0, limit);
+  const out = [...byId.values()].sort(compareMessagesNewestFirst).slice(0, limit);
 
   log.debug(
     {

--- a/Vyline/backend/src/service/lineService.ts
+++ b/Vyline/backend/src/service/lineService.ts
@@ -3418,7 +3418,10 @@ export async function fetchMessages(
   const isSpecial = opts?.lite || opts?.delta;
 
   if (opts?.localOnly) {
-    return getStoredMessages(accountId, chatMid, limit);
+    return getStoredMessages(accountId, chatMid, limit, {
+      beforeMessageId: opts.beforeMessageId,
+      beforeDeliveredTime: opts.beforeDeliveredTime,
+    });
   }
 
   if (!opts?.force && !isPagination && !isSpecial) {

--- a/Vyline/backend/src/storage/chatStore.iosRestore.test.ts
+++ b/Vyline/backend/src/storage/chatStore.iosRestore.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  compareMessagesNewestFirst,
   mergeChatDbRecords,
   type ChatDbRecords,
   type StoredChat,
@@ -32,6 +33,11 @@ function message(id: string, chatMid: string, text: string): StoredMessage {
 }
 
 describe("mergeChatDbRecords", () => {
+  test("uses message ID as a stable tie-breaker for equal timestamps", () => {
+    const sameTime = [message("10", "u-chat", "later"), message("9", "u-chat", "earlier")];
+    expect(sameTime.sort(compareMessagesNewestFirst).map((item) => item.id)).toEqual(["10", "9"]);
+  });
+
   test("adds missing iOS records without overwriting existing records", () => {
     const target: ChatDbRecords = {
       chats: { "u-chat": chat("u-chat", "Local name", 500) },
@@ -59,7 +65,7 @@ describe("mergeChatDbRecords", () => {
       skippedMessages: 1,
     });
     expect(target.chats["u-chat"]?.name).toBe("Local name");
-    expect(target.chats["u-chat"]?.lastMessageTime).toBe(700);
+    expect(target.chats["u-chat"]?.lastMessageTime).toBe(100);
     expect(target.messages["u-chat"]?.["1"]?.text).toBe("local");
     expect(target.messages["u-chat"]?.["2"]?.text).toBe("imported");
   });
@@ -83,5 +89,24 @@ describe("mergeChatDbRecords", () => {
       importedMessages: 0,
       skippedMessages: 1,
     });
+  });
+
+  test("keeps local fields while filling missing text from the backup on an ID conflict", () => {
+    const local = message("1", "u-chat", "");
+    local.text = null;
+    local.contentType = "NONE";
+    const imported = message("1", "u-chat", "restored text");
+    imported.contentType = "IMAGE";
+    imported.contentMetadata = { FILE_NAME: "photo.jpg" };
+    const target: ChatDbRecords = {
+      chats: { "u-chat": chat("u-chat", "Local") },
+      messages: { "u-chat": { "1": local } },
+    };
+
+    mergeChatDbRecords(target, { chats: {}, messages: { "u-chat": { "1": imported } } });
+
+    expect(target.messages["u-chat"]?.["1"]?.text).toBe("restored text");
+    expect(target.messages["u-chat"]?.["1"]?.contentType).toBe("IMAGE");
+    expect(target.messages["u-chat"]?.["1"]?.contentMetadata?.FILE_NAME).toBe("photo.jpg");
   });
 });

--- a/Vyline/backend/src/storage/chatStore.ts
+++ b/Vyline/backend/src/storage/chatStore.ts
@@ -26,8 +26,6 @@ const DATA_DIR = process.env.VYLINE_DATA_DIR ?? join(_dir, "..", "..", "data");
 const SAVE_DEBOUNCE_MS = Number(process.env.VYLINE_CHATDB_SAVE_MS ?? 400);
 const BOOTSTRAP_TOP_CHATS = Number(process.env.VYLINE_BOOTSTRAP_TOP_CHATS ?? 12);
 const BOOTSTRAP_MSG_LIMIT = Number(process.env.VYLINE_BOOTSTRAP_MSG_LIMIT ?? 40);
-/** チャットあたりの保持上限。無制限保存はメモリ・ディスク・全体書き込みを肥大させるため抑止 */
-const MAX_MESSAGES_PER_CHAT_DB = Number(process.env.VYLINE_CHATDB_MAX_MSGS_PER_CHAT ?? 500);
 
 export interface StoredChat {
   mid: string;
@@ -254,14 +252,6 @@ export async function upsertMessages(
     byChat[message.id] = next;
   }
   db.messages[chatMid] = byChat;
-  // 上限を超えたら古いものから落とす（全ファイル書き換えコストの抑止）
-  const ids = Object.keys(byChat);
-  if (ids.length > MAX_MESSAGES_PER_CHAT_DB) {
-    const drop = ids
-      .sort((a, b) => (byChat[a]?.createdTime ?? 0) - (byChat[b]?.createdTime ?? 0))
-      .slice(0, ids.length - MAX_MESSAGES_PER_CHAT_DB);
-    for (const id of drop) delete byChat[id];
-  }
   db.meta.messagesSyncedAt = db.meta.messagesSyncedAt ?? {};
   db.meta.messagesSyncedAt[chatMid] = new Date().toISOString();
   scheduleSave(accountId);
@@ -551,7 +541,6 @@ export async function importChatDb(
 export function mergeChatDbRecords(
   target: ChatDbRecords,
   incoming: ChatDbRecords,
-  opts?: { preserveHistory?: boolean },
 ): ChatDbMergeResult {
   let importedChats = 0;
   let skippedChats = 0;
@@ -593,15 +582,6 @@ export function mergeChatDbRecords(
       importedMessages++;
     }
 
-    const ids = Object.keys(targetMessages);
-    if (!opts?.preserveHistory && ids.length > MAX_MESSAGES_PER_CHAT_DB) {
-      const drop = ids
-        .sort(
-          (a, b) => (targetMessages[a]?.createdTime ?? 0) - (targetMessages[b]?.createdTime ?? 0),
-        )
-        .slice(0, ids.length - MAX_MESSAGES_PER_CHAT_DB);
-      for (const id of drop) delete targetMessages[id];
-    }
     target.messages[chatMid] = targetMessages;
   }
 
@@ -614,7 +594,7 @@ export async function mergeImportedChatDb(
   incoming: ChatDbRecords,
 ): Promise<ChatDbMergeResult> {
   const db = await getDb(accountId);
-  const result = mergeChatDbRecords(db, incoming, { preserveHistory: true });
+  const result = mergeChatDbRecords(db, incoming);
   if (result.importedChats > 0 || result.importedMessages > 0) scheduleSave(accountId);
   return result;
 }

--- a/Vyline/backend/src/storage/chatStore.ts
+++ b/Vyline/backend/src/storage/chatStore.ts
@@ -342,11 +342,32 @@ export async function getMessages(
   accountId: string,
   chatMid: string,
   limit: number,
+  opts?: { beforeMessageId?: string; beforeDeliveredTime?: number },
 ): Promise<StoredMessage[]> {
   const db = await getDb(accountId);
   const byChat = db.messages[chatMid];
   if (!byChat) return [];
+  const beforeTime = opts?.beforeDeliveredTime;
+  const beforeIdBigInt = opts?.beforeMessageId
+    ? (() => {
+        try {
+          return BigInt(opts.beforeMessageId);
+        } catch {
+          return null;
+        }
+      })()
+    : null;
   return Object.values(byChat)
+    .filter((message) => {
+      if (beforeTime == null) return true;
+      if (message.createdTime < beforeTime) return true;
+      if (message.createdTime > beforeTime || beforeIdBigInt == null) return false;
+      try {
+        return BigInt(message.id) < beforeIdBigInt;
+      } catch {
+        return false;
+      }
+    })
     .sort((a, b) => b.createdTime - a.createdTime)
     .slice(0, limit);
 }
@@ -435,8 +456,9 @@ export async function getStoredMessages(
   accountId: string,
   chatMid: string,
   limit: number,
+  opts?: { beforeMessageId?: string; beforeDeliveredTime?: number },
 ): Promise<Message[]> {
-  const stored = await getMessages(accountId, chatMid, limit);
+  const stored = await getMessages(accountId, chatMid, limit, opts);
   return stored.map(storedMessageToMessage);
 }
 

--- a/Vyline/backend/src/storage/chatStore.ts
+++ b/Vyline/backend/src/storage/chatStore.ts
@@ -92,6 +92,47 @@ export interface ChatDbMergeResult {
   skippedMessages: number;
 }
 
+type MessageCursor = Pick<StoredMessage, "id" | "createdTime">;
+
+function compareMessageIdsAscending(left: string, right: string): number {
+  if (left === right) return 0;
+  try {
+    return BigInt(left) < BigInt(right) ? -1 : 1;
+  } catch {
+    return left.localeCompare(right);
+  }
+}
+
+/** 全経路で共通に使う複合順序: 新しい時刻、同時刻なら大きいメッセージIDが先。 */
+export function compareMessagesNewestFirst(left: MessageCursor, right: MessageCursor): number {
+  const byTime = right.createdTime - left.createdTime;
+  return byTime || -compareMessageIdsAscending(left.id, right.id);
+}
+
+export function compareMessagesOldestFirst(left: MessageCursor, right: MessageCursor): number {
+  const byTime = left.createdTime - right.createdTime;
+  return byTime || compareMessageIdsAscending(left.id, right.id);
+}
+
+function previewForMessage(message: StoredMessage): string {
+  const text = message.text?.trim();
+  if (text) return text.slice(0, 120);
+  switch (message.contentType.toUpperCase()) {
+    case "IMAGE":
+      return "画像";
+    case "VIDEO":
+      return "動画";
+    case "AUDIO":
+      return "音声";
+    case "FILE":
+      return "ファイル";
+    case "STICKER":
+      return "スタンプ";
+    default:
+      return message.contentType || "メッセージ";
+  }
+}
+
 const memory = new Map<string, ChatDb>();
 const dirty = new Set<string>();
 const saveTimers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -368,7 +409,7 @@ export async function getMessages(
         return false;
       }
     })
-    .sort((a, b) => b.createdTime - a.createdTime)
+    .sort(compareMessagesNewestFirst)
     .slice(0, limit);
 }
 
@@ -555,6 +596,7 @@ export async function importChatDb(
   for (const [chatMid, iso] of Object.entries(data.meta?.messagesSyncedAt ?? {})) {
     db.meta.messagesSyncedAt[chatMid] = iso;
   }
+  rebuildChatDbRecords(db);
   scheduleSave(accountId);
   return { chats: chatCount, messages: messageCount };
 }
@@ -596,7 +638,27 @@ export function mergeChatDbRecords(
   for (const [chatMid, incomingMessages] of Object.entries(incoming.messages ?? {})) {
     const targetMessages = target.messages[chatMid] ?? {};
     for (const [id, incomingMessage] of Object.entries(incomingMessages)) {
-      if (targetMessages[id]) {
+      const existing = targetMessages[id];
+      if (existing) {
+        // 通常同期を優先しつつ、iOS側にしかない本文・メディア情報は欠損補完する。
+        targetMessages[id] = {
+          ...incomingMessage,
+          ...existing,
+          text: existing.text ?? incomingMessage.text,
+          contentType:
+            existing.contentType && existing.contentType !== "NONE"
+              ? existing.contentType
+              : incomingMessage.contentType,
+          contentMetadata: {
+            ...(incomingMessage.contentMetadata ?? {}),
+            ...(existing.contentMetadata ?? {}),
+          },
+          createdTime:
+            Number.isFinite(existing.createdTime) && existing.createdTime > 0
+              ? existing.createdTime
+              : incomingMessage.createdTime,
+          savedAt: existing.savedAt || incomingMessage.savedAt,
+        };
         skippedMessages++;
         continue;
       }
@@ -607,7 +669,39 @@ export function mergeChatDbRecords(
     target.messages[chatMid] = targetMessages;
   }
 
+  rebuildChatDbRecords(target);
   return { importedChats, skippedChats, importedMessages, skippedMessages };
+}
+
+/**
+ * iOS復元・通常同期で混在したレコードを、複合時刻順と実メッセージの最新値で正規化する。
+ * レコードは削除せず、同一IDは既存の正本を保持する。
+ */
+export function rebuildChatDbRecords(target: ChatDbRecords): { chats: number; messages: number } {
+  let messages = 0;
+  const allMids = new Set([...Object.keys(target.chats), ...Object.keys(target.messages)]);
+  for (const chatMid of allMids) {
+    const ordered = Object.values(target.messages[chatMid] ?? {}).sort(compareMessagesOldestFirst);
+    target.messages[chatMid] = Object.fromEntries(ordered.map((message) => [message.id, message]));
+    messages += ordered.length;
+    const latest = ordered.at(-1);
+    if (!latest) continue;
+    const existing = target.chats[chatMid];
+    target.chats[chatMid] = {
+      mid: chatMid,
+      name: existing?.name || chatMid,
+      kind: existing?.kind ?? "direct",
+      hasMessages: true,
+      lastMessageTime: latest.createdTime,
+      lastMessageId: latest.id,
+      lastMessagePreview: previewForMessage(latest),
+      ...(existing?.thumbnailUrl ? { thumbnailUrl: existing.thumbnailUrl } : {}),
+      ...(existing?.unreadCount != null ? { unreadCount: existing.unreadCount } : {}),
+      ...(existing?.isOfficial != null ? { isOfficial: existing.isOfficial } : {}),
+      updatedAt: existing?.updatedAt ?? latest.savedAt,
+    };
+  }
+  return { chats: Object.keys(target.chats).length, messages };
 }
 
 /** iOS / 外部履歴復元用の永続マージ。 */
@@ -619,6 +713,21 @@ export async function mergeImportedChatDb(
   const result = mergeChatDbRecords(db, incoming);
   if (result.importedChats > 0 || result.importedMessages > 0) scheduleSave(accountId);
   return result;
+}
+
+/** 現在のアカウントDBを退避してから、順序とチャット要約を再構築する。 */
+export async function rebuildAccountChatDb(
+  accountId: string,
+): Promise<{ chats: number; messages: number; backupFile: string }> {
+  const db = await getDb(accountId);
+  await flushDb(accountId);
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const backupFile = `chatdb.before-rebuild-${stamp}.json`;
+  await writeFile(accountFile(accountId, backupFile), JSON.stringify(db), "utf8");
+  const result = rebuildChatDbRecords(db);
+  scheduleSave(accountId);
+  await flushDb(accountId);
+  return { ...result, backupFile };
 }
 
 /** 復元完了時に、遅延保存を待たずにDBへ確実に書き出す。 */


### PR DESCRIPTION
## Summary
- rebuild mixed Vyline/iOS chat records into a deterministic timestamp + message-ID order, with an automatic pre-rebuild DB snapshot
- fill missing iOS text/media metadata without overwriting existing synced records
- remove frontend retention truncation and keep restored chats accessible without changing hidden-chat state
- load local history in stable pages and continue loading at the top until the actual beginning of the conversation
- show restore progress immediately and expose an accurate older-history loading state

## Validation
- un run lint passed
- desktop TypeScript check passed
- desktop production build passed
- un test Vyline/backend/src/storage/chatStore.iosRestore.test.ts passed
- live local API audit: 5,222/5,222 messages returned uniquely for うりちゃん, ordered through 2026-07-19

## Data safety
- rebuilding creates an account-local chatdb.before-rebuild-<timestamp>.json snapshot before writing
- hidden-chat settings are not changed