### PR TITLE
test: add regression coverage for CDN body size limits

### DIFF
--- a/Vyline/backend/src/storage/cdnAssetCache.test.ts
+++ b/Vyline/backend/src/storage/cdnAssetCache.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "bun:test";
+
+import { getCachedLineCdn } from "./cdnAssetCache.js";
+
+const MAX_CDN_RESPONSE_BYTES = 10 * 1024 * 1024;
+
+test("rejects a CDN response whose declared size exceeds the limit", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    new Response("small body", {
+      headers: { "content-length": String(MAX_CDN_RESPONSE_BYTES + 1) },
+    })) as unknown as typeof fetch;
+
+  try {
+    await expect(
+      getCachedLineCdn("https://static.line-scdn.net/tests/declared-too-large.png"),
+    ).rejects.toThrow("cdn response too large");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("rejects a CDN response that exceeds the limit while streaming", async () => {
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new Uint8Array(MAX_CDN_RESPONSE_BYTES));
+      controller.enqueue(new Uint8Array(1));
+      controller.close();
+    },
+  });
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () => new Response(body)) as unknown as typeof fetch;
+
+  try {
+    await expect(
+      getCachedLineCdn("https://static.line-scdn.net/tests/streamed-too-large.png"),
+    ).rejects.toThrow("cdn response exceeded");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## Summary\n\n- Add regression coverage for the 10MB CDN response limit introduced by #4\n- Cover both oversized Content-Length and oversized streamed bodies\n- Preserve the original contribution with a Co-authored-by trailer for @yuz-mc\n\n## Validation\n\n- un test with a no-preload test config: 2 pass\n- unx biome check Vyline/backend/src/storage/cdnAssetCache.test.ts: pass\n- Repository pre-push typecheck could not run because the Windows job system rejected Bun child-process assignment (AssignProcessToJobObject)\n\nRelated: #4