### PR TITLE
fix: persist Windows sessions with DPAPI

### DIFF
--- a/Vyline/backend/src/storage/secureStore.test.ts
+++ b/Vyline/backend/src/storage/secureStore.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+
+import { protectSecret, unprotectSecret } from "./secureStore.js";
+
+describe("secureStore", () => {
+  test.skipIf(process.platform !== "win32")(
+    "round-trips a secret through Windows DPAPI",
+    async () => {
+      const secret = `vyline-dpapi-${crypto.randomUUID()}`;
+
+      const protectedValue = await protectSecret(secret);
+
+      expect(protectedValue).not.toBe(secret);
+      await expect(unprotectSecret(protectedValue)).resolves.toBe(secret);
+    },
+  );
+});

--- a/Vyline/backend/src/storage/secureStore.ts
+++ b/Vyline/backend/src/storage/secureStore.ts
@@ -2,34 +2,35 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
+const DPAPI_INPUT_ENV = "VYLINE_DPAPI_INPUT";
+
+async function runDpapi(script: string, input: string): Promise<string> {
+  const { stdout } = await execFileAsync(
+    "powershell.exe",
+    ["-NoProfile", "-NonInteractive", "-Command", script],
+    {
+      // With -Command, trailing CLI values become PowerShell source rather than $args.
+      // Pass the value through the child-only environment instead, keeping it out of
+      // the command line and avoiding script injection from persisted data.
+      env: { ...process.env, [DPAPI_INPUT_ENV]: input },
+    },
+  );
+  return stdout.trim();
+}
 
 /** Windows DesktopではDPAPI(CurrentUser)でユーザーごとの秘密として保存する。 */
 export async function protectSecret(value: string): Promise<string> {
   if (process.platform !== "win32")
     throw new Error("OS secure storage is only available on Windows");
   const script =
-    "$b=[Convert]::FromBase64String($args[0]); [Convert]::ToBase64String([Security.Cryptography.ProtectedData]::Protect($b,$null,[Security.Cryptography.DataProtectionScope]::CurrentUser))";
-  const { stdout } = await execFileAsync("powershell.exe", [
-    "-NoProfile",
-    "-NonInteractive",
-    "-Command",
-    script,
-    Buffer.from(value).toString("base64"),
-  ]);
-  return stdout.trim();
+    "Add-Type -AssemblyName System.Security; $b=[Convert]::FromBase64String($env:VYLINE_DPAPI_INPUT); [Convert]::ToBase64String([Security.Cryptography.ProtectedData]::Protect($b,$null,[Security.Cryptography.DataProtectionScope]::CurrentUser))";
+  return runDpapi(script, Buffer.from(value).toString("base64"));
 }
 
 export async function unprotectSecret(value: string): Promise<string> {
   if (process.platform !== "win32")
     throw new Error("OS secure storage is only available on Windows");
   const script =
-    "$b=[Convert]::FromBase64String($args[0]); [Text.Encoding]::UTF8.GetString([Security.Cryptography.ProtectedData]::Unprotect($b,$null,[Security.Cryptography.DataProtectionScope]::CurrentUser))";
-  const { stdout } = await execFileAsync("powershell.exe", [
-    "-NoProfile",
-    "-NonInteractive",
-    "-Command",
-    script,
-    value,
-  ]);
-  return stdout.trim();
+    "Add-Type -AssemblyName System.Security; $b=[Convert]::FromBase64String($env:VYLINE_DPAPI_INPUT); [Text.Encoding]::UTF8.GetString([Security.Cryptography.ProtectedData]::Unprotect($b,$null,[Security.Cryptography.DataProtectionScope]::CurrentUser))";
+  return runDpapi(script, value);
 }


### PR DESCRIPTION
## 原因
Windows安全ストレージがPowerShellの `-Command` 後に秘密値を渡しており、値が `$args[0]` ではなくPowerShellソースとして解釈されていました。結果としてDPAPI保護が失敗し、ログインセッションを永続化できませんでした。

## 修正
- DPAPI入出力を子プロセス専用の環境変数で渡し、コマンド行から秘密値を除外
- `System.Security` を明示ロードして `ProtectedData` を利用可能にする
- Windows DPAPIの暗号化・復号往復テストを追加

## 検証
- `bun test`（32 pass）
- `bun run typecheck`
- `bun run lint`
- pre-push checks（protocol/backend/frontend typecheck、lint、renderer build）