### PR TITLE
feat: add plugin settings and runtime recovery

### DIFF
--- a/Vyline/apps/desktop/src/api/client.ts
+++ b/Vyline/apps/desktop/src/api/client.ts
@@ -710,6 +710,26 @@ export const api = {
         { enable },
       ),
 
+    plugins: (accountId: string) =>
+      request<{
+        plugins: Array<{
+          id: string;
+          name: string;
+          version: string;
+          description?: string;
+          permissions?: string[];
+          loadable: boolean;
+          enabled: boolean;
+          active: boolean;
+        }>;
+      }>("GET", `/line/${accountId}/plugins`),
+
+    setPluginEnabled: (accountId: string, pluginId: string, enabled: boolean) =>
+      request<{ ok: boolean; enabled?: boolean; error?: string }>(
+        "POST",
+        `/line/${accountId}/plugins/${encodeURIComponent(pluginId)}/${enabled ? "enable" : "disable"}`,
+      ),
+
     /** 既読にする */
     markAsRead: (accountId: string, chatMid: string, lastMessageId?: string) =>
       request<{ ok: boolean }>("POST", `/line/${accountId}/read`, {

--- a/Vyline/apps/desktop/src/components/settings-sections.tsx
+++ b/Vyline/apps/desktop/src/components/settings-sections.tsx
@@ -62,6 +62,7 @@ type Section =
   | "advanced"
   | "subdevices"
   | "storage"
+  | "plugins"
   | "info"
   | "beta";
 
@@ -75,6 +76,7 @@ const NAV: { key: Section; label: string; icon: React.ReactNode }[] = [
   { key: "advanced", label: "詳細・復元", icon: <IconChevron size={18} /> },
   { key: "subdevices", label: "サブデバイス", icon: <IconSettings size={18} /> },
   { key: "storage", label: "ストレージ", icon: <IconHardDrive size={18} /> },
+  { key: "plugins", label: "プラグイン", icon: <IconSpark size={18} /> },
   { key: "info", label: "情報", icon: <IconSpark size={18} /> },
   { key: "beta", label: "ベータ機能", icon: <IconSpark size={18} /> },
 ];
@@ -539,6 +541,8 @@ export function SettingsSections() {
 
               {section === "storage" && <StorageSection />}
 
+              {section === "plugins" && <PluginsSection />}
+
               {section === "info" && <InfoSection />}
 
               {section === "beta" && (
@@ -701,6 +705,108 @@ function Section({
       {desc && <p className="mt-1 mb-5 text-sm text-[var(--vy-text-dim)]">{desc}</p>}
       {children}
     </div>
+  );
+}
+
+function PluginsSection() {
+  const accountId = useStore((s) => s.accountId);
+  const [plugins, setPlugins] = useState<
+    Array<{
+      id: string;
+      name: string;
+      version: string;
+      description?: string;
+      permissions?: string[];
+      loadable: boolean;
+      enabled: boolean;
+      active: boolean;
+    }>
+  >([]);
+  const [loading, setLoading] = useState(true);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const load = async () => {
+    if (!accountId) {
+      setPlugins([]);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    try {
+      const result = await api.line.plugins(accountId);
+      setPlugins(result.plugins ?? []);
+    } catch (err) {
+      setMessage(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void load();
+  }, [accountId]);
+
+  const toggle = async (plugin: (typeof plugins)[number]) => {
+    if (!accountId || busyId) return;
+    setBusyId(plugin.id);
+    setMessage(null);
+    try {
+      const result = await api.line.setPluginEnabled(accountId, plugin.id, !plugin.enabled);
+      if (!result.ok) throw new Error(result.error ?? "プラグインの切替に失敗しました");
+      setPlugins((current) =>
+        current.map((item) =>
+          item.id === plugin.id ? { ...item, enabled: !plugin.enabled } : item,
+        ),
+      );
+    } catch (err) {
+      setMessage(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  return (
+    <Section title="プラグイン" desc="この端末に保存した信頼できるローカルプラグインを管理します">
+      <p className="mb-4 rounded-xl border border-[var(--vy-border)] bg-[var(--vy-surface-2)] px-3 py-2 text-xs leading-relaxed text-[var(--vy-text-dim)]">
+        プラグインは Vyline
+        の権限でローカルコードを実行します。内容を確認したものだけを有効にしてください。
+      </p>
+      <Card>
+        {loading ? (
+          <p className="py-4 text-sm text-[var(--vy-text-dim)]">読み込み中…</p>
+        ) : plugins.length === 0 ? (
+          <p className="py-4 text-sm text-[var(--vy-text-dim)]">
+            プラグインは見つかりませんでした。backend/data/plugins に manifest.json
+            を含むフォルダを置くと表示されます。
+          </p>
+        ) : (
+          plugins.map((plugin) => (
+            <Row
+              key={plugin.id}
+              title={`${plugin.name} v${plugin.version}`}
+              desc={`${plugin.description ?? plugin.id}${plugin.permissions?.length ? ` · ${plugin.permissions.join(", ")}` : ""}${plugin.loadable ? (plugin.enabled && !plugin.active ? " · 起動待ち/失敗（ログを確認）" : "") : " · 実行ファイルがありません"}`}
+            >
+              <Toggle
+                checked={plugin.enabled}
+                onChange={() => void toggle(plugin)}
+                disabled={!accountId || !plugin.loadable || busyId === plugin.id}
+                label={`${plugin.name}を有効にする`}
+              />
+            </Row>
+          ))
+        )}
+      </Card>
+      {message && <p className="mt-3 text-xs text-[var(--vy-danger)]">{message}</p>}
+      <button
+        type="button"
+        onClick={() => void load()}
+        disabled={loading}
+        className="mt-4 rounded-lg border border-[var(--vy-border)] px-3 py-2 text-xs font-medium transition-colors hover:bg-[var(--vy-surface-2)] disabled:opacity-50"
+      >
+        再読み込み
+      </button>
+    </Section>
   );
 }
 

--- a/Vyline/backend/src/api/line.ts
+++ b/Vyline/backend/src/api/line.ts
@@ -29,6 +29,7 @@ import { rebuildAccountChatDb } from "../storage/chatStore.js";
 import { getProxyConfig, setProxyConfig } from "../proxyConfig.js";
 import { getFeatureLocks, unbanCreateGroup } from "../storage/featureLocks.js";
 import { getPluginStates, listPlugins, setPluginState } from "../line/pluginManager.js";
+import { isPluginActive } from "../line/pluginRuntime.js";
 import {
   createNote,
   deleteNote,
@@ -199,13 +200,16 @@ lineRouter.post("/:accountId/notes/:postId/share", async (c) => {
     return handleError(err, c);
   }
 });
-// ─── plugins（基盤: マニフェスト一覧と有効/無効の永続化。コード実行は未対応） ───
+// ─── plugins（ローカルの信頼済みプラグインのみ実行） ───
 lineRouter.get("/:accountId/plugins", async (c) => {
   const accountId = c.req.param("accountId");
   const states = getPluginStates(accountId);
   return c.json({
-    plugins: listPlugins().map((p) => ({ ...p, enabled: states[p.id] === true })),
-    runtimePending: true,
+    plugins: listPlugins().map((p) => ({
+      ...p,
+      enabled: states[p.id] === true,
+      active: isPluginActive(accountId, p.id),
+    })),
   });
 });
 

--- a/Vyline/backend/src/line/clientManager.ts
+++ b/Vyline/backend/src/line/clientManager.ts
@@ -24,6 +24,7 @@ import {
 } from "../storage/tokenStore.js";
 import { getVylineProfile } from "../vyline/profileBridge.js";
 import { warmLineCache, detachFetchOps } from "../service/lineService.js";
+import { restoreEnabledPlugins } from "./pluginManager.js";
 
 const log = childLogger("clientManager");
 
@@ -45,6 +46,12 @@ interface ManagedClient {
 }
 
 const clients = new Map<string, ManagedClient>();
+
+function restorePluginsForSession(accountId: string): void {
+  void restoreEnabledPlugins(accountId).catch((err) =>
+    log.warn({ accountId, err }, "enabled plugins could not be restored"),
+  );
+}
 
 /** アカウントごとの fetchOps カーソル（revision ベース） */
 const opsRevision = new Map<
@@ -438,6 +445,7 @@ export async function loginWithEmail(
     pincode: null,
     loggedInAt: Date.now(),
   });
+  restorePluginsForSession(accountId);
   log.info({ accountId }, "email login success");
   return client;
 }
@@ -502,6 +510,7 @@ export async function loginWithQRCode(
     managed.pincode = null;
     managed.loggedInAt = Date.now();
     watchAuthToken(client, accountId);
+    restorePluginsForSession(accountId);
     void warmLineCache(accountId).catch(() => undefined);
     log.info({ accountId }, "QR login success");
     return client;
@@ -539,6 +548,7 @@ export async function loginWithToken(accountId: string): Promise<VylineClient> {
     pincode: null,
     loggedInAt: Date.now(),
   });
+  restorePluginsForSession(accountId);
   log.info({ accountId }, "token login success");
   return client;
 }
@@ -570,6 +580,7 @@ export async function loginWithAuthToken(
     pincode: null,
     loggedInAt: Date.now(),
   });
+  restorePluginsForSession(accountId);
   log.info({ accountId }, "authToken login success");
   return client;
 }

--- a/Vyline/backend/src/line/pluginManager.ts
+++ b/Vyline/backend/src/line/pluginManager.ts
@@ -22,6 +22,8 @@ export interface PluginEntry extends PluginManifest {
   dir: string;
   /** エントリファイルが存在し実行可能か */
   loadable: boolean;
+  /** manifest.json の実行エントリ（未指定時は index.ts / index.js）。 */
+  main?: string;
 }
 
 type PluginStates = Record<string, Record<string, boolean>>;
@@ -63,6 +65,7 @@ export function listPlugins(): PluginEntry[] {
         permissions: Array.isArray(raw.permissions) ? raw.permissions : [],
         dir: entry.name,
         loadable: resolvePluginEntry(entry.name, raw.main) != null,
+        ...(raw.main ? { main: raw.main } : {}),
       });
     } catch (err) {
       log.warn({ plugin: entry.name, err }, "invalid plugin manifest");
@@ -93,7 +96,14 @@ export async function setPluginState(
 
   if (enabled) {
     if (!entry.loadable) throw new Error("plugin has no index.ts / index.js entry");
-    const ok = await activatePlugin(accountId, pluginId, entry.dir, entry.permissions ?? []);
+    const ok = await activatePlugin(
+      accountId,
+      pluginId,
+      entry.dir,
+      entry.permissions ?? [],
+      undefined,
+      entry.main,
+    );
     if (!ok) throw new Error("plugin activation failed (see backend logs)");
   } else {
     await deactivatePlugin(accountId, pluginId);
@@ -103,4 +113,17 @@ export async function setPluginState(
   states[accountId] = states[accountId] ?? {};
   states[accountId]![pluginId] = enabled;
   saveStates(states);
+}
+
+/** バックエンド再起動後に、そのアカウントで有効化済みのローカルプラグインを戻す。 */
+export async function restoreEnabledPlugins(accountId: string): Promise<void> {
+  const enabled = getPluginStates(accountId);
+  for (const plugin of listPlugins()) {
+    if (!enabled[plugin.id]) continue;
+    try {
+      await setPluginState(accountId, plugin.id, true);
+    } catch (err) {
+      log.warn({ accountId, pluginId: plugin.id, err }, "saved plugin was not restored");
+    }
+  }
 }

--- a/Vyline/backend/src/line/pluginRuntime.ts
+++ b/Vyline/backend/src/line/pluginRuntime.ts
@@ -32,6 +32,8 @@ interface ActivePlugin {
   pluginId: string;
   permissions: Set<string>;
   messageHandlers: Set<(m: PluginMessageSnapshot) => void>;
+  plugin: VylinePlugin;
+  context: PluginContext;
 }
 
 const active = new Map<string, ActivePlugin>();
@@ -99,6 +101,7 @@ export async function activatePlugin(
   pluginDirName: string,
   permissions: string[],
   loaded?: VylinePlugin,
+  manifestMain?: string,
 ): Promise<boolean> {
   const k = key(accountId, pluginId);
   if (active.has(k)) return true;
@@ -106,11 +109,8 @@ export async function activatePlugin(
   let plugin: VylinePlugin | undefined = loaded;
   try {
     if (!plugin) {
-      // resolvePluginEntry と同じ候補で動的 import（Bun は .ts を直接実行できる）
-      const candidates = ["index.ts", "index.js"].map((f) => join(PLUGIN_DIR, pluginDirName, f));
-      let entry: string | null = null;
-      for (const c of candidates) if (existsSync(c)) entry = c;
-      if (!entry) throw new Error("no entry file (index.ts / index.js)");
+      const entry = resolvePluginEntry(pluginDirName, manifestMain);
+      if (!entry) throw new Error("no loadable entry file");
       const mod = (await import(entry)) as { default?: VylinePlugin };
       plugin = mod.default;
     }
@@ -163,7 +163,14 @@ export async function activatePlugin(
         throw err;
       });
 
-    active.set(k, { accountId, pluginId, permissions: perms, messageHandlers: handlers });
+    active.set(k, {
+      accountId,
+      pluginId,
+      permissions: perms,
+      messageHandlers: handlers,
+      plugin,
+      context: ctx,
+    });
     logger.info(`activated (${[...perms].join(",") || "no permissions"})`);
     return true;
   } catch (err) {
@@ -182,11 +189,9 @@ export async function deactivatePlugin(accountId: string, pluginId: string): Pro
   if (!entry) return;
   active.delete(k);
   try {
-    // deactivate 用に最小コンテキストを再構築（logger だけ必要）
-    const logger = await makeLogger(pluginId);
-    logger.info("deactivated");
-  } catch {
-    /* noop */
+    await entry.plugin.deactivate?.(entry.context);
+  } catch (err) {
+    log.warn({ accountId, pluginId, err }, "plugin deactivation failed (isolated)");
   }
 }
 


### PR DESCRIPTION
## Summary
- add a Plugin tab in Settings that scans local plugins and enables/disables them
- run enabled plugins after session restoration, support manifest main entries, and call deactivate with the original context
- expose the actual runtime state and clearly label plugins as trusted local code

## Validation
- activated and deactivated the existing ackend/data/plugins/example-plugin runtime successfully
- un run lint
- un run --cwd Vyline/apps/desktop typecheck
- un run --cwd Vyline/apps/desktop build

Stacked on #101.