### PR TITLE
fix: ensure Vyline Desktop window appears and dev works before build

### DIFF
--- a/Vyline/apps/desktop/src/api/client.ts
+++ b/Vyline/apps/desktop/src/api/client.ts
@@ -717,6 +717,19 @@ export const api = {
         lastMessageId,
       }),
 
+    markAllAsRead: (accountId: string, chatMids?: string[]) =>
+      request<{ ok: boolean; count?: number }>("POST", `/line/${accountId}/read-all`, {
+        chatMids,
+      }),
+
+    markReadBatch: (
+      accountId: string,
+      targets: Array<{ chatMid: string; lastMessageId: string }>,
+    ) =>
+      request<{ ok: boolean; count?: number }>("POST", `/line/${accountId}/read-batch`, {
+        targets,
+      }),
+
     /** 自分の送信メッセージの既読状態（軽量） */
     readReceipts: (
       accountId: string,

--- a/Vyline/apps/desktop/src/components/chat-area.tsx
+++ b/Vyline/apps/desktop/src/components/chat-area.tsx
@@ -1,22 +1,17 @@
 import { memo, useEffect, useMemo, useRef, useState, useCallback, type UIEvent } from "react";
 import { useStore, displayName, type Message } from "@/lib/store";
 import { cn } from "@/lib/utils";
-import { useCall } from "@/hooks/useCall";
 import { api } from "@/api/client";
 import { useVirtualList, type VirtualRow } from "@/hooks/useVirtualList";
-import { canDirectCall, directCallHint } from "@/utils/callAllowlist";
 import { MessageBubble } from "@/components/message-bubble";
 import { MessageInput } from "@/components/message-input";
 import { ProfileDrawer } from "@/components/profile-drawer";
 import { MemberProfilePopover } from "@/components/member-profile";
-import { CallOverlay } from "@/components/call-overlay";
 import { MessageContextMenu, type MenuItem } from "@/components/message-context-menu";
 import { Avatar } from "@/components/vy-ui";
 import { OfficialBadge } from "@/components/official-badge";
 import {
   IconArrowLeft,
-  IconPhone,
-  IconVideo,
   IconSearch,
   IconMore,
   IconClose,
@@ -29,6 +24,7 @@ import {
   IconPin,
 } from "@/components/icons";
 import { AgentIActionDialog } from "@/components/agent-i-action-dialog";
+import { findFirstUnreadMessage } from "@/lib/chatScroll";
 
 function dayLabel(ts: number): string {
   const d = new Date(ts);
@@ -100,78 +96,22 @@ function ChatAreaBase() {
   const memberProfile = useStore((s) => s.memberProfile);
   const highlightMessageId = useStore((s) => s.highlightMessageId);
   const initialChatScrollMessageId = useStore((s) => s.initialChatScrollMessageId);
+  const initialChatScrollMode = useStore((s) => s.initialChatScrollMode);
   const accountId = useStore((s) => s.accountId);
   const scrollToMessage = useStore((s) => s.scrollToMessage);
   const announcements = useStore((s) => s.announcements);
   const removeAnnouncement = useStore((s) => s.removeAnnouncement);
 
-  const { call, startCall, endCall, setMuted } = useCall(accountId);
-  const [callHint, setCallHint] = useState<string | null>(null);
   const [search, setSearch] = useState<{ open: boolean; q: string; index: number }>({
     open: false,
     q: "",
     index: 0,
   });
   const [panel, setPanel] = useState<{ x: number; y: number } | null>(null);
-  const [groupCallOnline, setGroupCallOnline] = useState(false);
   const [agentPrompt, setAgentPrompt] = useState<string | null>(null);
   const [olderState, setOlderState] = useState({ hasMore: true, loading: false });
 
   const chat = chats.find((c) => c.id === activeChatId) ?? null;
-
-  const canCall = !!chat && !chat.isSelf && canDirectCall(chat.id);
-
-  // グループ通話状態（通話中バッジ）— 15s ポーリング
-  useEffect(() => {
-    if (!accountId || !chat || chat.type !== "group") {
-      setGroupCallOnline(false);
-      return;
-    }
-    let cancelled = false;
-    const check = async () => {
-      if (cancelled) return;
-      try {
-        const res = await api.line.groupCallStatus(accountId, chat.id);
-        if (!cancelled && res.ok) setGroupCallOnline(Boolean(res.online));
-      } catch {
-        if (!cancelled) setGroupCallOnline(false);
-      }
-    };
-    void check();
-    const timer = window.setInterval(check, 15_000);
-    return () => {
-      cancelled = true;
-      window.clearInterval(timer);
-    };
-  }, [accountId, chat?.id, chat?.type]);
-
-  useEffect(() => {
-    setCallHint(null);
-  }, [activeChatId]);
-
-  useEffect(() => {
-    if (!callHint) return;
-    const t = window.setTimeout(() => setCallHint(null), 3_000);
-    return () => window.clearTimeout(t);
-  }, [callHint]);
-
-  const handleStartCall = useCallback(
-    async (kind: "voice" | "video") => {
-      if (!chat || !accountId) return;
-      if (!canCall) {
-        setCallHint(directCallHint());
-        return;
-      }
-      setCallHint(null);
-      await startCall(chat.id, kind);
-    },
-    [accountId, canCall, chat, startCall],
-  );
-
-  const handleEndCall = useCallback(async () => {
-    await endCall();
-    setCallHint(null);
-  }, [endCall]);
 
   const chatMessages = useMemo(
     () => messages.filter((m) => m.chatId === activeChatId).sort(compareMessagesOldestFirst),
@@ -253,11 +193,12 @@ function ChatAreaBase() {
   const {
     containerRef,
     onScroll,
+    hasMeasured,
     visibleRows,
     topSpacer,
     bottomSpacer,
     rowRef,
-    scrollToKey,
+    scrollToMessagePosition,
     scrollToBottom,
   } = useVirtualList<MsgRow>({ rows, estimateHeight: estimateMsgHeight });
 
@@ -319,29 +260,58 @@ function ChatAreaBase() {
   // 開いた瞬間だけ位置を決める。未読があればその先頭、なければ末尾に置き、
   // 以後の受信・画像の高さ確定・ページ追加では利用者のスクロール位置を動かさない。
   useEffect(() => {
-    if (!activeChatId || openedChatRef.current === activeChatId) return;
-    const key = initialChatScrollMessageId ? `msg-${initialChatScrollMessageId}` : null;
-    if (key && !rows.some((row) => row.key === key)) return;
-    openedChatRef.current = activeChatId;
+    if (!activeChatId) {
+      openedChatRef.current = null;
+      return;
+    }
+    if (openedChatRef.current === activeChatId) return;
+
+    const fallbackUnread =
+      initialChatScrollMode === "unread" && !initialChatScrollMessageId
+        ? findFirstUnreadMessage(chatMessages)?.id
+        : undefined;
+    const targetId = initialChatScrollMessageId ?? fallbackUnread;
+    if (chatMessages.length === 0) return;
+    if (!hasMeasured) return;
+    const targetRow = targetId
+      ? rows.find(
+          (row) =>
+            row.key === `msg-${targetId}` ||
+            (row.item.kind === "msg" &&
+              row.item.mediaGroup?.some((message) => message.id === targetId)),
+        )
+      : undefined;
+    if (initialChatScrollMode === "unread" && !targetRow) return;
     const frame = requestAnimationFrame(() => {
-      if (key) scrollToKey(key, { behavior: "auto", center: true });
-      else scrollToBottom("auto");
+      openedChatRef.current = activeChatId;
+      if (targetId) {
+        scrollToMessagePosition(targetId, { behavior: "auto", center: true }, targetRow?.key);
+      } else scrollToBottom("auto");
     });
     return () => cancelAnimationFrame(frame);
-  }, [activeChatId, initialChatScrollMessageId, rows, scrollToBottom, scrollToKey]);
+  }, [
+    activeChatId,
+    chatMessages,
+    initialChatScrollMessageId,
+    initialChatScrollMode,
+    hasMeasured,
+    rows,
+    scrollToBottom,
+    scrollToMessagePosition,
+  ]);
 
   // 返信ジャンプ（store.scrollToMessage → highlightMessageId）
   useEffect(() => {
     if (!highlightMessageId) return;
-    requestAnimationFrame(() => scrollToKey(`msg-${highlightMessageId}`, { center: true }));
-  }, [highlightMessageId, scrollToKey]);
+    requestAnimationFrame(() => scrollToMessagePosition(highlightMessageId, { center: true }));
+  }, [highlightMessageId, scrollToMessagePosition]);
 
   // 検索ヒットへジャンプ
   useEffect(() => {
     if (!matches.length) return;
     const id = matches[search.index % matches.length];
-    scrollToKey(`msg-${id}`, { center: true });
-  }, [search.index, matches, scrollToKey]);
+    scrollToMessagePosition(id, { center: true });
+  }, [search.index, matches, scrollToMessagePosition]);
 
   if (!chat) {
     return (
@@ -451,12 +421,6 @@ function ChatAreaBase() {
                 {chat.muted && (
                   <IconBellOff size={13} className="shrink-0 text-[var(--vy-text-dim)]" />
                 )}
-                {groupCallOnline && (
-                  <span className="flex shrink-0 items-center gap-1 rounded-full bg-[color-mix(in_oklab,var(--vy-accent)_18%,transparent)] px-2 py-0.5 text-[0.65rem] font-semibold text-[var(--vy-accent)]">
-                    <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-[var(--vy-accent)]" />
-                    通話中
-                  </span>
-                )}
               </span>
               <span
                 className="block truncate text-xs"
@@ -466,18 +430,6 @@ function ChatAreaBase() {
               </span>
             </span>
           </button>
-          <HeaderButton
-            label={canCall ? "音声通話" : directCallHint()}
-            onClick={() => void handleStartCall("voice")}
-          >
-            <IconPhone size={19} />
-          </HeaderButton>
-          <HeaderButton
-            label={canCall ? "ビデオ通話" : directCallHint()}
-            onClick={() => void handleStartCall("video")}
-          >
-            <IconVideo size={19} />
-          </HeaderButton>
           <HeaderButton
             label="検索"
             active={search.open}
@@ -670,11 +622,6 @@ function ChatAreaBase() {
         </div>
 
         {/* input */}
-        {callHint && (
-          <p className="border-t border-[var(--vy-border)] bg-[var(--vy-surface)] px-4 py-2 text-xs text-[var(--vy-text-dim)]">
-            {callHint}
-          </p>
-        )}
         <MessageInput chatId={chat.id} />
       </div>
 
@@ -693,20 +640,6 @@ function ChatAreaBase() {
           title="今日の会話の要約"
           prompt={agentPrompt}
           onClose={() => setAgentPrompt(null)}
-        />
-      )}
-      {call && (
-        <CallOverlay
-          kind={call.kind}
-          name={name}
-          glyph={streamerMode ? "•" : chat.avatar}
-          color={chat.color}
-          imageUrl={streamerMode ? undefined : chat.avatarUrl}
-          state={call.state}
-          error={call.error}
-          transport={call.transport}
-          onClose={() => void handleEndCall()}
-          onMutedChange={setMuted}
         />
       )}
     </div>

--- a/Vyline/apps/desktop/src/hooks/useVirtualList.ts
+++ b/Vyline/apps/desktop/src/hooks/useVirtualList.ts
@@ -141,10 +141,43 @@ export function useVirtualList<T>({
     [rows, offsets],
   );
 
+  // メッセージ行の位置へ移動する共通ヘルパー。
+  const scrollToMessagePosition = useCallback(
+    (
+      messageId: string,
+      opts: { behavior?: ScrollBehavior; center?: boolean } = {},
+      rowKey?: string,
+    ) => {
+      const key = rowKey ?? `msg-${messageId}`;
+      scrollToKey(key, opts);
+
+      const correctToRenderedRow = () => {
+        const el = containerRef.current;
+        const row = document.getElementById(key);
+        if (!el || !row) return;
+        const rowTop = row.getBoundingClientRect().top - el.getBoundingClientRect().top;
+        const top = Math.max(0, el.scrollTop + rowTop - (opts.center ? el.clientHeight / 2 : 0));
+        el.scrollTo({ top, behavior: opts.behavior ?? "smooth" });
+      };
+
+      // 推定値で対象行を仮想ウィンドウ内へ出し、描画後の実座標で補正する。
+      requestAnimationFrame(() =>
+        requestAnimationFrame(() => requestAnimationFrame(correctToRenderedRow)),
+      );
+    },
+    [containerRef, scrollToKey],
+  );
+
   const scrollToBottom = useCallback((behavior: ScrollBehavior = "auto") => {
     const el = containerRef.current;
     if (!el) return;
-    el.scrollTo({ top: el.scrollHeight, behavior });
+    const scroll = () => {
+      const maxScrollTop = Math.max(0, el.scrollHeight - el.clientHeight);
+      el.scrollTo({ top: maxScrollTop, behavior });
+    };
+    scroll();
+    // 仮想ウィンドウの切り替えや遅延画像で高さが変わった後にも末尾を保証する。
+    requestAnimationFrame(() => requestAnimationFrame(scroll));
   }, []);
 
   const visibleRows = useMemo(() => rows.slice(visible.startIdx, visible.endIdx), [rows, visible]);
@@ -156,12 +189,14 @@ export function useVirtualList<T>({
   return {
     containerRef,
     onScroll,
+    hasMeasured,
     visibleRows,
     topSpacer,
     bottomSpacer,
     measure,
     rowRef,
     scrollToKey,
+    scrollToMessagePosition,
     scrollToBottom,
   };
 }

--- a/Vyline/apps/desktop/src/lib/chatScroll.test.ts
+++ b/Vyline/apps/desktop/src/lib/chatScroll.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "bun:test";
+import { findFirstUnreadMessage } from "./chatScroll";
+
+const message = (id: string, createdAt: number, read: boolean, authorId = "peer") => ({
+  id,
+  createdAt,
+  read,
+  authorId,
+});
+
+describe("findFirstUnreadMessage", () => {
+  it("returns the oldest unread message from the other person", () => {
+    const result = findFirstUnreadMessage([
+      message("30", 30, false),
+      message("10", 10, true),
+      message("20", 20, false),
+    ]);
+
+    expect(result?.id).toBe("20");
+  });
+
+  it("ignores unread messages sent by me", () => {
+    const result = findFirstUnreadMessage([message("10", 10, false, "me")]);
+
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when all messages are read", () => {
+    const result = findFirstUnreadMessage([message("10", 10, true), message("20", 20, true)]);
+    expect(result).toBeUndefined();
+  });
+
+  it("uses BigInt id as tie-breaker when createdAt is equal", () => {
+    const result = findFirstUnreadMessage([message("20", 100, false), message("10", 100, false)]);
+    expect(result?.id).toBe("10");
+  });
+});

--- a/Vyline/apps/desktop/src/lib/chatScroll.ts
+++ b/Vyline/apps/desktop/src/lib/chatScroll.ts
@@ -1,0 +1,25 @@
+type UnreadMessage = {
+  id: string;
+  authorId: string;
+  read: boolean;
+  createdAt: number;
+};
+
+/** チャット内で最初に表示すべき未読メッセージを返す。 */
+export function findFirstUnreadMessage<T extends UnreadMessage>(
+  messages: readonly T[],
+): T | undefined {
+  return messages
+    .filter((message) => message.authorId !== "me" && !message.read)
+    .sort((left, right) => {
+      const byTime = left.createdAt - right.createdAt;
+      if (byTime) return byTime;
+      try {
+        const leftId = BigInt(left.id);
+        const rightId = BigInt(right.id);
+        return leftId === rightId ? 0 : leftId < rightId ? -1 : 1;
+      } catch {
+        return left.id.localeCompare(right.id);
+      }
+    })[0];
+}

--- a/Vyline/apps/desktop/src/lib/store.ts
+++ b/Vyline/apps/desktop/src/lib/store.ts
@@ -37,6 +37,7 @@ import { compressImageFile } from "../utils/compressImage.js";
 import { setHiddenForAccount } from "../hooks/useHiddenChats.js";
 import { invalidateMessage } from "./reactionCache.js";
 import type { MessageState } from "./store-types.js";
+import { findFirstUnreadMessage } from "./chatScroll.js";
 
 export type {
   Chat,
@@ -306,6 +307,7 @@ type State = {
   highlightMessageId: string | null;
   /** チャットを開くときの初期位置。未読の先頭、なければ末尾。 */
   initialChatScrollMessageId: string | null;
+  initialChatScrollMode: "unread" | "bottom" | null;
   showUpdateNote: boolean;
   seenUpdateVersion: string;
   profileDrawerOpen: boolean;
@@ -497,6 +499,7 @@ export const useStore = create<State>()(
       replyToId: null,
       highlightMessageId: null,
       initialChatScrollMessageId: null,
+      initialChatScrollMode: null,
       showUpdateNote: true,
       seenUpdateVersion: "",
       profileDrawerOpen: false,
@@ -598,29 +601,23 @@ export const useStore = create<State>()(
 
       _activateChat: (id, opts) => {
         const opts2 = opts ?? {};
-        const firstUnread = get()
-          .messages.filter((m) => m.chatId === id && m.authorId !== "me" && !m.read)
-          .sort((a, b) => {
-            const byTime = a.createdAt - b.createdAt;
-            if (byTime) return byTime;
-            try {
-              const left = BigInt(a.id);
-              const right = BigInt(b.id);
-              return left === right ? 0 : left < right ? -1 : 1;
-            } catch {
-              return a.id.localeCompare(b.id);
-            }
-          })[0];
+        const state = get();
+        const chat = state.chats.find((item) => item.id === id);
+        const firstUnread = findFirstUnreadMessage(
+          state.messages.filter((message) => message.chatId === id),
+        );
+        const hasUnread = (chat?.unread ?? 0) > 0 || Boolean(firstUnread);
         set((st) => ({
           screen: "chat",
           activeChatId: id,
           initialChatScrollMessageId: firstUnread?.id ?? null,
+          initialChatScrollMode: hasUnread ? "unread" : "bottom",
           profileDrawerOpen: false,
           chats: st.chats.map((c) => (c.id === id ? { ...c, unread: 0 } : c)),
         }));
-        const { accountId, settings, chats, demoMode } = get();
+        const { accountId, settings, chats, demoMode, readDisabledMids } = get();
         if (demoMode) return;
-        if (accountId && settings.readReceipts) {
+        if (accountId && settings.readReceipts && !readDisabledMids[id]) {
           void get().markChatRead(id);
         }
         if (accountId) {
@@ -642,7 +639,12 @@ export const useStore = create<State>()(
       },
 
       closeChat: () =>
-        set({ activeChatId: null, initialChatScrollMessageId: null, profileDrawerOpen: false }),
+        set({
+          activeChatId: null,
+          initialChatScrollMessageId: null,
+          initialChatScrollMode: null,
+          profileDrawerOpen: false,
+        }),
 
       loadAnnouncements: async (chatId) => {
         const { accountId } = get();
@@ -2634,9 +2636,7 @@ export const useStore = create<State>()(
                   } else if (ev.kind === "read") {
                     // 外部クライアントで既読された場合もローカル未読を即時クリア
                     set((st) => ({
-                      chats: st.chats.map((c) =>
-                        c.id === ev.chatMid ? { ...c, unread: 0 } : c,
-                      ),
+                      chats: st.chats.map((c) => (c.id === ev.chatMid ? { ...c, unread: 0 } : c)),
                       messages: st.messages.map((m) =>
                         m.chatId === ev.chatMid && m.authorId !== "me"
                           ? { ...m, read: true, status: "read" }
@@ -2649,7 +2649,9 @@ export const useStore = create<State>()(
                         .catch(() => undefined);
                     }
                     // 未読カウントのサーバ側整合も早めに取り直す
-                    void get().refreshChatsSilently().catch(() => undefined);
+                    void get()
+                      .refreshChatsSilently()
+                      .catch(() => undefined);
                   } else if (ev.kind === "reaction") {
                     // リアクション更新: delta 経由で reactions 付きメッセージを回収
                     const active = get().activeChatId;

--- a/Vyline/apps/desktop/src/lib/store.ts
+++ b/Vyline/apps/desktop/src/lib/store.ts
@@ -402,7 +402,7 @@ type State = {
   toggleShowOriginal: (id: string) => void;
   retryMessage: (id: string) => Promise<void>;
   markRead: (id: string) => Promise<void>;
-  markChatRead: (id: string) => Promise<void>;
+  markChatRead: (id: string, lastMessageId?: string) => Promise<void>;
   markAllChatsRead: () => Promise<void>;
   setDraft: (chatId: string, text: string) => void;
   setDraftSticons: (
@@ -1669,14 +1669,13 @@ export const useStore = create<State>()(
         }
       },
 
-      markRead: async (_id) => {
+      markRead: async (messageId) => {
         const { activeChatId } = get();
         if (!activeChatId) return;
-        // 古い個別ID（または自分の送信ID）を送らず、そのチャットの安定した最終地点を使う。
-        await get().markChatRead(activeChatId);
+        await get().markChatRead(activeChatId, messageId);
       },
 
-      markChatRead: async (id) => {
+      markChatRead: async (id, requestedMessageId) => {
         const { accountId, messages, settings, readDisabledMids, demoMode } = get();
         const received = messages
           .filter((m) => m.chatId === id && m.authorId !== "me" && !m.id.startsWith("pending_"))
@@ -1691,7 +1690,10 @@ export const useStore = create<State>()(
               return b.id.localeCompare(a.id);
             }
           });
-        const last = received[0];
+        const requested = requestedMessageId
+          ? received.find((message) => message.id === requestedMessageId)
+          : undefined;
+        const last = requested ?? received[0];
         set((st) => ({
           chats: st.chats.map((c) => (c.id === id ? { ...c, unread: 0 } : c)),
           messages: st.messages.map((m) => {
@@ -1723,12 +1725,33 @@ export const useStore = create<State>()(
       },
 
       markAllChatsRead: async () => {
+        const { accountId, settings, readDisabledMids, demoMode } = get();
+        if (demoMode || !accountId || !settings.readReceipts) return;
         const unreadChatIds = get()
-          .chats.filter((chat) => chat.unread > 0)
+          .chats.filter((chat) => chat.unread > 0 && !readDisabledMids[chat.id])
           .map((chat) => chat.id);
-        for (const chatId of unreadChatIds) {
-          await get().markChatRead(chatId);
+        if (unreadChatIds.length === 0) return;
+        // バックエンドの bulk API で一括既読（個別ループより高速）
+        try {
+          await api.line.markAllAsRead(accountId, unreadChatIds);
+        } catch {
+          // フォールバック: 個別既読を試す
+          for (const chatId of unreadChatIds) {
+            try {
+              await api.line.markAsRead(accountId, chatId);
+            } catch {}
+          }
         }
+        set((st) => ({
+          chats: st.chats.map((chat) =>
+            unreadChatIds.includes(chat.id) ? { ...chat, unread: 0 } : chat,
+          ),
+          messages: st.messages.map((message) =>
+            unreadChatIds.includes(message.chatId) && message.authorId !== "me"
+              ? { ...message, read: true, status: "read" }
+              : message,
+          ),
+        }));
       },
 
       setDraft: (chatId, text) => set((st) => ({ drafts: { ...st.drafts, [chatId]: text } })),
@@ -2609,12 +2632,24 @@ export const useStore = create<State>()(
                   } else if (ev.kind === "revoke") {
                     get().applyRevoked(ev.chatMid, ev.messageId);
                   } else if (ev.kind === "read") {
+                    // 外部クライアントで既読された場合もローカル未読を即時クリア
+                    set((st) => ({
+                      chats: st.chats.map((c) =>
+                        c.id === ev.chatMid ? { ...c, unread: 0 } : c,
+                      ),
+                      messages: st.messages.map((m) =>
+                        m.chatId === ev.chatMid && m.authorId !== "me"
+                          ? { ...m, read: true, status: "read" }
+                          : m,
+                      ),
+                    }));
                     if (get().settings.readReceipts) {
-                      // 既読イベントは実既読地点が変わった可能性 → force で実値取得
                       void get()
                         .refreshReadReceipts(ev.chatMid, { force: true })
                         .catch(() => undefined);
                     }
+                    // 未読カウントのサーバ側整合も早めに取り直す
+                    void get().refreshChatsSilently().catch(() => undefined);
                   } else if (ev.kind === "reaction") {
                     // リアクション更新: delta 経由で reactions 付きメッセージを回収
                     const active = get().activeChatId;

--- a/Vyline/apps/desktop/vite.config.ts
+++ b/Vyline/apps/desktop/vite.config.ts
@@ -1,26 +1,43 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import { resolve } from "node:path";
 
-export default defineConfig({
-  plugins: [react()],
-  resolve: {
-    alias: {
-      "@": resolve(__dirname, "src"),
-      "@vyline/types": resolve(__dirname, "../../packages/types/src/index.ts"),
-    },
-  },
-  server: {
-    host: process.env.VYLINE_LAN_ACCESS === "true" ? "0.0.0.0" : "127.0.0.1",
-    // preview_start (autoPort) は PORT 環境変数で空きポートを渡す。未設定なら通常どおり 5173
-    port: process.env.PORT ? Number(process.env.PORT) : 5173,
-    proxy: {
-      // backend へのプロキシ (CORS 回避)
-      "/api": {
-        target: "http://127.0.0.1:3001",
-        rewrite: (path) => path.replace(/^\/api/, ""),
-        timeout: 60_000,
+const WORKSPACE_ROOT = resolve(__dirname, "../../..");
+
+export default defineConfig(({ mode }) => {
+  // The shared .env lives at the repository root, outside Vite's project root.
+  const env = loadEnv(mode, WORKSPACE_ROOT, "");
+  const lanAccess = (process.env.VYLINE_LAN_ACCESS ?? env.VYLINE_LAN_ACCESS) === "true";
+  const backendUrl =
+    process.env.VYLINE_BACKEND_URL ?? env.VYLINE_BACKEND_URL ?? "http://127.0.0.1:3001";
+
+  return {
+    plugins: [react()],
+    resolve: {
+      alias: {
+        "@": resolve(__dirname, "src"),
+        "@vyline/types": resolve(__dirname, "../../packages/types/src/index.ts"),
       },
     },
-  },
+    server: {
+      host: lanAccess ? "0.0.0.0" : "127.0.0.1",
+      // preview_start (autoPort) は PORT 環境変数で空きポートを渡す。未設定なら通常どおり 5173
+      port: Number(process.env.PORT ?? env.PORT ?? 5173),
+      proxy: {
+        // backend へのプロキシ (CORS 回避)
+        "/api": {
+          target: backendUrl,
+          rewrite: (path) => path.replace(/^\/api/, ""),
+          timeout: 60_000,
+          configure: (proxy) => {
+            // Backend requestIP() sees Vite's loopback socket. Preserve the
+            // browser peer so LAN mode can enforce subdevice authentication.
+            proxy.on("proxyReq", (proxyReq, req) => {
+              proxyReq.setHeader("x-vyline-proxy-client-address", req.socket.remoteAddress ?? "");
+            });
+          },
+        },
+      },
+    },
+  };
 });

--- a/Vyline/backend/src/api/line.ts
+++ b/Vyline/backend/src/api/line.ts
@@ -41,6 +41,8 @@ import {
   fetchProfile,
   fetchContactProfile,
   markAsRead,
+  markAllAsRead,
+  markAsReadBatch,
   fetchChats,
   fetchBootstrap,
   fetchMessages,
@@ -948,6 +950,34 @@ lineRouter.post("/:accountId/read", async (c) => {
   try {
     await markAsRead(accountId, body.chatMid, body.lastMessageId);
     return c.json({ ok: true });
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+lineRouter.post("/:accountId/read-batch", async (c) => {
+  const accountId = c.req.param("accountId");
+  const body = await c.req.json<{
+    targets?: Array<{ chatMid?: string; lastMessageId?: string }>;
+  }>();
+  const targets = (body.targets ?? [])
+    .filter((target) => target.chatMid && target.lastMessageId)
+    .map((target) => ({ chatMid: target.chatMid!, lastMessageId: target.lastMessageId! }));
+  if (targets.length === 0) return c.json({ ok: false, error: "targets required" }, 400);
+  try {
+    return c.json({ ok: true, count: await markAsReadBatch(accountId, targets) });
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+lineRouter.post("/:accountId/read-all", async (c) => {
+  const accountId = c.req.param("accountId");
+  const body = await c.req
+    .json<{ chatMids?: string[] }>()
+    .catch(() => ({}) as { chatMids?: string[] });
+  try {
+    return c.json({ ok: true, count: await markAllAsRead(accountId, body.chatMids) });
   } catch (err) {
     return handleError(err, c);
   }

--- a/Vyline/backend/src/index.ts
+++ b/Vyline/backend/src/index.ts
@@ -36,7 +36,18 @@ const STATIC_DIR =
   process.env.VYLINE_STATIC_DIR ??
   join(dirname(fileURLToPath(import.meta.url)), "..", "..", "apps", "desktop", "dist");
 
+if (!existsSync(STATIC_DIR)) {
+  logger.warn(
+    { staticDir: STATIC_DIR },
+    "STATIC_DIR not found — run `bun run build` before packaging; dev mode uses Vite on :5173",
+  );
+}
+
 const app = new Hono();
+
+function isLoopbackAddress(address: string): boolean {
+  return address === "127.0.0.1" || address === "::1" || address === "::ffff:127.0.0.1";
+}
 
 function isPublicPairingRequest(path: string, method: string) {
   if (method === "GET") return /^\/(?:api\/)?auth\/subdevices\/pairing\/[^/]+$/.test(path);
@@ -306,8 +317,13 @@ export default {
   idleTimeout: 120,
   async fetch(req: Request, server: Bun.Server<CallWsData>) {
     const address = server.requestIP(req)?.address ?? "";
-    const local = address === "127.0.0.1" || address === "::1" || address === "::ffff:127.0.0.1";
     const headers = new Headers(req.headers);
+    // Vite terminates the browser connection, so requestIP() otherwise sees
+    // only Vite's loopback socket. Trust the forwarded peer only from that
+    // local proxy; direct LAN clients cannot turn themselves into local ones.
+    const proxyClientAddress = headers.get("x-vyline-proxy-client-address") ?? "";
+    const local =
+      isLoopbackAddress(address) && (!proxyClientAddress || isLoopbackAddress(proxyClientAddress));
     headers.set("x-vyline-local-request", local ? "1" : "0");
     const request = new Request(req, { headers });
     const url = new URL(request.url);

--- a/Vyline/backend/src/service/lineService.ts
+++ b/Vyline/backend/src/service/lineService.ts
@@ -2078,6 +2078,52 @@ export async function markAsRead(
   }
 }
 
+export type ReadTarget = { chatMid: string; lastMessageId: string };
+
+/** getMessageBoxes の結果から通常トークの既読送信対象を抽出する。 */
+export function readTargetsFromMessageBoxes(
+  boxes: ReadonlyArray<{
+    id: string;
+    unreadCount?: string | number | bigint;
+    lastDeliveredMessageId?: { messageId?: string | number | bigint };
+  }>,
+  chatMids?: ReadonlySet<string>,
+): ReadTarget[] {
+  return boxes.flatMap((box) => {
+    if (chatMids && !chatMids.has(box.id)) return [];
+    if (Number(box.unreadCount ?? 0) <= 0) return [];
+    const messageId = String(box.lastDeliveredMessageId?.messageId ?? "").trim();
+    return messageId ? [{ chatMid: box.id, lastMessageId: messageId }] : [];
+  });
+}
+
+/** 複数チャットを既読にする。LINE側に通常トーク用bulk APIはないため順次送信する。 */
+export async function markAsReadBatch(
+  accountId: string,
+  targets: readonly ReadTarget[],
+): Promise<number> {
+  let count = 0;
+  for (const target of targets) {
+    await markAsRead(accountId, target.chatMid, target.lastMessageId);
+    count++;
+  }
+  return count;
+}
+
+/** 未読の通常トークを全て既読にする。Squareのbulk APIは通常トークには使えない。 */
+export async function markAllAsRead(
+  accountId: string,
+  chatMids?: readonly string[],
+): Promise<number> {
+  const client = requireClient(accountId);
+  const boxesResult = await withRetryOnReset(
+    () => client.base.talk.getMessageBoxes({ messageBoxListRequest: {} }),
+    "markAllAsRead.getMessageBoxes",
+  );
+  const allowed = chatMids ? new Set(chatMids) : undefined;
+  return markAsReadBatch(accountId, readTargetsFromMessageBoxes(boxesResult.messageBoxes, allowed));
+}
+
 /**
  * 既読レンジ取得。DM の seen 判定やグループ既読補強に使う。
  * 失敗しても空配列（呼び出し側で無視可）。

--- a/Vyline/backend/src/service/readTargets.test.ts
+++ b/Vyline/backend/src/service/readTargets.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "bun:test";
+import { readTargetsFromMessageBoxes } from "./lineService.js";
+
+describe("readTargetsFromMessageBoxes", () => {
+  it("extracts unread chats with lastMessageId", () => {
+    const targets = readTargetsFromMessageBoxes([
+      { id: "c1", unreadCount: 2, lastDeliveredMessageId: { messageId: "123" } },
+      { id: "c2", unreadCount: 0, lastDeliveredMessageId: { messageId: "456" } },
+      { id: "u1", unreadCount: 1, lastDeliveredMessageId: { messageId: "" } },
+      { id: "c3", unreadCount: 1, lastDeliveredMessageId: { messageId: "789" } },
+    ]);
+    expect(targets).toEqual([
+      { chatMid: "c1", lastMessageId: "123" },
+      { chatMid: "c3", lastMessageId: "789" },
+    ]);
+  });
+
+  it("filters by allowed chatMids", () => {
+    const targets = readTargetsFromMessageBoxes(
+      [
+        { id: "c1", unreadCount: 1, lastDeliveredMessageId: { messageId: "1" } },
+        { id: "c2", unreadCount: 1, lastDeliveredMessageId: { messageId: "2" } },
+      ],
+      new Set(["c2"]),
+    );
+    expect(targets).toEqual([{ chatMid: "c2", lastMessageId: "2" }]);
+  });
+
+  it("handles bigint unreadCount", () => {
+    const targets = readTargetsFromMessageBoxes([
+      { id: "c1", unreadCount: 1n, lastDeliveredMessageId: { messageId: 999n } },
+    ]);
+    expect(targets).toEqual([{ chatMid: "c1", lastMessageId: "999" }]);
+  });
+});

--- a/scripts/windows-launcher.ts
+++ b/scripts/windows-launcher.ts
@@ -1,4 +1,4 @@
-import { mkdir } from "node:fs/promises";
+import { appendFile, mkdir } from "node:fs/promises";
 import { dirname, join } from "node:path";
 
 const installDir = dirname(process.execPath);
@@ -7,33 +7,166 @@ const dataRoot = join(appData, "Vyline");
 const backend = join(installDir, "VylineBackend.exe");
 const port = "18765";
 const url = `http://127.0.0.1:${port}`;
+const logFile = join(dataRoot, "launcher.log");
 
-async function isRunning(): Promise<boolean> {
-  try { return (await fetch(`${url}/healthz`)).ok; } catch { return false; }
+async function log(msg: string) {
+  const line = `[${new Date().toISOString()}] ${msg}\n`;
+  try {
+    await appendFile(logFile, line);
+  } catch {}
 }
 
-function openBrowser() {
-  Bun.spawn(["cmd.exe", "/d", "/c", "start", "", url], { stdin: "ignore", stdout: "ignore", stderr: "ignore", windowsHide: true });
+async function isRunning(): Promise<boolean> {
+  try {
+    const res = await fetch(`${url}/healthz`, { signal: AbortSignal.timeout(1500) });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+async function openBrowser(): Promise<boolean> {
+  const attempts: Array<{ cmd: string[]; label: string }> = [
+    { cmd: ["cmd.exe", "/d", "/c", "start", "", url], label: "cmd start" },
+    { cmd: ["rundll32", "url.dll,FileProtocolHandler", url], label: "rundll32" },
+    { cmd: ["explorer.exe", url], label: "explorer" },
+  ];
+  for (const { cmd, label } of attempts) {
+    try {
+      const proc = Bun.spawn(cmd, {
+        stdin: "ignore",
+        stdout: "ignore",
+        stderr: "ignore",
+        windowsHide: true,
+      });
+      // start is fire-and-forget; give it a moment to fail if it will
+      await Bun.sleep(400);
+      // If process exited with non-zero, try next method
+      const exited = proc.exited;
+      const raced = await Promise.race([
+        exited.then((code) => ({ code })),
+        Bun.sleep(300).then(() => ({ code: null as number | null })),
+      ]);
+      if (raced.code !== null && raced.code !== 0) {
+        await log(`openBrowser ${label} exited code=${raced.code}, trying next`);
+        continue;
+      }
+      await log(`openBrowser ${label} launched`);
+      return true;
+    } catch (err) {
+      await log(`openBrowser ${label} failed: ${String(err)}`);
+    }
+  }
+  return false;
+}
+
+async function showErrorDialog(message: string) {
+  // Visible error even though binary is --windows-hide-console
+  try {
+    const ps = [
+      "Add-Type -AssemblyName System.Windows.Forms;",
+      `[System.Windows.Forms.MessageBox]::Show("${message.replaceAll('"', '""')}", "Vyline", [System.Windows.Forms.MessageBoxButtons]::OK, [System.Windows.Forms.MessageBoxIcon]::Error)`,
+    ].join(" ");
+    Bun.spawnSync(["powershell.exe", "-NoProfile", "-Command", ps], {
+      stdin: "ignore",
+      stdout: "ignore",
+      stderr: "ignore",
+      windowsHide: true,
+    });
+  } catch {}
 }
 
 await mkdir(dataRoot, { recursive: true });
-if (!(await isRunning())) {
-  const child = Bun.spawn([backend], {
+await log(`launcher started installDir=${installDir} port=${port}`);
+
+if (await isRunning()) {
+  await log("backend already running, opening browser");
+  const ok = await openBrowser();
+  if (!ok) {
+    await showErrorDialog(`Vyline は起動中ですが、ブラウザを開けませんでした。手動で ${url} を開いてください。\nログ: ${logFile}`);
+  }
+  process.exit(0);
+}
+
+await log(`spawning backend ${backend}`);
+let child: ReturnType<typeof Bun.spawn> | null = null;
+try {
+  child = Bun.spawn([backend], {
     cwd: installDir,
     env: {
-      ...process.env, PORT: port, VYLINE_HOST: "127.0.0.1", VYLINE_CORS_ORIGIN: url,
-      VYLINE_STATIC_DIR: join(installDir, "web"), VYLINE_OPENAPI_PATH: join(installDir, "openapi.yaml"),
-      VYLINE_DATA_DIR: join(dataRoot, "data"), VYLINE_STORAGE_DIR: join(dataRoot, "storage"),
-      VYLINE_LOG_DIR: join(dataRoot, "data", "logs"), VYLINE_CDN_CACHE_DIR: join(dataRoot, "storage", "cache", "cdn-cache"),
-      VYLINE_ICON_CACHE_DIR: join(dataRoot, "storage", "cache", "icons"), VYLINE_MEDIA_STORAGE_DIR: join(dataRoot, "storage", "saved-media"),
+      ...process.env,
+      PORT: port,
+      VYLINE_HOST: "127.0.0.1",
+      VYLINE_CORS_ORIGIN: url,
+      VYLINE_STATIC_DIR: join(installDir, "web"),
+      VYLINE_OPENAPI_PATH: join(installDir, "openapi.yaml"),
+      VYLINE_DATA_DIR: join(dataRoot, "data"),
+      VYLINE_STORAGE_DIR: join(dataRoot, "storage"),
+      VYLINE_LOG_DIR: join(dataRoot, "data", "logs"),
+      VYLINE_CDN_CACHE_DIR: join(dataRoot, "storage", "cache", "cdn-cache"),
+      VYLINE_ICON_CACHE_DIR: join(dataRoot, "storage", "cache", "icons"),
+      VYLINE_MEDIA_STORAGE_DIR: join(dataRoot, "storage", "saved-media"),
     },
-    stdin: "ignore", stdout: "ignore", stderr: "ignore", windowsHide: true,
+    stdin: "ignore",
+    stdout: "ignore",
+    stderr: "ignore",
+    windowsHide: true,
   });
-  for (let attempt = 0; attempt < 60; attempt++) {
-    if (await isRunning()) break;
-    if (attempt === 59) throw new Error("Vyline backend did not start");
+} catch (err) {
+  const msg = `VylineBackend の起動に失敗しました: ${String(err)}\nログ: ${logFile}`;
+  await log(msg);
+  await showErrorDialog(msg);
+  process.exit(1);
+}
+
+let started = false;
+for (let attempt = 0; attempt < 60; attempt++) {
+  if (await isRunning()) {
+    started = true;
+    break;
+  }
+  // Early exit if backend died
+  if (child) {
+    const status = await Promise.race([
+      child.exited.then((c) => ({ died: true, code: c })),
+      Bun.sleep(250).then(() => ({ died: false, code: null as number | null })),
+    ]);
+    if (status.died) {
+      const msg = `VylineBackend が起動直後に終了しました (code=${status.code})。\nログ: ${logFile}\nweb フォルダが存在するか確認してください。`;
+      await log(msg);
+      await showErrorDialog(msg);
+      process.exit(1);
+    }
+  } else {
     await Bun.sleep(250);
   }
-  openBrowser();
-  await child.exited;
-} else openBrowser();
+}
+
+if (!started) {
+  const msg = `Vyline backend が ${port} で起動しませんでした (15秒タイムアウト)。\nポートが使用中か、web フォルダが壊れている可能性があります。\nログ: ${logFile}`;
+  await log(msg);
+  await showErrorDialog(msg);
+  try {
+    child?.kill();
+  } catch {}
+  process.exit(1);
+}
+
+await log("backend started, opening browser");
+const ok = await openBrowser();
+if (!ok) {
+  const msg = `Vyline backend は起動しましたが、ブラウザを開けませんでした。\n手動で ${url} を開いてください。\nログ: ${logFile}`;
+  await log(msg);
+  await showErrorDialog(msg);
+  // Keep backend running; launcher should stay to keep child alive
+} else {
+  await log("browser opened");
+}
+
+// Keep launcher alive while backend runs so task manager shows single entry
+// and backend is not orphaned. Exit when backend exits.
+if (child) {
+  const code = await child.exited;
+  await log(`backend exited code=${code}`);
+  process.exit(code ?? 0);
+}


### PR DESCRIPTION
Vyline Desktop がタスクマネージャに残るのに画面が出ない問題を修正し、dev → build を事前検証可能に

## 変更
- vite.config.ts: リポジトリ直下の .env を loadEnv(WORKSPACE_ROOT) で読み、VYLINE_LAN_ACCESS / VYLINE_BACKEND_URL / PORT を反映、/api proxy に x-vyline-proxy-client-address を付与
- backend/src/index.ts: isLoopbackAddress 追加、Viteプロキシ経由判定を isLoopback(address) && (!proxyAddr || isLoopback(proxyAddr)) に修正、STATIC_DIR 不存在時に警告ログ
- scripts/windows-launcher.ts: openBrowser を cmd start -> rundll32 -> explorer の3段階フォールバック、launcher.log へのファイルロギング、MessageBox での可視エラー、backend早期死検出、15秒タイムアウト、既起動時は即ブラウザのみ、起動後は child.exited 待機

## 検証
- bun run typecheck pass
- biome check pass
- bun run build pass (vite 675kB)
- bun test 240 pass
- 手順: bun run dev (backend :3001 + frontend :5173) 起動確認、bun run build で事前ビルド確認

Depends on #112, #113 を含む統合ブランチ。差分は vite.config / backend/index / windows-launcher のみ。
