### PR TITLE
fix: restore the last opened chat on startup

### DIFF
--- a/Vyline/apps/desktop/src/lib/store.test.ts
+++ b/Vyline/apps/desktop/src/lib/store.test.ts
@@ -2,6 +2,24 @@ import { describe, expect, it } from "bun:test";
 import { useStore } from "./store.js";
 
 describe("useStore account initialization", () => {
+  it("restores the account's explicitly last opened chat before chat loading", () => {
+    const storage = new Map<string, string>([
+      ["vyline:last-opened-chat:account-1", "chat-last-opened"],
+    ]);
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => storage.set(key, value),
+      },
+    });
+    useStore.setState({ accountId: null, activeChatId: null });
+
+    useStore.getState().setAccountId("account-1");
+
+    expect(useStore.getState().activeChatId).toBe("chat-last-opened");
+  });
+
   it("keeps the last opened chat when the persisted account is initialized", () => {
     useStore.setState({
       accountId: null,

--- a/Vyline/apps/desktop/src/lib/store.test.ts
+++ b/Vyline/apps/desktop/src/lib/store.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "bun:test";
+import { useStore } from "./store.js";
+
+describe("useStore.resetAccountData", () => {
+  it("keeps the last opened chat for startup restoration", () => {
+    useStore.setState({
+      activeChatId: "chat-last-opened",
+    });
+
+    useStore.getState().resetAccountData();
+
+    expect(useStore.getState().activeChatId).toBe("chat-last-opened");
+  });
+});

--- a/Vyline/apps/desktop/src/lib/store.test.ts
+++ b/Vyline/apps/desktop/src/lib/store.test.ts
@@ -1,14 +1,27 @@
 import { describe, expect, it } from "bun:test";
 import { useStore } from "./store.js";
 
-describe("useStore.resetAccountData", () => {
-  it("keeps the last opened chat for startup restoration", () => {
+describe("useStore account initialization", () => {
+  it("keeps the last opened chat when the persisted account is initialized", () => {
     useStore.setState({
+      accountId: null,
       activeChatId: "chat-last-opened",
     });
 
+    useStore.getState().setAccountId("account-1");
     useStore.getState().resetAccountData();
 
     expect(useStore.getState().activeChatId).toBe("chat-last-opened");
+  });
+
+  it("clears the last opened chat when switching accounts", () => {
+    useStore.setState({
+      accountId: "account-1",
+      activeChatId: "chat-account-1",
+    });
+
+    useStore.getState().setAccountId("account-2");
+
+    expect(useStore.getState().activeChatId).toBeNull();
   });
 });

--- a/Vyline/apps/desktop/src/lib/store.ts
+++ b/Vyline/apps/desktop/src/lib/store.ts
@@ -77,6 +77,23 @@ const contactFetched = new Set<string>();
 const sessionOpenedChats = new Set<string>();
 
 const accountChatKey = (accountId: string, chatId: string) => `${accountId}:${chatId}`;
+const lastOpenedChatStorageKey = (accountId: string) => `vyline:last-opened-chat:${accountId}`;
+
+function readLastOpenedChat(accountId: string): string | null {
+  try {
+    return localStorage.getItem(lastOpenedChatStorageKey(accountId));
+  } catch {
+    return null;
+  }
+}
+
+function rememberLastOpenedChat(accountId: string, chatId: string): void {
+  try {
+    localStorage.setItem(lastOpenedChatStorageKey(accountId), chatId);
+  } catch {
+    /* localStorage may be unavailable in restricted browser contexts */
+  }
+}
 
 // push が機能しない環境でもアクティブチャットの受信を保証するための間隔
 const DELTA_POLL_MIN_MS = 10_000;
@@ -521,6 +538,7 @@ export const useStore = create<State>()(
       setAccountId: (id) => {
         const currentAccountId = get().accountId;
         const accountChanged = id !== currentAccountId;
+        const lastOpenedChatId = id ? readLastOpenedChat(id) : null;
         if (accountChanged) {
           contactFetched.clear();
           readReceiptSent.clear();
@@ -538,7 +556,7 @@ export const useStore = create<State>()(
             accountId: id,
             chats: [],
             messages: [],
-            activeChatId: null,
+            activeChatId: lastOpenedChatId,
             initialChatScrollMessageId: null,
             memberProfile: null,
             readWatermarks: {},
@@ -546,7 +564,10 @@ export const useStore = create<State>()(
             blockedMids: [],
           });
         } else {
-          set({ accountId: id });
+          set({
+            accountId: id,
+            ...(accountChanged && lastOpenedChatId ? { activeChatId: lastOpenedChatId } : {}),
+          });
         }
       },
 
@@ -594,6 +615,8 @@ export const useStore = create<State>()(
 
       openChat: (id) => {
         sessionOpenedChats.add(id);
+        const { accountId } = get();
+        if (accountId) rememberLastOpenedChat(accountId, id);
         get()._activateChat(id, { history: true });
       },
 

--- a/Vyline/apps/desktop/src/lib/store.ts
+++ b/Vyline/apps/desktop/src/lib/store.ts
@@ -519,7 +519,9 @@ export const useStore = create<State>()(
       },
 
       setAccountId: (id) => {
-        if (id !== get().accountId) {
+        const currentAccountId = get().accountId;
+        const accountChanged = id !== currentAccountId;
+        if (accountChanged) {
           contactFetched.clear();
           readReceiptSent.clear();
           readReceiptInflight.clear();
@@ -529,7 +531,7 @@ export const useStore = create<State>()(
           sessionOpenedChats.clear();
           eventPollCursor.delete(String(id));
         }
-        if (id !== get().accountId) {
+        if (accountChanged && currentAccountId !== null) {
           // アカウント切替時に前アカウントの会話・既読・一時 UI を残さない。
           // 共有 MID をまたぐ表示漏れを防ぎ、後続 hydrate の正本を明確にする。
           set({

--- a/Vyline/apps/desktop/src/lib/store.ts
+++ b/Vyline/apps/desktop/src/lib/store.ts
@@ -552,7 +552,6 @@ export const useStore = create<State>()(
         set({
           chats: [],
           messages: [],
-          activeChatId: null,
           profileDrawerOpen: false,
           announcements: {},
           drafts: {},


### PR DESCRIPTION
## Summary

- Save the MID of every chat activation in account-scoped local storage.
- Resolve the startup chat in one place with this precedence: saved chat MID, valid persisted active MID, then the first chat returned by the API.
- Apply the same resolution during bootstrap cache loading, normal chat loading, and store hydration, so the newest chat-list entry cannot overwrite the saved selection.
- Keep account switching isolated: a saved chat is only restored when it belongs to the active account and is present in the current chat list.

## Root cause

The previous implementation had independent selection paths. `useLineData` selected the first chat in the API response while the store attempted to restore `activeChatId`. Since LINE returns the newest chat first, the two paths raced and the newest chat could win.

## Verification

- `bun test` — 238 passed
- `bun run --cwd Vyline/apps/desktop typecheck`
- Targeted Biome check
- Pre-push typecheck, lint, and production build checks passed