### PR TITLE
fix: preserve chat position and local read state

### DIFF
--- a/Vyline/apps/desktop/src/components/chat-area.tsx
+++ b/Vyline/apps/desktop/src/components/chat-area.tsx
@@ -99,6 +99,7 @@ function ChatAreaBase() {
   const toggleMute = useStore((s) => s.toggleMute);
   const memberProfile = useStore((s) => s.memberProfile);
   const highlightMessageId = useStore((s) => s.highlightMessageId);
+  const initialChatScrollMessageId = useStore((s) => s.initialChatScrollMessageId);
   const accountId = useStore((s) => s.accountId);
   const scrollToMessage = useStore((s) => s.scrollToMessage);
   const announcements = useStore((s) => s.announcements);
@@ -313,37 +314,21 @@ function ChatAreaBase() {
     return () => window.removeEventListener("vyline:older-messages-state", onOlderState);
   }, [activeChatId]);
 
-  const prevLen = useRef(chatMessages.length);
-  const prevChat = useRef(activeChatId);
-  const justSwitched = useRef(true);
+  const openedChatRef = useRef<string | null>(null);
 
-  // チャット切替時は必ず一番下へ（メッセージ描画後に再スクロール）
+  // 開いた瞬間だけ位置を決める。未読があればその先頭、なければ末尾に置き、
+  // 以後の受信・画像の高さ確定・ページ追加では利用者のスクロール位置を動かさない。
   useEffect(() => {
-    justSwitched.current = true;
-    prevLen.current = chatMessages.length;
-    prevChat.current = activeChatId;
-    const t1 = setTimeout(() => scrollToBottom("auto"), 0);
-    const t2 = setTimeout(() => scrollToBottom("auto"), 150);
-    const t3 = setTimeout(() => scrollToBottom("auto"), 400);
-    return () => {
-      clearTimeout(t1);
-      clearTimeout(t2);
-      clearTimeout(t3);
-    };
-  }, [activeChatId, scrollToBottom]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  // 同一チャットの新着: 切替直後 or 下部に居るときだけ自動スクロール
-  useEffect(() => {
-    const el = containerRef.current;
-    if (!el) return;
-    const grew = chatMessages.length > prevLen.current;
-    prevLen.current = chatMessages.length;
-    if (!grew) return;
-    const force = justSwitched.current;
-    justSwitched.current = false;
-    const nearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 160;
-    if (force || nearBottom) scrollToBottom("auto");
-  }, [chatMessages.length, scrollToBottom, containerRef]);
+    if (!activeChatId || openedChatRef.current === activeChatId) return;
+    const key = initialChatScrollMessageId ? `msg-${initialChatScrollMessageId}` : null;
+    if (key && !rows.some((row) => row.key === key)) return;
+    openedChatRef.current = activeChatId;
+    const frame = requestAnimationFrame(() => {
+      if (key) scrollToKey(key, { behavior: "auto", center: true });
+      else scrollToBottom("auto");
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [activeChatId, initialChatScrollMessageId, rows, scrollToBottom, scrollToKey]);
 
   // 返信ジャンプ（store.scrollToMessage → highlightMessageId）
   useEffect(() => {

--- a/Vyline/apps/desktop/src/components/sidebar.tsx
+++ b/Vyline/apps/desktop/src/components/sidebar.tsx
@@ -130,6 +130,7 @@ function SidebarBase() {
   const toggleHide = useStore((s) => s.toggleHide);
   const toggleMute = useStore((s) => s.toggleMute);
   const markChatRead = useStore((s) => s.markChatRead);
+  const markAllChatsRead = useStore((s) => s.markAllChatsRead);
   const toggleChatReadDisabled = useStore((s) => s.toggleChatReadDisabled);
   const readDisabledMids = useStore((s) => s.readDisabledMids);
 
@@ -471,6 +472,18 @@ function SidebarBase() {
                     {sort === s && <IconCheck size={15} style={{ color: "var(--vy-accent)" }} />}
                   </button>
                 ))}
+                <div className="my-1 border-t border-[var(--vy-border)]" />
+                <button
+                  type="button"
+                  onClick={() => {
+                    void markAllChatsRead();
+                    setSortOpen(false);
+                  }}
+                  className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors hover:bg-[color-mix(in_oklab,var(--vy-text)_10%,transparent)]"
+                >
+                  <IconCheck size={15} />
+                  すべて既読にする
+                </button>
               </div>
             </>
           )}

--- a/Vyline/apps/desktop/src/lib/store.ts
+++ b/Vyline/apps/desktop/src/lib/store.ts
@@ -307,6 +307,8 @@ type State = {
   draftMentions: Record<string, MentionDraft[]>;
   replyToId: string | null;
   highlightMessageId: string | null;
+  /** チャットを開くときの初期位置。未読の先頭、なければ末尾。 */
+  initialChatScrollMessageId: string | null;
   showUpdateNote: boolean;
   seenUpdateVersion: string;
   profileDrawerOpen: boolean;
@@ -404,6 +406,7 @@ type State = {
   retryMessage: (id: string) => Promise<void>;
   markRead: (id: string) => Promise<void>;
   markChatRead: (id: string) => Promise<void>;
+  markAllChatsRead: () => Promise<void>;
   setDraft: (chatId: string, text: string) => void;
   setDraftSticons: (
     chatId: string,
@@ -495,6 +498,7 @@ export const useStore = create<State>()(
       draftMentions: {},
       replyToId: null,
       highlightMessageId: null,
+      initialChatScrollMessageId: null,
       showUpdateNote: true,
       seenUpdateVersion: "",
       profileDrawerOpen: false,
@@ -535,6 +539,7 @@ export const useStore = create<State>()(
             chats: [],
             messages: [],
             activeChatId: null,
+            initialChatScrollMessageId: null,
             memberProfile: null,
             readWatermarks: {},
             announcements: {},
@@ -557,6 +562,7 @@ export const useStore = create<State>()(
           draftMentions: {},
           replyToId: null,
           highlightMessageId: null,
+          initialChatScrollMessageId: null,
           customOrder: [],
           readDisabledMids: {},
           blockedMids: [],
@@ -593,9 +599,23 @@ export const useStore = create<State>()(
 
       _activateChat: (id, opts) => {
         const opts2 = opts ?? {};
+        const firstUnread = get()
+          .messages.filter((m) => m.chatId === id && m.authorId !== "me" && !m.read)
+          .sort((a, b) => {
+            const byTime = a.createdAt - b.createdAt;
+            if (byTime) return byTime;
+            try {
+              const left = BigInt(a.id);
+              const right = BigInt(b.id);
+              return left === right ? 0 : left < right ? -1 : 1;
+            } catch {
+              return a.id.localeCompare(b.id);
+            }
+          })[0];
         set((st) => ({
           screen: "chat",
           activeChatId: id,
+          initialChatScrollMessageId: firstUnread?.id ?? null,
           profileDrawerOpen: false,
           chats: st.chats.map((c) => (c.id === id ? { ...c, unread: 0 } : c)),
         }));
@@ -621,7 +641,8 @@ export const useStore = create<State>()(
         }
       },
 
-      closeChat: () => set({ activeChatId: null, profileDrawerOpen: false }),
+      closeChat: () =>
+        set({ activeChatId: null, initialChatScrollMessageId: null, profileDrawerOpen: false }),
 
       loadAnnouncements: async (chatId) => {
         const { accountId } = get();
@@ -1506,45 +1527,65 @@ export const useStore = create<State>()(
         }
       },
 
-      markRead: async (id) => {
-        const { accountId, activeChatId } = get();
-        if (!accountId || !activeChatId) return;
-        await api.line.markAsRead(accountId, activeChatId, id).catch(() => {});
-        set((st) => ({
-          messages: st.messages.map((m) =>
-            m.id === id ? { ...m, read: true, status: "read" } : m,
-          ),
-        }));
+      markRead: async (_id) => {
+        const { activeChatId } = get();
+        if (!activeChatId) return;
+        // 古い個別ID（または自分の送信ID）を送らず、そのチャットの安定した最終地点を使う。
+        await get().markChatRead(activeChatId);
       },
 
       markChatRead: async (id) => {
         const { accountId, messages, settings, readDisabledMids } = get();
+        const received = messages
+          .filter((m) => m.chatId === id && m.authorId !== "me" && !m.id.startsWith("pending_"))
+          .sort((a, b) => {
+            const byTime = b.createdAt - a.createdAt;
+            if (byTime) return byTime;
+            try {
+              const left = BigInt(a.id);
+              const right = BigInt(b.id);
+              return left === right ? 0 : right > left ? 1 : -1;
+            } catch {
+              return b.id.localeCompare(a.id);
+            }
+          });
+        const last = received[0];
         set((st) => ({
           chats: st.chats.map((c) => (c.id === id ? { ...c, unread: 0 } : c)),
           messages: st.messages.map((m) => {
             // 自分の送信メッセージの read は相手側の既読状態。
             // チャットを開いただけで自分の最新送信まで既読にしてはいけない。
-            if (m.chatId !== id || m.authorId === "me") return m;
+            if (m.chatId !== id || m.authorId === "me" || !last) return m;
+            try {
+              if (BigInt(m.id) > BigInt(last.id)) return m;
+            } catch {
+              return m;
+            }
             return { ...m, read: true, status: "read" };
           }),
         }));
         // 全体無効（設定）または個別無効（右クリック）なら送信しない
         if (!accountId || !settings.readReceipts || readDisabledMids[id]) return;
-        const last = [...messages]
-          .reverse()
-          .find(
-            (m) => m.chatId === id && m.authorId !== "me" && m.id && !m.id.startsWith("pending_"),
-          );
-        if (!last?.id) return;
+        // ローカルに未取得の履歴だけでもバックエンドがDB/サーバの最終地点を解決する。
+        const lastId = last?.id;
         // 同じ最終メッセージへの既読は再送しない
         const receiptKey = accountChatKey(accountId, id);
         const prev = readReceiptSent.get(receiptKey);
-        if (prev === last.id) return;
-        readReceiptSent.set(receiptKey, last.id);
+        if (lastId && prev === lastId) return;
+        if (lastId) readReceiptSent.set(receiptKey, lastId);
         try {
-          await api.line.markAsRead(accountId, id, last.id);
+          await api.line.markAsRead(accountId, id, lastId);
         } catch {
-          readReceiptSent.delete(receiptKey);
+          if (lastId) readReceiptSent.delete(receiptKey);
+        }
+      },
+
+      markAllChatsRead: async () => {
+        const unreadChatIds = get()
+          .chats.filter((chat) => chat.unread > 0)
+          .map((chat) => chat.id);
+        for (const chatId of unreadChatIds) {
+          await get().markChatRead(chatId);
         }
       },
 

--- a/Vyline/backend/src/service/lineService.ts
+++ b/Vyline/backend/src/service/lineService.ts
@@ -75,6 +75,7 @@ import {
   messageSyncAgeMs,
   upsertChats,
   upsertMessages,
+  markStoredMessagesReadThrough,
   compareMessagesNewestFirst,
   markMessageRevoked,
   restoreRevokedMessage,
@@ -2063,6 +2064,7 @@ export async function markAsRead(
       lastMessageId: messageId,
       sessionId: 0,
     });
+    await markStoredMessagesReadThrough(accountId, chatMid, messageId);
     log.info({ accountId, chatMid, lastMessageId: messageId }, "chat marked as read");
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);

--- a/Vyline/backend/src/storage/chatStore.readState.test.ts
+++ b/Vyline/backend/src/storage/chatStore.readState.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mergeStoredReadState } from "./chatStore.js";
+import { applyLocalReadWatermark, mergeStoredReadState, type StoredMessage } from "./chatStore.js";
 
 describe("mergeStoredReadState", () => {
   test("does not turn an unknown group message into read", () => {
@@ -14,5 +14,64 @@ describe("mergeStoredReadState", () => {
 
   test("never rolls a persisted seen flag back to unread", () => {
     expect(mergeStoredReadState({ seen: true }, { seen: false })).toEqual({ seen: true });
+  });
+});
+
+describe("applyLocalReadWatermark", () => {
+  test("marks every received message through the confirmed read point without changing own receipts", () => {
+    const messages: Record<string, StoredMessage> = {
+      "100": {
+        id: "100",
+        chatMid: "u-chat",
+        from: "u-peer",
+        to: "u-me",
+        text: "old",
+        contentType: "NONE",
+        createdTime: 1,
+        isMyMessage: false,
+        savedAt: "2026-08-24T00:00:00.000Z",
+      },
+      "101": {
+        id: "101",
+        chatMid: "u-chat",
+        from: "u-me",
+        to: "u-peer",
+        text: "mine",
+        contentType: "NONE",
+        createdTime: 2,
+        isMyMessage: true,
+        seen: false,
+        savedAt: "2026-08-24T00:00:00.000Z",
+      },
+      "102": {
+        id: "102",
+        chatMid: "u-chat",
+        from: "u-peer",
+        to: "u-me",
+        text: "read",
+        contentType: "NONE",
+        createdTime: 3,
+        isMyMessage: false,
+        savedAt: "2026-08-24T00:00:00.000Z",
+      },
+      "103": {
+        id: "103",
+        chatMid: "u-chat",
+        from: "u-peer",
+        to: "u-me",
+        text: "unread",
+        contentType: "NONE",
+        createdTime: 4,
+        isMyMessage: false,
+        savedAt: "2026-08-24T00:00:00.000Z",
+      },
+    };
+
+    applyLocalReadWatermark(messages, "102");
+
+    expect(messages["100"]?.seen).toBe(true);
+    expect(messages["101"]?.seen).toBe(false);
+    expect(messages["102"]?.seen).toBe(true);
+    expect(messages["103"]?.seen).toBeUndefined();
   });
 });

--- a/Vyline/backend/src/storage/chatStore.ts
+++ b/Vyline/backend/src/storage/chatStore.ts
@@ -72,6 +72,8 @@ interface ChatDbMeta {
   chatsSyncedAt?: string;
   /** chatMid → ISO */
   messagesSyncedAt?: Record<string, string>;
+  /** 自分が受信メッセージを既読にした最終位置（復元DBにも適用する）。 */
+  localReadUpTo?: Record<string, { messageId: string; at: string }>;
 }
 
 interface ChatDb {
@@ -293,8 +295,57 @@ export async function upsertMessages(
     byChat[message.id] = next;
   }
   db.messages[chatMid] = byChat;
+  applyLocalReadWatermark(byChat, db.meta.localReadUpTo?.[chatMid]?.messageId);
   db.meta.messagesSyncedAt = db.meta.messagesSyncedAt ?? {};
   db.meta.messagesSyncedAt[chatMid] = new Date().toISOString();
+  scheduleSave(accountId);
+}
+
+/**
+ * 自分が送った既読位置を、受信メッセージだけへ単調に反映する。
+ * 相手が読んだ自分のメッセージの既読状態とは別の情報である。
+ */
+export function applyLocalReadWatermark(
+  messages: Record<string, StoredMessage>,
+  upToMessageId: string | undefined,
+): void {
+  if (!upToMessageId) return;
+  let upTo: bigint;
+  try {
+    upTo = BigInt(upToMessageId);
+  } catch {
+    return;
+  }
+  for (const message of Object.values(messages)) {
+    if (message.isMyMessage) continue;
+    try {
+      if (BigInt(message.id) <= upTo) message.seen = true;
+    } catch {
+      /* non-numeric local IDs cannot be part of a server read range */
+    }
+  }
+}
+
+/** 既読リクエスト成功後、同じ地点以前の受信メッセージをDBへ単調に保存する。 */
+export async function markStoredMessagesReadThrough(
+  accountId: string,
+  chatMid: string,
+  messageId: string,
+): Promise<void> {
+  const db = await getDb(accountId);
+  const current = db.meta.localReadUpTo?.[chatMid]?.messageId;
+  try {
+    if (current && BigInt(current) > BigInt(messageId)) return;
+  } catch {
+    /* replace malformed legacy cursor */
+  }
+  db.meta.localReadUpTo = {
+    ...db.meta.localReadUpTo,
+    [chatMid]: { messageId, at: new Date().toISOString() },
+  };
+  applyLocalReadWatermark(db.messages[chatMid] ?? {}, messageId);
+  const chat = db.chats[chatMid];
+  if (chat) chat.unreadCount = 0;
   scheduleSave(accountId);
 }
 
@@ -590,6 +641,9 @@ export async function importChatDb(
     }
     db.messages[chatMid] = target;
   }
+  for (const [chatMid, messages] of Object.entries(db.messages)) {
+    applyLocalReadWatermark(messages, db.meta.localReadUpTo?.[chatMid]?.messageId);
+  }
   if (data.meta?.boxOrder) db.meta.boxOrder = data.meta.boxOrder;
   if (data.meta?.chatsSyncedAt) db.meta.chatsSyncedAt = data.meta.chatsSyncedAt;
   db.meta.messagesSyncedAt = db.meta.messagesSyncedAt ?? {};
@@ -711,6 +765,9 @@ export async function mergeImportedChatDb(
 ): Promise<ChatDbMergeResult> {
   const db = await getDb(accountId);
   const result = mergeChatDbRecords(db, incoming);
+  for (const [chatMid, messages] of Object.entries(db.messages)) {
+    applyLocalReadWatermark(messages, db.meta.localReadUpTo?.[chatMid]?.messageId);
+  }
   if (result.importedChats > 0 || result.importedMessages > 0) scheduleSave(accountId);
   return result;
 }


### PR DESCRIPTION
## Summary
- open chats at the first unread received message, or at the latest message when there is no unread state
- stop automatic jumps while messages, media, or older history arrive
- persist the successful local read watermark in chatdb and apply it to restored/imported history
- use a stable received-message cursor for read requests and add bulk mark-as-read

## Validation
- un test Vyline/backend/src/storage/chatStore.readState.test.ts
- un run lint
- un run --cwd Vyline/apps/desktop typecheck
- un run --cwd Vyline/apps/desktop build

Stacked on the restore-history PR.