### PR TITLE
fix: repair read receipt APIs and speed up unread sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [main, master]
   push:

--- a/Vyline/apps/desktop/src/api/client.ts
+++ b/Vyline/apps/desktop/src/api/client.ts
@@ -717,6 +717,19 @@ export const api = {
         lastMessageId,
       }),
 
+    markAllAsRead: (accountId: string, chatMids?: string[]) =>
+      request<{ ok: boolean; count?: number }>("POST", `/line/${accountId}/read-all`, {
+        chatMids,
+      }),
+
+    markReadBatch: (
+      accountId: string,
+      targets: Array<{ chatMid: string; lastMessageId: string }>,
+    ) =>
+      request<{ ok: boolean; count?: number }>("POST", `/line/${accountId}/read-batch`, {
+        targets,
+      }),
+
     /** 自分の送信メッセージの既読状態（軽量） */
     readReceipts: (
       accountId: string,

--- a/Vyline/apps/desktop/src/lib/store.ts
+++ b/Vyline/apps/desktop/src/lib/store.ts
@@ -1724,6 +1724,9 @@ export const useStore = create<State>()(
         if (lastId) readReceiptSent.set(receiptKey, lastId);
         try {
           await api.line.markAsRead(accountId, id, lastId);
+          void get()
+            .refreshChatsSilently()
+            .catch(() => undefined);
         } catch {
           if (lastId) readReceiptSent.delete(receiptKey);
           if (localKey) recentlyReadAt.delete(localKey);
@@ -1761,6 +1764,9 @@ export const useStore = create<State>()(
               : message,
           ),
         }));
+        void get()
+          .refreshChatsSilently()
+          .catch(() => undefined);
       },
 
       setDraft: (chatId, text) => set((st) => ({ drafts: { ...st.drafts, [chatId]: text } })),

--- a/Vyline/apps/desktop/src/lib/store.ts
+++ b/Vyline/apps/desktop/src/lib/store.ts
@@ -75,6 +75,9 @@ const backfillInflight = new Map<string, Promise<void>>();
 const contactFetched = new Set<string>();
 /** このセッションでユーザーが明示的に開いた chatId（自動既読ガード） */
 const sessionOpenedChats = new Set<string>();
+/** 最近既読にした chat の時刻（サーバ反映前の未読上書き抑止） */
+const recentlyReadAt = new Map<string, number>();
+const RECENTLY_READ_WINDOW_MS = 60_000;
 
 const accountChatKey = (accountId: string, chatId: string) => `${accountId}:${chatId}`;
 
@@ -402,7 +405,7 @@ type State = {
   toggleShowOriginal: (id: string) => void;
   retryMessage: (id: string) => Promise<void>;
   markRead: (id: string) => Promise<void>;
-  markChatRead: (id: string) => Promise<void>;
+  markChatRead: (id: string, lastMessageId?: string) => Promise<void>;
   markAllChatsRead: () => Promise<void>;
   setDraft: (chatId: string, text: string) => void;
   setDraftSticons: (
@@ -1669,14 +1672,13 @@ export const useStore = create<State>()(
         }
       },
 
-      markRead: async (_id) => {
+      markRead: async (messageId) => {
         const { activeChatId } = get();
         if (!activeChatId) return;
-        // 古い個別ID（または自分の送信ID）を送らず、そのチャットの安定した最終地点を使う。
-        await get().markChatRead(activeChatId);
+        await get().markChatRead(activeChatId, messageId);
       },
 
-      markChatRead: async (id) => {
+      markChatRead: async (id, requestedMessageId) => {
         const { accountId, messages, settings, readDisabledMids, demoMode } = get();
         const received = messages
           .filter((m) => m.chatId === id && m.authorId !== "me" && !m.id.startsWith("pending_"))
@@ -1691,7 +1693,12 @@ export const useStore = create<State>()(
               return b.id.localeCompare(a.id);
             }
           });
-        const last = received[0];
+        const requested = requestedMessageId
+          ? received.find((message) => message.id === requestedMessageId)
+          : undefined;
+        const last = requested ?? received[0];
+        const localKey = accountId ? accountChatKey(accountId, id) : null;
+        if (localKey) recentlyReadAt.set(localKey, Date.now());
         set((st) => ({
           chats: st.chats.map((c) => (c.id === id ? { ...c, unread: 0 } : c)),
           messages: st.messages.map((m) => {
@@ -1719,16 +1726,41 @@ export const useStore = create<State>()(
           await api.line.markAsRead(accountId, id, lastId);
         } catch {
           if (lastId) readReceiptSent.delete(receiptKey);
+          if (localKey) recentlyReadAt.delete(localKey);
         }
       },
 
       markAllChatsRead: async () => {
+        const { accountId, settings, readDisabledMids, demoMode } = get();
+        if (demoMode || !accountId || !settings.readReceipts) return;
         const unreadChatIds = get()
-          .chats.filter((chat) => chat.unread > 0)
+          .chats.filter((chat) => chat.unread > 0 && !readDisabledMids[chat.id])
           .map((chat) => chat.id);
+        if (unreadChatIds.length === 0) return;
         for (const chatId of unreadChatIds) {
-          await get().markChatRead(chatId);
+          recentlyReadAt.set(accountChatKey(accountId, chatId), Date.now());
         }
+        // バックエンドの bulk API で一括既読（個別ループより高速）
+        try {
+          await api.line.markAllAsRead(accountId, unreadChatIds);
+        } catch {
+          // フォールバック: 個別既読を試す
+          for (const chatId of unreadChatIds) {
+            try {
+              await api.line.markAsRead(accountId, chatId);
+            } catch {}
+          }
+        }
+        set((st) => ({
+          chats: st.chats.map((chat) =>
+            unreadChatIds.includes(chat.id) ? { ...chat, unread: 0 } : chat,
+          ),
+          messages: st.messages.map((message) =>
+            unreadChatIds.includes(message.chatId) && message.authorId !== "me"
+              ? { ...message, read: true, status: "read" }
+              : message,
+          ),
+        }));
       },
 
       setDraft: (chatId, text) => set((st) => ({ drafts: { ...st.drafts, [chatId]: text } })),
@@ -1866,6 +1898,15 @@ export const useStore = create<State>()(
                       : prev?.name && !looksLikeMid(prev.name)
                         ? prev.name
                         : base.name;
+                  const recentlyKey = accountChatKey(accountId, c.mid);
+                  const recentAt = recentlyReadAt.get(recentlyKey);
+                  const isRecentlyRead =
+                    recentAt != null && Date.now() - recentAt < RECENTLY_READ_WINDOW_MS;
+                  const serverUnread = c.unreadCount ?? prev?.unread ?? 0;
+                  const nextUnread =
+                    isRecentlyRead && serverUnread > 0 && st.activeChatId !== c.mid
+                      ? 0
+                      : serverUnread;
                   return prev
                     ? {
                         ...base,
@@ -1877,7 +1918,7 @@ export const useStore = create<State>()(
                         hidden: prev.hidden,
                         localName: prev.localName,
                         members: prev.members,
-                        unread: st.activeChatId === c.mid ? 0 : (c.unreadCount ?? prev.unread),
+                        unread: st.activeChatId === c.mid ? 0 : nextUnread,
                         lastMessagePreview:
                           c.lastMessagePreview && c.lastMessagePreview !== "暗号化メッセージ"
                             ? c.lastMessagePreview
@@ -2609,12 +2650,24 @@ export const useStore = create<State>()(
                   } else if (ev.kind === "revoke") {
                     get().applyRevoked(ev.chatMid, ev.messageId);
                   } else if (ev.kind === "read") {
+                    // 外部クライアントで既読された場合もローカル未読を即時クリア
+                    set((st) => ({
+                      chats: st.chats.map((c) => (c.id === ev.chatMid ? { ...c, unread: 0 } : c)),
+                      messages: st.messages.map((m) =>
+                        m.chatId === ev.chatMid && m.authorId !== "me"
+                          ? { ...m, read: true, status: "read" }
+                          : m,
+                      ),
+                    }));
                     if (get().settings.readReceipts) {
-                      // 既読イベントは実既読地点が変わった可能性 → force で実値取得
                       void get()
                         .refreshReadReceipts(ev.chatMid, { force: true })
                         .catch(() => undefined);
                     }
+                    // 未読カウントのサーバ側整合も早めに取り直す
+                    void get()
+                      .refreshChatsSilently()
+                      .catch(() => undefined);
                   } else if (ev.kind === "reaction") {
                     // リアクション更新: delta 経由で reactions 付きメッセージを回収
                     const active = get().activeChatId;

--- a/Vyline/backend/src/api/line.ts
+++ b/Vyline/backend/src/api/line.ts
@@ -41,6 +41,8 @@ import {
   fetchProfile,
   fetchContactProfile,
   markAsRead,
+  markAllAsRead,
+  markAsReadBatch,
   fetchChats,
   fetchBootstrap,
   fetchMessages,
@@ -948,6 +950,34 @@ lineRouter.post("/:accountId/read", async (c) => {
   try {
     await markAsRead(accountId, body.chatMid, body.lastMessageId);
     return c.json({ ok: true });
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+lineRouter.post("/:accountId/read-batch", async (c) => {
+  const accountId = c.req.param("accountId");
+  const body = await c.req.json<{
+    targets?: Array<{ chatMid?: string; lastMessageId?: string }>;
+  }>();
+  const targets = (body.targets ?? [])
+    .filter((target) => target.chatMid && target.lastMessageId)
+    .map((target) => ({ chatMid: target.chatMid!, lastMessageId: target.lastMessageId! }));
+  if (targets.length === 0) return c.json({ ok: false, error: "targets required" }, 400);
+  try {
+    return c.json({ ok: true, count: await markAsReadBatch(accountId, targets) });
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+lineRouter.post("/:accountId/read-all", async (c) => {
+  const accountId = c.req.param("accountId");
+  const body = await c.req
+    .json<{ chatMids?: string[] }>()
+    .catch(() => ({}) as { chatMids?: string[] });
+  try {
+    return c.json({ ok: true, count: await markAllAsRead(accountId, body.chatMids) });
   } catch (err) {
     return handleError(err, c);
   }

--- a/Vyline/backend/src/service/lineService.ts
+++ b/Vyline/backend/src/service/lineService.ts
@@ -2065,6 +2065,11 @@ export async function markAsRead(
       sessionId: 0,
     });
     await markStoredMessagesReadThrough(accountId, chatMid, messageId);
+    try {
+      invalidateMessageBoxesCache(accountId);
+      chatsCache.delete(accountId);
+      invalidateBoxCursorCache(accountId, chatMid);
+    } catch {}
     log.info({ accountId, chatMid, lastMessageId: messageId }, "chat marked as read");
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -2076,6 +2081,52 @@ export async function markAsRead(
     log.warn({ accountId, chatMid, err }, "markAsRead failed");
     throw err;
   }
+}
+
+export type ReadTarget = { chatMid: string; lastMessageId: string };
+
+/** getMessageBoxes の結果から通常トークの既読送信対象を抽出する。 */
+export function readTargetsFromMessageBoxes(
+  boxes: ReadonlyArray<{
+    id: string;
+    unreadCount?: string | number | bigint;
+    lastDeliveredMessageId?: { messageId?: string | number | bigint };
+  }>,
+  chatMids?: ReadonlySet<string>,
+): ReadTarget[] {
+  return boxes.flatMap((box) => {
+    if (chatMids && !chatMids.has(box.id)) return [];
+    if (Number(box.unreadCount ?? 0) <= 0) return [];
+    const messageId = String(box.lastDeliveredMessageId?.messageId ?? "").trim();
+    return messageId ? [{ chatMid: box.id, lastMessageId: messageId }] : [];
+  });
+}
+
+/** 複数チャットを既読にする。LINE側に通常トーク用bulk APIはないため順次送信する。 */
+export async function markAsReadBatch(
+  accountId: string,
+  targets: readonly ReadTarget[],
+): Promise<number> {
+  let count = 0;
+  for (const target of targets) {
+    await markAsRead(accountId, target.chatMid, target.lastMessageId);
+    count++;
+  }
+  return count;
+}
+
+/** 未読の通常トークを全て既読にする。Squareのbulk APIは通常トークには使えない。 */
+export async function markAllAsRead(
+  accountId: string,
+  chatMids?: readonly string[],
+): Promise<number> {
+  const client = requireClient(accountId);
+  const boxesResult = await withRetryOnReset(
+    () => client.base.talk.getMessageBoxes({ messageBoxListRequest: {} }),
+    "markAllAsRead.getMessageBoxes",
+  );
+  const allowed = chatMids ? new Set(chatMids) : undefined;
+  return markAsReadBatch(accountId, readTargetsFromMessageBoxes(boxesResult.messageBoxes, allowed));
 }
 
 /**

--- a/Vyline/backend/src/service/readTargets.test.ts
+++ b/Vyline/backend/src/service/readTargets.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "bun:test";
+import { readTargetsFromMessageBoxes } from "./lineService.js";
+
+describe("readTargetsFromMessageBoxes", () => {
+  it("extracts unread chats with lastMessageId", () => {
+    const targets = readTargetsFromMessageBoxes([
+      { id: "c1", unreadCount: 2, lastDeliveredMessageId: { messageId: "123" } },
+      { id: "c2", unreadCount: 0, lastDeliveredMessageId: { messageId: "456" } },
+      { id: "u1", unreadCount: 1, lastDeliveredMessageId: { messageId: "" } },
+      { id: "c3", unreadCount: 1, lastDeliveredMessageId: { messageId: "789" } },
+    ]);
+    expect(targets).toEqual([
+      { chatMid: "c1", lastMessageId: "123" },
+      { chatMid: "c3", lastMessageId: "789" },
+    ]);
+  });
+
+  it("filters by allowed chatMids", () => {
+    const targets = readTargetsFromMessageBoxes(
+      [
+        { id: "c1", unreadCount: 1, lastDeliveredMessageId: { messageId: "1" } },
+        { id: "c2", unreadCount: 1, lastDeliveredMessageId: { messageId: "2" } },
+      ],
+      new Set(["c2"]),
+    );
+    expect(targets).toEqual([{ chatMid: "c2", lastMessageId: "2" }]);
+  });
+
+  it("handles bigint unreadCount", () => {
+    const targets = readTargetsFromMessageBoxes([
+      { id: "c1", unreadCount: 1n, lastDeliveredMessageId: { messageId: 999n } },
+    ]);
+    expect(targets).toEqual([{ chatMid: "c1", lastMessageId: "999" }]);
+  });
+});


### PR DESCRIPTION
PR #110 の既読API修正を整理して未読同期を高速化

## 変更
- store.markRead が指定 messageId を無視していた回帰を修正 (markChatRead(id, lastMessageId?) で received.find で解決)
- readTargetsFromMessageBoxes / markAsReadBatch / markAllAsRead を lineService に追加
- /read-batch /read-all BFF 追加 (readTargets.test.ts で回帰テスト)
- markAllChatsRead は readDisabledMids を除外し api.line.markAllAsRead で一括送信、ローカルは即時 unread=0 + read=true
- pollIncoming の read イベントでローカル未読を即時クリア + refreshChatsSilently()

## 検証
- bun run typecheck pass
- biome check pass
- bun run build pass
- bun test 240 pass (readTargets 3件含む)

Fixes #110 のうち既読API部分
