### PR TITLE
feat: add account handoff and diagnostics workflows

### DIFF
--- a/Vyline/apps/desktop/src/api/client.ts
+++ b/Vyline/apps/desktop/src/api/client.ts
@@ -1136,4 +1136,33 @@ export const api = {
         { step, settings },
       ),
   },
+  handoff: {
+    export: (mid: string) =>
+      request<{ ok: boolean; filename: string; archiveBase64: string; manifest: unknown }>(
+        "POST",
+        `/handoff/${encodeURIComponent(mid)}/export`,
+        {},
+        { "x-vyline-platform": "desktop" },
+      ),
+    import: (mid: string, archiveBase64: string, mode: "overwrite" | "merge" | "cancel") =>
+      request<{ ok: boolean; imported: string[]; manifest: unknown }>(
+        "POST",
+        `/handoff/${encodeURIComponent(mid)}/import`,
+        { archiveBase64, mode },
+      ),
+  },
+  diagnostics: {
+    list: (mid: string) =>
+      request<{ ok: boolean; entries: unknown[] }>(
+        "GET",
+        `/diagnostics/${encodeURIComponent(mid)}`,
+      ),
+    clear: (mid: string) =>
+      request<{ ok: boolean }>("DELETE", `/diagnostics/${encodeURIComponent(mid)}`),
+    export: (mid: string) =>
+      request<{ ok: boolean; content: string }>(
+        "GET",
+        `/diagnostics/${encodeURIComponent(mid)}/export`,
+      ),
+  },
 };

--- a/Vyline/apps/desktop/src/components/settings-sections.tsx
+++ b/Vyline/apps/desktop/src/components/settings-sections.tsx
@@ -63,7 +63,8 @@ type Section =
   | "subdevices"
   | "storage"
   | "info"
-  | "beta";
+  | "beta"
+  | "handoff";
 
 const NAV: { key: Section; label: string; icon: React.ReactNode }[] = [
   { key: "profile", label: "プロフィール", icon: <IconEdit size={18} /> },
@@ -77,6 +78,7 @@ const NAV: { key: Section; label: string; icon: React.ReactNode }[] = [
   { key: "storage", label: "ストレージ", icon: <IconHardDrive size={18} /> },
   { key: "info", label: "情報", icon: <IconSpark size={18} /> },
   { key: "beta", label: "ベータ機能", icon: <IconSpark size={18} /> },
+  { key: "handoff", label: "引継ぎ・診断", icon: <IconDownload size={18} /> },
 ];
 
 function Row({
@@ -564,6 +566,8 @@ export function SettingsSections() {
 
               {section === "info" && <InfoSection />}
 
+              {section === "handoff" && <HandoffSection />}
+
               {section === "beta" && (
                 <>
                   <BetaSection />
@@ -576,6 +580,151 @@ export function SettingsSections() {
         </div>
       </div>
     </div>
+  );
+}
+
+function HandoffSection() {
+  const accountId = useStore((s) => s.accountId);
+  const [message, setMessage] = useState<string | null>(null);
+  const [entries, setEntries] = useState<unknown[]>([]);
+  const download = (name: string, content: BlobPart, type: string) => {
+    const url = URL.createObjectURL(new Blob([content], { type }));
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = name;
+    anchor.click();
+    URL.revokeObjectURL(url);
+  };
+  const exportHandoff = async () => {
+    if (!accountId) return setMessage("ログインが必要です");
+    const result = await api.handoff.export(accountId);
+    const bytes = Uint8Array.from(atob(result.archiveBase64), (char) => char.charCodeAt(0));
+    download(result.filename, bytes, "application/zip");
+    setMessage("引継ぎZIPを作成しました");
+  };
+  const importHandoff = () => {
+    if (!accountId) return setMessage("ログインが必要です");
+    const input = document.createElement("input");
+    input.type = "file";
+    input.accept = ".zip";
+    input.onchange = async () => {
+      const file = input.files?.[0];
+      if (!file) return;
+      const data = btoa(String.fromCharCode(...new Uint8Array(await file.arrayBuffer())));
+      const result = await api.handoff.import(accountId, data, "overwrite");
+      setMessage(
+        result.ok ? "引継ぎを適用しました。必要なら再起動してください" : "引継ぎに失敗しました",
+      );
+    };
+    input.click();
+  };
+  const exportLogs = async () => {
+    if (!accountId) return setMessage("ログインが必要です");
+    const result = await api.diagnostics.export(accountId);
+    download("vyline-diagnostics.json", result.content, "application/json");
+    setMessage("サニタイズ済みログを出力しました");
+  };
+  const loadLogs = async () => {
+    if (!accountId) return setMessage("ログインが必要です");
+    const result = await api.diagnostics.list(accountId);
+    setEntries(result.entries);
+    setMessage(`${result.entries.length}件のログを読み込みました`);
+  };
+  const reportIssue = async () => {
+    if (!accountId) return setMessage("ログインが必要です");
+    const result = await api.diagnostics.export(accountId);
+    const body = [
+      "## 問題の概要",
+      "",
+      "（ここに問題を記入してください）",
+      "",
+      "## Vyline診断情報",
+      "",
+      "```json",
+      result.content.slice(0, 12000),
+      "```",
+      "",
+    ].join("\n");
+    const url = `https://github.com/nezumi0627/vyline/issues/new?title=${encodeURIComponent("Vyline issue")}&body=${encodeURIComponent(body)}`;
+    window.open(url, "_blank", "noopener,noreferrer");
+  };
+  return (
+    <>
+      <Section
+        title="引継ぎ"
+        desc="設定だけを安全に別のVylineへ移行します。認証情報やトークンは含みません。"
+      >
+        <Card>
+          <Row title="引継ぎZIPを作成" desc="manifestと改ざん検知用ハッシュを含めます">
+            <button
+              type="button"
+              onClick={() => void exportHandoff()}
+              className="rounded-lg border border-[var(--vy-border)] px-3 py-1.5 text-xs"
+            >
+              エクスポート
+            </button>
+          </Row>
+          <Row title="引継ぎZIPを適用" desc="適用前に既存設定をバックアップします">
+            <button
+              type="button"
+              onClick={importHandoff}
+              className="rounded-lg border border-[var(--vy-border)] px-3 py-1.5 text-xs"
+            >
+              インポート
+            </button>
+          </Row>
+        </Card>
+      </Section>
+      <Section title="デバッグログ" desc="共有前にサニタイズされた診断情報だけを出力します">
+        <Card>
+          <Row title="ログをエクスポート" desc="GitHub Issue作成画面へ貼り付けられるJSONです">
+            <button
+              type="button"
+              onClick={() => void exportLogs()}
+              className="rounded-lg border border-[var(--vy-border)] px-3 py-1.5 text-xs"
+            >
+              出力
+            </button>
+          </Row>
+          <Row title="ログ一覧" desc="共有前にサニタイズ済みの内容を確認します">
+            <button
+              type="button"
+              onClick={() => void loadLogs()}
+              className="rounded-lg border border-[var(--vy-border)] px-3 py-1.5 text-xs"
+            >
+              確認
+            </button>
+          </Row>
+          <Row title="GitHubで問題を報告" desc="ログを自動添付したIssue作成画面を開きます">
+            <button
+              type="button"
+              onClick={() => void reportIssue()}
+              className="rounded-lg border border-[var(--vy-border)] px-3 py-1.5 text-xs"
+            >
+              Issue作成
+            </button>
+          </Row>
+          <Row title="ログを削除" desc="保存済みの診断ログを削除します">
+            <button
+              type="button"
+              onClick={() =>
+                accountId &&
+                void api.diagnostics.clear(accountId).then(() => setMessage("ログを削除しました"))
+              }
+              className="rounded-lg border border-red-400/50 px-3 py-1.5 text-xs text-red-300"
+            >
+              削除
+            </button>
+          </Row>
+        </Card>
+        {entries.length > 0 && (
+          <pre className="mt-3 max-h-56 overflow-auto rounded-xl bg-[var(--vy-bg)] p-3 text-[0.65rem] text-[var(--vy-text-dim)]">
+            {JSON.stringify(entries, null, 2)}
+          </pre>
+        )}
+      </Section>
+      {message && <p className="mt-3 text-xs text-[var(--vy-text-dim)]">{message}</p>}
+    </>
   );
 }
 

--- a/Vyline/backend/package.json
+++ b/Vyline/backend/package.json
@@ -9,10 +9,11 @@
     "typecheck": "node ./node_modules/typescript/bin/tsc --noEmit"
   },
   "dependencies": {
-    "@vyline/plugin-sdk": "workspace:*",
     "@vyline/ios-backup": "workspace:*",
+    "@vyline/plugin-sdk": "workspace:*",
     "@vyline/protocol": "workspace:*",
     "@vyline/types": "workspace:*",
+    "fflate": "^0.8.3",
     "hono": "^4.7.11",
     "pino": "^9.6.0",
     "pino-pretty": "^13.0.0"

--- a/Vyline/backend/src/api/diagnostics.ts
+++ b/Vyline/backend/src/api/diagnostics.ts
@@ -1,0 +1,29 @@
+import { Hono } from "hono";
+import type { Context } from "hono";
+import {
+  clearDiagnostics,
+  exportDiagnostics,
+  listDiagnostics,
+} from "../service/diagnosticsService.js";
+
+export const diagnosticsRouter = new Hono();
+const MID = /^u[0-9a-f]{32}$/i;
+function valid(c: Context) {
+  return MID.test(c.req.param("mid") ?? "");
+}
+diagnosticsRouter.get("/:mid/export", async (c) => {
+  if (!valid(c)) return c.json({ ok: false, error: "invalid account MID" }, 422);
+  return c.json({ ok: true, content: await exportDiagnostics(c.req.param("mid") ?? "") });
+});
+diagnosticsRouter.get("/:mid", async (c) => {
+  if (!valid(c)) return c.json({ ok: false, error: "invalid account MID" }, 422);
+  return c.json({
+    ok: true,
+    entries: await listDiagnostics(c.req.param("mid") ?? "", Number(c.req.query("limit") ?? 200)),
+  });
+});
+diagnosticsRouter.delete("/:mid", async (c) => {
+  if (!valid(c)) return c.json({ ok: false, error: "invalid account MID" }, 422);
+  await clearDiagnostics(c.req.param("mid") ?? "");
+  return c.json({ ok: true });
+});

--- a/Vyline/backend/src/api/handoff.ts
+++ b/Vyline/backend/src/api/handoff.ts
@@ -1,0 +1,36 @@
+import { Hono } from "hono";
+import { exportHandoff, importHandoff } from "../service/handoffService.js";
+
+const MID = /^u[0-9a-f]{32}$/i;
+export const handoffRouter = new Hono();
+
+handoffRouter.post("/:mid/export", async (c) => {
+  const mid = c.req.param("mid");
+  if (!MID.test(mid)) return c.json({ ok: false, error: "invalid account MID" }, 422);
+  try {
+    return c.json({ ok: true, ...(await exportHandoff(mid, c.req.header("x-vyline-platform"))) });
+  } catch (error) {
+    return c.json(
+      { ok: false, error: error instanceof Error ? error.message : String(error) },
+      400,
+    );
+  }
+});
+
+handoffRouter.post("/:mid/import", async (c) => {
+  const mid = c.req.param("mid");
+  if (!MID.test(mid)) return c.json({ ok: false, error: "invalid account MID" }, 422);
+  const body = await c.req.json<{
+    archiveBase64?: string;
+    mode?: "overwrite" | "merge" | "cancel";
+  }>();
+  if (!body.archiveBase64) return c.json({ ok: false, error: "archiveBase64 is required" }, 422);
+  try {
+    return c.json({ ok: true, ...(await importHandoff(mid, body.archiveBase64, body.mode)) });
+  } catch (error) {
+    return c.json(
+      { ok: false, error: error instanceof Error ? error.message : String(error) },
+      400,
+    );
+  }
+});

--- a/Vyline/backend/src/index.ts
+++ b/Vyline/backend/src/index.ts
@@ -28,6 +28,8 @@ import { ensureMediaStorageDir } from "./storage/mediaStorage.js";
 import { subdeviceRouter } from "./api/subdevices.js";
 import { isSubdeviceSessionValid } from "./storage/subdeviceStore.js";
 import { accountSettingsRouter } from "./api/accountSettings.js";
+import { handoffRouter } from "./api/handoff.js";
+import { diagnosticsRouter } from "./api/diagnostics.js";
 
 const PORT = Number(process.env.PORT ?? 3001);
 const LAN_ACCESS = process.env.VYLINE_LAN_ACCESS === "true";
@@ -128,6 +130,8 @@ app.route("/api/beta/agent-i", agentIRouter);
 app.route("/api/debug", debugRouter);
 app.route("/api/cdn", cdnRouter);
 app.route("/api/settings/accounts", accountSettingsRouter);
+app.route("/api/handoff", handoffRouter);
+app.route("/api/diagnostics", diagnosticsRouter);
 
 // 公開 REST API（Bearer トークン認証）
 app.route("/v1", publicRouter);

--- a/Vyline/backend/src/service/diagnosticsService.ts
+++ b/Vyline/backend/src/service/diagnosticsService.ts
@@ -1,0 +1,46 @@
+import { existsSync } from "node:fs";
+import { appendFile, mkdir, readFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import type { DebugContext } from "@vyline/types";
+import { redactForDiagnostics } from "./redaction.js";
+import { safePathComponent } from "../storage/safeFile.js";
+
+const DATA_DIR = process.env.VYLINE_DATA_DIR ?? join(import.meta.dir, "..", "..", "data");
+const LOG_DIR = process.env.VYLINE_LOG_DIR ?? join(DATA_DIR, "logs");
+function logPath(mid: string): string {
+  return join(LOG_DIR, `diagnostics-${safePathComponent(mid)}.jsonl`);
+}
+
+export async function appendDiagnostic(
+  mid: string,
+  context: DebugContext,
+  details?: unknown,
+): Promise<void> {
+  await mkdir(LOG_DIR, { recursive: true });
+  const entry = redactForDiagnostics({ ...context, details, at: new Date().toISOString() });
+  await appendFile(logPath(mid), `${JSON.stringify(entry)}\n`, "utf8");
+}
+
+export async function listDiagnostics(mid: string, limit = 200): Promise<unknown[]> {
+  const path = logPath(mid);
+  if (!existsSync(path)) return [];
+  const lines = (await readFile(path, "utf8"))
+    .split("\n")
+    .filter(Boolean)
+    .slice(-Math.min(limit, 1000));
+  return lines.flatMap((line) => {
+    try {
+      return [JSON.parse(line)];
+    } catch {
+      return [];
+    }
+  });
+}
+
+export async function clearDiagnostics(mid: string): Promise<void> {
+  await rm(logPath(mid), { force: true });
+}
+
+export async function exportDiagnostics(mid: string): Promise<string> {
+  return JSON.stringify(await listDiagnostics(mid, 1000), null, 2);
+}

--- a/Vyline/backend/src/service/handoffService.test.ts
+++ b/Vyline/backend/src/service/handoffService.test.ts
@@ -1,0 +1,23 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+describe("handoff archive", () => {
+  test("exports a verifiable zip and rejects tampering", async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), "vyline-handoff-"));
+    process.env.VYLINE_DATA_DIR = dataDir;
+    const { exportHandoff, importHandoff } = await import("./handoffService.js");
+    const mid = "u1234567890abcdef1234567890abcdef";
+    const exported = await exportHandoff(mid, "web");
+    expect(exported.filename).toMatch(/^[0-9a-f-]+\.zip$/);
+    expect(exported.manifest.account.midHash).toHaveLength(16);
+    await expect(importHandoff(mid, exported.archiveBase64, "overwrite")).resolves.toMatchObject({
+      imported: ["settings.json"],
+    });
+    const tampered = Buffer.from(exported.archiveBase64, "base64");
+    tampered[tampered.length - 1] ^= 1;
+    await expect(importHandoff(mid, tampered.toString("base64"), "overwrite")).rejects.toThrow();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+});

--- a/Vyline/backend/src/service/handoffService.test.ts
+++ b/Vyline/backend/src/service/handoffService.test.ts
@@ -16,7 +16,8 @@ describe("handoff archive", () => {
       imported: ["settings.json"],
     });
     const tampered = Buffer.from(exported.archiveBase64, "base64");
-    tampered[tampered.length - 1] ^= 1;
+    const last = tampered.length - 1;
+    tampered[last] = (tampered[last] ?? 0) ^ 1;
     await expect(importHandoff(mid, tampered.toString("base64"), "overwrite")).rejects.toThrow();
     await rm(dataDir, { recursive: true, force: true });
   });

--- a/Vyline/backend/src/service/handoffService.ts
+++ b/Vyline/backend/src/service/handoffService.ts
@@ -1,0 +1,109 @@
+import { createHash, randomUUID } from "node:crypto";
+import { existsSync } from "node:fs";
+import { mkdir, rename, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { zipSync, unzipSync, strFromU8, strToU8 } from "fflate";
+import {
+  HANDOFF_FORMAT,
+  HANDOFF_VERSION,
+  type HandoffManifest,
+  type Platform,
+} from "@vyline/types";
+import { accountFile, accountDir } from "../storage/accountDirs.js";
+import { safePathComponent, writeJsonAtomic } from "../storage/safeFile.js";
+import { loadAccountSettings } from "./accountSettingsService.js";
+import { anonymousId } from "./redaction.js";
+
+const MAX_ARCHIVE_BYTES = 5 * 1024 * 1024;
+const DATA_DIR = process.env.VYLINE_DATA_DIR ?? join(import.meta.dir, "..", "..", "data");
+
+function sha256(data: Uint8Array): string {
+  return createHash("sha256").update(data).digest("hex");
+}
+
+function platform(value: unknown): Platform {
+  return value === "web" ? "web" : "desktop";
+}
+
+export async function exportHandoff(
+  mid: string,
+  sourcePlatform: unknown = "desktop",
+): Promise<{ filename: string; archiveBase64: string; manifest: HandoffManifest }> {
+  const settings = strToU8(JSON.stringify(await loadAccountSettings(mid), null, 2));
+  const files = [{ path: "settings.json", data: settings }];
+  const manifest: HandoffManifest = {
+    format: HANDOFF_FORMAT,
+    version: HANDOFF_VERSION,
+    handoffId: randomUUID(),
+    source: {
+      platform: platform(sourcePlatform),
+      appVersion: process.env.npm_package_version ?? "dev",
+      schemaVersion: 1,
+    },
+    createdAt: new Date().toISOString(),
+    account: { midHash: anonymousId(mid) },
+    files: files.map(({ path, data }) => ({ path, sha256: sha256(data), size: data.byteLength })),
+    encryption: { mode: "none" },
+  };
+  const archive = zipSync({
+    "manifest.json": strToU8(JSON.stringify(manifest, null, 2)),
+    ...Object.fromEntries(files.map(({ path, data }) => [path, data])),
+  });
+  if (archive.byteLength > MAX_ARCHIVE_BYTES) throw new Error("handoff archive is too large");
+  return {
+    filename: `${manifest.handoffId}.zip`,
+    archiveBase64: Buffer.from(archive).toString("base64"),
+    manifest,
+  };
+}
+
+export async function importHandoff(
+  mid: string,
+  archiveBase64: string,
+  mode: "overwrite" | "merge" | "cancel" = "cancel",
+): Promise<{ manifest: HandoffManifest; imported: string[] }> {
+  if (mode === "cancel") throw new Error("import cancelled");
+  const archive = Buffer.from(archiveBase64, "base64");
+  if (archive.byteLength > MAX_ARCHIVE_BYTES) throw new Error("handoff archive is too large");
+  const entries = unzipSync(archive);
+  const manifestBytes = entries["manifest.json"];
+  if (!manifestBytes) throw new Error("manifest.json is required");
+  const manifest = JSON.parse(strFromU8(manifestBytes)) as HandoffManifest;
+  if (manifest.format !== HANDOFF_FORMAT || manifest.version !== HANDOFF_VERSION)
+    throw new Error("unsupported handoff format");
+  if (!manifest.handoffId || !Array.isArray(manifest.files) || manifest.encryption?.mode !== "none")
+    throw new Error("invalid handoff manifest");
+  for (const file of manifest.files) {
+    if (!/^[-a-zA-Z0-9_.]+$/.test(file.path) || file.path.includes(".."))
+      throw new Error("unsafe handoff path");
+    const data = entries[file.path];
+    if (!data || data.byteLength !== file.size || sha256(data) !== file.sha256)
+      throw new Error(`handoff integrity check failed: ${file.path}`);
+  }
+  const settingsData = entries["settings.json"];
+  if (!settingsData) throw new Error("settings.json is required");
+  const incoming = JSON.parse(strFromU8(settingsData)) as Record<string, unknown>;
+  const current = await loadAccountSettings(mid);
+  const next = mode === "merge" ? { ...current, ...incoming } : incoming;
+  const dir = accountDir(mid);
+  await mkdir(dir, { recursive: true });
+  const backup = join(
+    DATA_DIR,
+    "accounts",
+    `${safePathComponent(mid)}.handoff-backup-${Date.now()}`,
+  );
+  const currentPath = accountFile(mid, "settings.json");
+  if (existsSync(currentPath)) await rename(currentPath, backup);
+  try {
+    await writeJsonAtomic(currentPath, next);
+  } catch (error) {
+    if (existsSync(backup)) await rename(backup, currentPath).catch(() => undefined);
+    throw error;
+  }
+  await rm(backup, { force: true }).catch(() => undefined);
+  await writeFile(
+    accountFile(mid, "handoff.json"),
+    JSON.stringify({ handoffId: manifest.handoffId, importedAt: new Date().toISOString() }),
+  );
+  return { manifest, imported: ["settings.json"] };
+}

--- a/Vyline/backend/src/storage/accountDirs.ts
+++ b/Vyline/backend/src/storage/accountDirs.ts
@@ -11,8 +11,9 @@
  */
 
 import { existsSync } from "node:fs";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
+import { writeJsonAtomic } from "./safeFile.js";
 
 const DATA_DIR = process.env.VYLINE_DATA_DIR ?? join(import.meta.dir, "..", "..", "data");
 const ACCOUNTS_ROOT = join(DATA_DIR, "accounts");
@@ -59,7 +60,7 @@ export function ensureAccount(accountId: string): void {
         dirName: safeId(accountId),
         registeredAt: new Date().toISOString(),
       });
-      require("node:fs").writeFileSync(REGISTRY_PATH, JSON.stringify(reg, null, 2), "utf8");
+      void writeJsonAtomic(REGISTRY_PATH, reg);
     }
   } catch {
     /* レジストリ失敗はデータ分離に影響させない */
@@ -88,7 +89,7 @@ export async function readAccountJson<T>(
     try {
       const parsed = JSON.parse(await readFile(legacyPath, "utf8")) as T;
       await mkdir(dirname(newPath), { recursive: true });
-      await writeFile(newPath, JSON.stringify(parsed), "utf8");
+      await writeJsonAtomic(newPath, parsed);
       return parsed;
     } catch {
       return null;

--- a/Vyline/backend/src/storage/secureStore.ts
+++ b/Vyline/backend/src/storage/secureStore.ts
@@ -1,0 +1,35 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+/** Windows DesktopではDPAPI(CurrentUser)でユーザーごとの秘密として保存する。 */
+export async function protectSecret(value: string): Promise<string> {
+  if (process.platform !== "win32")
+    throw new Error("OS secure storage is only available on Windows");
+  const script =
+    "$b=[Convert]::FromBase64String($args[0]); [Convert]::ToBase64String([Security.Cryptography.ProtectedData]::Protect($b,$null,[Security.Cryptography.DataProtectionScope]::CurrentUser))";
+  const { stdout } = await execFileAsync("powershell.exe", [
+    "-NoProfile",
+    "-NonInteractive",
+    "-Command",
+    script,
+    Buffer.from(value).toString("base64"),
+  ]);
+  return stdout.trim();
+}
+
+export async function unprotectSecret(value: string): Promise<string> {
+  if (process.platform !== "win32")
+    throw new Error("OS secure storage is only available on Windows");
+  const script =
+    "$b=[Convert]::FromBase64String($args[0]); [Text.Encoding]::UTF8.GetString([Security.Cryptography.ProtectedData]::Unprotect($b,$null,[Security.Cryptography.DataProtectionScope]::CurrentUser))";
+  const { stdout } = await execFileAsync("powershell.exe", [
+    "-NoProfile",
+    "-NonInteractive",
+    "-Command",
+    script,
+    value,
+  ]);
+  return stdout.trim();
+}

--- a/Vyline/backend/src/storage/tokenStore.ts
+++ b/Vyline/backend/src/storage/tokenStore.ts
@@ -23,6 +23,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { childLogger } from "../logger.js";
+import { protectSecret, unprotectSecret } from "./secureStore.js";
 
 const log = childLogger("tokenStore");
 
@@ -32,6 +33,7 @@ const TOKENS_FILE = join(DATA_DIR, "tokens.json");
 
 export interface TokenEntry {
   authToken: string;
+  authTokenProtected?: string;
   /** VylineFileStorage のパス */
   storageFile: string;
   savedAt: string;
@@ -49,6 +51,16 @@ export interface TokenEntry {
 }
 
 export type TokenMap = Record<string, TokenEntry>;
+
+async function persistTokens(tokens: TokenMap): Promise<void> {
+  const persisted = Object.fromEntries(
+    Object.entries(tokens).map(([id, entry]) => {
+      const { authToken: _plain, ...safeEntry } = entry;
+      return [id, entry.authTokenProtected ? safeEntry : entry];
+    }),
+  );
+  await writeFile(TOKENS_FILE, JSON.stringify(persisted, null, 2), "utf-8");
+}
 
 export type SessionMeta = {
   mid?: string;
@@ -80,7 +92,10 @@ export async function loadTokens(): Promise<TokenMap> {
     // 空トークンのゴミを除外
     const cleaned: TokenMap = {};
     for (const [id, entry] of Object.entries(parsed)) {
-      if (entry?.authToken && typeof entry.authToken === "string") {
+      if (entry?.authTokenProtected && typeof entry.authTokenProtected === "string") {
+        const token = await unprotectSecret(entry.authTokenProtected);
+        cleaned[id] = { ...entry, authToken: token };
+      } else if (entry?.authToken && typeof entry.authToken === "string") {
         cleaned[id] = entry;
       }
     }
@@ -123,6 +138,13 @@ export async function saveToken(
     storageFile: existing?.storageFile ?? join(DATA_DIR, `storage-${accountId}.json`),
     savedAt: new Date().toISOString(),
   };
+  try {
+    entry.authTokenProtected = await protectSecret(token);
+  } catch (error) {
+    if (process.platform === "win32") throw error;
+    entry.authToken = token;
+    log.warn("OS secure storage unavailable; token is stored only for local development");
+  }
   const mid = meta?.mid ?? existing?.mid;
   const displayName = meta?.displayName ?? existing?.displayName;
   const picturePath = meta?.picturePath ?? existing?.picturePath;
@@ -135,7 +157,7 @@ export async function saveToken(
   if (premium) entry.premium = premium;
   tokens[accountId] = entry;
 
-  await writeFile(TOKENS_FILE, JSON.stringify(tokens, null, 2), "utf-8");
+  await persistTokens(tokens);
   log.info({ accountId, displayName: entry.displayName, mid: entry.mid }, "token saved");
 }
 
@@ -150,13 +172,13 @@ export async function updateSessionMeta(accountId: string, meta: SessionMeta): P
   if (meta.premium != null) existing.premium = meta.premium;
   existing.savedAt = new Date().toISOString();
   tokens[accountId] = existing;
-  await writeFile(TOKENS_FILE, JSON.stringify(tokens, null, 2), "utf-8");
+  await persistTokens(tokens);
 }
 
 export async function deleteToken(accountId: string): Promise<void> {
   const tokens = await loadTokens();
   delete tokens[accountId];
-  await writeFile(TOKENS_FILE, JSON.stringify(tokens, null, 2), "utf-8");
+  await persistTokens(tokens);
   log.info({ accountId }, "token deleted");
 }
 
@@ -192,7 +214,7 @@ export async function listSavedSessions(): Promise<
       } = {
         accountId,
         savedAt: entry.savedAt,
-        hasToken: Boolean(entry.authToken),
+        hasToken: Boolean(entry.authToken || entry.authTokenProtected),
       };
       if (entry.mid) row.mid = entry.mid;
       if (entry.displayName) row.displayName = entry.displayName;

--- a/bun.lock
+++ b/bun.lock
@@ -44,6 +44,7 @@
         "@vyline/plugin-sdk": "workspace:*",
         "@vyline/protocol": "workspace:*",
         "@vyline/types": "workspace:*",
+        "fflate": "^0.8.3",
         "hono": "^4.7.11",
         "pino": "^9.6.0",
         "pino-pretty": "^13.0.0",
@@ -494,6 +495,8 @@
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fflate": ["fflate@0.8.3", "", {}, "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="],
 
     "file-uri-to-path": ["file-uri-to-path@1.0.0", "", {}, "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="],
 

--- a/docs/setup-account-handoff-debug.md
+++ b/docs/setup-account-handoff-debug.md
@@ -16,10 +16,9 @@
 VylineData/
 ├─ accounts/{safe-mid}/settings.json
 ├─ accounts/{safe-mid}/preferences.json
-├─ accounts/{safe-mid}/debug/
-├─ accounts/{safe-mid}/handoff/
+├─ accounts/{safe-mid}/handoff.json
 ├─ global/app-settings.json
-└─ logs/
+└─ logs/diagnostics-{safe-mid}.jsonl
 ```
 
 認証token、Cookie、パスワード、E2EE鍵、秘密鍵、トーク本文は設定・引継ぎ・共有ログから除外します。旧flat形式は新形式へコピーして移行し、移行失敗時は元データを削除しません。
@@ -30,4 +29,12 @@ VylineData/
 
 ## 実装ステータス
 
-現在のPRでは共通型、MID単位設定API、Setup進捗、原子的保存、診断マスキングを実装します。引継ぎZIP・OS credential store・診断ログUI・GitHub Issueフォームは同じ契約上に段階追加します。
+実装済みのAPIは以下です。
+
+- `POST /api/handoff/:mid/export`: manifest・ファイルSHA-256付きの実ZIPを生成
+- `POST /api/handoff/:mid/import`: ZIP、manifest、対応version、各ファイルのハッシュを検証して適用
+- `GET /api/diagnostics/:mid`: MID単位の診断ログ一覧
+- `GET /api/diagnostics/:mid/export`: サニタイズ済みログを取得
+- `DELETE /api/diagnostics/:mid`: 診断ログを削除
+
+Windowsでは認証tokenをDPAPI(CurrentUser)で保護します。Desktop設定画面には引継ぎ、ログ一覧、ログ出力、ログ削除、GitHub Issue作成画面への導線を追加しています。Issue作成はGitHub APIへtokenを渡さず、サニタイズ済みログを本文にしたIssue作成URLを開きます。


### PR DESCRIPTION
## 概要

PR #117で追加した共通設定基盤を拡張し、Web版・WebView2 Desktop版の双方から利用できる引継ぎ、診断ログ、Issue報告、安全なtoken保存を追加します。

## 実装内容

- 実ZIP形式の引継ぎアーカイブ生成
  - `manifest.json`
  - UUIDファイル名
  - source platform / version / schema
  - 各ファイルのSHA-256
  - token、Cookie、password、秘密鍵、E2EE鍵、本文は含めない
- ZIPインポート時のformat/version/path/hash検証
- 設定上書き前のバックアップと失敗時ロールバック
- Windows DPAPI(CurrentUser)によるtoken保護
- MID単位の診断ログ一覧・削除・サニタイズ済みJSON出力
- 「引継ぎ・診断」設定タブ
- GitHub Issue作成URL生成（GitHub Token不要、サニタイズ済みログのみ）
- 旧アカウントファイルの新レイアウト移行を原子的保存へ統一
- 引継ぎZIPの改ざん検知テスト
- API / 型 / READMEドキュメント更新

## API

- `POST /api/handoff/:mid/export`
- `POST /api/handoff/:mid/import`
- `GET /api/diagnostics/:mid`
- `GET /api/diagnostics/:mid/export`
- `DELETE /api/diagnostics/:mid`

## 検証

- `bun run lint` passed
- backend typecheck passed
- desktop frontend typecheck passed
- renderer build passed
- 実ZIP生成・インポート・改ざん拒否の手動スモーク passed

## セキュリティ

- MIDはAPI境界で検証し、パス要素を安全化
- 引継ぎ内容は設定のみ
- 診断ログはMID別保存
- Issue作成時にGitHub API tokenを使用しない
- Windows tokenはDPAPI保護。非Windows開発環境ではOS secure storage unavailableとして明示的に警告
