### PR TITLE
fix: restore saved chat before list fallback

### DIFF
--- a/Vyline/apps/desktop/src/hooks/useLineData.ts
+++ b/Vyline/apps/desktop/src/hooks/useLineData.ts
@@ -18,7 +18,7 @@ import {
   vylineClientPutMany,
   vylineClientToContactMap,
 } from "../lib/vyline-cache.js";
-import { useStore } from "../lib/store.js";
+import { resolveChatToOpen, useStore } from "../lib/store.js";
 
 interface UseLineDataOptions {
   accountId: string | null;
@@ -166,7 +166,12 @@ export function useLineData({ accountId }: UseLineDataOptions) {
         if (accountIdRef.current !== accountId) return;
         if (res.ok && res.chats?.length) {
           setChats(res.chats);
-          setSelectedChatMid((prev) => prev || res.chats?.[0]?.mid || "");
+          const initialChatMid = resolveChatToOpen(
+            accountId,
+            useStore.getState().activeChatId,
+            res.chats.map((chat) => chat.mid),
+          );
+          setSelectedChatMid((prev) => prev || initialChatMid || "");
           applyChatsToContactCache(res.chats);
           setFromLocalCache(Boolean(res.fromCache));
           const warmTargets = res.chats
@@ -342,7 +347,12 @@ export function useLineData({ accountId }: UseLineDataOptions) {
         setChats(res.chats);
         setFromLocalCache(true);
         applyChatsToContactCache(res.chats);
-        setSelectedChatMid((prev) => prev || res.chats[0]?.mid || "");
+        const initialChatMid = resolveChatToOpen(
+          accountId,
+          useStore.getState().activeChatId,
+          res.chats.map((chat) => chat.mid),
+        );
+        setSelectedChatMid((prev) => prev || initialChatMid || "");
       }
     } catch {
       /* bootstrap optional */
@@ -362,7 +372,7 @@ export function useLineData({ accountId }: UseLineDataOptions) {
       const restoreTarget = restoredChatMids[0];
       if (restoreTarget) {
         setSelectedChatMid(restoreTarget);
-        useStore.setState({ activeChatId: restoreTarget, screen: "chat" });
+        useStore.getState()._activateChat(restoreTarget);
       }
       void (async () => {
         await loadBootstrap();

--- a/Vyline/apps/desktop/src/lib/store.test.ts
+++ b/Vyline/apps/desktop/src/lib/store.test.ts
@@ -1,7 +1,23 @@
 import { describe, expect, it } from "bun:test";
-import { useStore } from "./store.js";
+import { resolveChatToOpen, useStore } from "./store.js";
 
 describe("useStore account initialization", () => {
+  it("records every activated chat for the next startup", () => {
+    const storage = new Map<string, string>();
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => storage.set(key, value),
+      },
+    });
+    useStore.setState({ accountId: "account-1", demoMode: true, activeChatId: null });
+
+    useStore.getState()._activateChat("chat-last-opened", { history: false });
+
+    expect(storage.get("vyline:last-opened-chat:account-1")).toBe("chat-last-opened");
+  });
+
   it("restores the account's explicitly last opened chat before chat loading", () => {
     const storage = new Map<string, string>([
       ["vyline:last-opened-chat:account-1", "chat-last-opened"],
@@ -18,6 +34,23 @@ describe("useStore account initialization", () => {
     useStore.getState().setAccountId("account-1");
 
     expect(useStore.getState().activeChatId).toBe("chat-last-opened");
+  });
+
+  it("chooses the saved chat instead of the newest chat-list entry", () => {
+    const storage = new Map<string, string>([
+      ["vyline:last-opened-chat:account-1", "chat-last-opened"],
+    ]);
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => storage.set(key, value),
+      },
+    });
+
+    expect(resolveChatToOpen("account-1", null, ["chat-newest-message", "chat-last-opened"])).toBe(
+      "chat-last-opened",
+    );
   });
 
   it("keeps the last opened chat when the persisted account is initialized", () => {

--- a/Vyline/apps/desktop/src/lib/store.ts
+++ b/Vyline/apps/desktop/src/lib/store.ts
@@ -98,6 +98,19 @@ function rememberLastOpenedChat(accountId: string, chatId: string): void {
   }
 }
 
+/** 起動時の選択候補は、明示保存したチャットを常に優先する。 */
+export function resolveChatToOpen(
+  accountId: string | null,
+  activeChatId: string | null,
+  availableChatIds: readonly string[],
+): string | null {
+  const rememberedChatId = accountId ? readLastOpenedChat(accountId) : null;
+  for (const chatId of [rememberedChatId, activeChatId]) {
+    if (chatId && availableChatIds.includes(chatId)) return chatId;
+  }
+  return availableChatIds[0] ?? null;
+}
+
 // push が機能しない環境でもアクティブチャットの受信を保証するための間隔
 const DELTA_POLL_MIN_MS = 10_000;
 
@@ -618,12 +631,14 @@ export const useStore = create<State>()(
 
       openChat: (id) => {
         sessionOpenedChats.add(id);
-        const { accountId } = get();
-        if (accountId) rememberLastOpenedChat(accountId, id);
         get()._activateChat(id, { history: true });
       },
 
       _activateChat: (id, opts) => {
+        if (!id) {
+          get().closeChat();
+          return;
+        }
         const opts2 = opts ?? {};
         const firstUnread = get()
           .messages.filter((m) => m.chatId === id && m.authorId !== "me" && !m.read)
@@ -646,6 +661,7 @@ export const useStore = create<State>()(
           chats: st.chats.map((c) => (c.id === id ? { ...c, unread: 0 } : c)),
         }));
         const { accountId, settings, chats, demoMode } = get();
+        if (accountId) rememberLastOpenedChat(accountId, id);
         if (demoMode) return;
         if (accountId && settings.readReceipts) {
           void get().markChatRead(id);
@@ -801,10 +817,10 @@ export const useStore = create<State>()(
           if (prev) hiddenByPrev.set(c.id, prev.hidden ?? false);
         });
 
-        const chatId =
-          activeChatId && (!dismissed.has(activeChatId) || restored.has(activeChatId))
-            ? activeChatId
-            : (mappedChats[0]?.id ?? null);
+        const visibleChatIds = mappedChats
+          .filter((chat) => !dismissed.has(chat.id) || restored.has(chat.id))
+          .map((chat) => chat.id);
+        const chatId = resolveChatToOpen(accountId, activeChatId, visibleChatIds);
         // 1on1 の受信メッセージは from=相手(chatId)/to=自分 になるため、from 側も対象に含める
         const chatMessageFilter = (m: LineMessage) => !m.to || m.to === chatId || m.from === chatId;
         const mappedMessages =
@@ -863,7 +879,7 @@ export const useStore = create<State>()(
             const keep = pending.filter((p) => !ids.has(p.id));
             return [...mappedMessages, ...keep];
           })(),
-          activeChatId: st.activeChatId ?? chatId,
+          activeChatId: chatId,
           customOrder: st.customOrder.length ? st.customOrder : mappedChats.map((c) => c.id),
           self: profile
             ? {
@@ -1819,6 +1835,7 @@ export const useStore = create<State>()(
           activeChatId: memberMid,
         });
         const { accountId, settings } = get();
+        if (accountId) rememberLastOpenedChat(accountId, memberMid);
         if (accountId && settings.readReceipts) {
           void get().markChatRead(memberMid);
         }


### PR DESCRIPTION
## Summary

- Save the MID of every chat activation in account-scoped local storage.
- Resolve the startup chat in one place with this precedence: saved chat MID, valid persisted active MID, then the first chat returned by the API.
- Apply the same resolution during bootstrap cache loading, normal chat loading, and store hydration, so the newest chat-list entry cannot overwrite the saved selection.
- Keep account switching isolated: a saved chat is only restored when it belongs to the active account and is present in the current chat list.

## Root cause

`useLineData` selected the first chat in the API response independently of the store restore path. LINE returns the newest chat first, so that path could race with and overwrite the intended last-opened chat.

## Verification

- `bun test` — 238 passed
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- Pre-push checks passed