### PR TITLE
fix: stabilize chat bottom positioning

### DIFF
--- a/Vyline/apps/desktop/src/components/chat-area.tsx
+++ b/Vyline/apps/desktop/src/components/chat-area.tsx
@@ -29,7 +29,6 @@ import {
   IconPin,
 } from "@/components/icons";
 import { AgentIActionDialog } from "@/components/agent-i-action-dialog";
-import { findFirstUnreadMessage } from "@/lib/chatScroll";
 
 function dayLabel(ts: number): string {
   const d = new Date(ts);
@@ -101,7 +100,7 @@ function ChatAreaBase() {
   const memberProfile = useStore((s) => s.memberProfile);
   const highlightMessageId = useStore((s) => s.highlightMessageId);
   const initialChatScrollMessageId = useStore((s) => s.initialChatScrollMessageId);
-  const initialChatScrollMode = useStore((s) => s.initialChatScrollMode);
+  const loadingMessages = useStore((s) => s.loadingMessages);
   const accountId = useStore((s) => s.accountId);
   const scrollToMessage = useStore((s) => s.scrollToMessage);
   const announcements = useStore((s) => s.announcements);
@@ -180,6 +179,14 @@ function ChatAreaBase() {
     [messages, activeChatId],
   );
 
+  const firstUnreadMessageId = useMemo(
+    () =>
+      chat?.unread
+        ? (chatMessages.find((message) => message.authorId !== "me" && !message.read)?.id ?? null)
+        : null,
+    [chat?.unread, chatMessages],
+  );
+
   const matches = useMemo(() => {
     const q = search.q.trim().toLowerCase();
     if (!q) return [] as string[];
@@ -255,8 +262,8 @@ function ChatAreaBase() {
   const {
     containerRef,
     onScroll,
-    hasMeasured,
     visibleRows,
+    hasMeasured,
     topSpacer,
     bottomSpacer,
     rowRef,
@@ -319,55 +326,36 @@ function ChatAreaBase() {
 
   const openedChatRef = useRef<string | null>(null);
 
-  // 開いた瞬間だけ位置を決める。未読があればその先頭、なければ末尾に置き、
-  // 以後の受信・画像の高さ確定・ページ追加では利用者のスクロール位置を動かさない。
+  // 開いた瞬間の基準位置を決める。未読があればその先頭、なければ末尾に置き、
+  // 高さ確定中はその基準を維持する（利用者が操作した後は補正しない）。
   useEffect(() => {
     if (!activeChatId) {
       openedChatRef.current = null;
       return;
     }
-    if (openedChatRef.current === activeChatId) return;
-
-    const fallbackUnread =
-      initialChatScrollMode === "unread" && !initialChatScrollMessageId
-        ? findFirstUnreadMessage(chatMessages)?.id
-        : undefined;
-    const targetId = initialChatScrollMessageId ?? fallbackUnread;
-    if (chatMessages.length === 0) return;
+    // リロード直後はチャットIDだけ復元され、メッセージが後から hydrate される。
+    // 空の状態で初期位置を確定すると、メッセージ到着後に再実行されなくなる。
+    if (!rows.length || openedChatRef.current === activeChatId) return;
     if (!hasMeasured) return;
-    const targetRow = targetId
-      ? rows.find(
-          (row) =>
-            row.key === `msg-${targetId}` ||
-            (row.item.kind === "msg" &&
-              row.item.mediaGroup?.some((message) => message.id === targetId)),
-        )
-      : undefined;
-    if (initialChatScrollMode === "unread" && targetId && !targetRow) {
-      // 未読がまだ読み込まれていない（履歴の奥にある）→ 過去を読み込みつつ上端で待機
-      window.dispatchEvent(
-        new CustomEvent("vyline:load-older-messages", { detail: { chatMid: activeChatId } }),
-      );
-      return;
+    const targetMessageId = firstUnreadMessageId ?? initialChatScrollMessageId;
+    const key = targetMessageId ? `msg-${targetMessageId}` : null;
+    if (key && !rows.some((row) => row.key === key)) {
+      // 初回取得中は、未読位置が分かるまでスクロール位置を確定しない。
+      if (loadingMessages) return;
     }
+    openedChatRef.current = activeChatId;
     const frame = requestAnimationFrame(() => {
-      openedChatRef.current = activeChatId;
-      if (targetId && targetRow) {
-        scrollToMessagePosition(targetId, { behavior: "auto", center: true }, targetRow.key);
-      } else if (targetId && !targetRow) {
-        // フォールバック: 見つからなければ末尾
-        scrollToBottom("auto");
-      } else {
-        scrollToBottom("auto");
-      }
+      if (targetMessageId) {
+        scrollToMessagePosition(targetMessageId, { behavior: "auto", center: true });
+      } else scrollToBottom("auto");
     });
     return () => cancelAnimationFrame(frame);
   }, [
     activeChatId,
-    chatMessages,
+    firstUnreadMessageId,
     hasMeasured,
     initialChatScrollMessageId,
-    initialChatScrollMode,
+    loadingMessages,
     rows,
     scrollToBottom,
     scrollToMessagePosition,

--- a/Vyline/apps/desktop/src/hooks/useVirtualList.ts
+++ b/Vyline/apps/desktop/src/hooks/useVirtualList.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 
 /**
  * 可変高さリストのウィンドウ仮想化
@@ -24,11 +24,36 @@ export function useVirtualList<T>({
   const containerRef = useRef<HTMLDivElement>(null);
   const [scrollTop, setScrollTop] = useState(0);
   const heights = useRef(new Map<string, number>());
-  const [, setMeasuredTick] = useState(0);
-  const measuredTick = useRef(0);
+  const [measuredVersion, setMeasuredVersion] = useState(0);
   const tickScheduled = useRef(false);
   const refCache = useRef(new Map<string, (el: HTMLElement | null) => void>());
   const observers = useRef(new Map<string, ResizeObserver>());
+  const anchorRef = useRef<{ key: string; center: boolean } | null>(null);
+  const keepBottomRef = useRef(false);
+  const autoScrollInFlightRef = useRef(false);
+
+  const preserveInitialPosition = useCallback(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    if (keepBottomRef.current && !autoScrollInFlightRef.current) {
+      el.scrollTo({ top: Math.max(0, el.scrollHeight - el.clientHeight), behavior: "auto" });
+      return;
+    }
+
+    const anchor = anchorRef.current;
+    if (!anchor) return;
+    const row = document.getElementById(anchor.key);
+    if (!row) return;
+
+    const rowTop = row.getBoundingClientRect().top - el.getBoundingClientRect().top;
+    const desiredTop = anchor.center ? el.clientHeight / 2 : 0;
+    const nextTop = Math.max(0, el.scrollTop + rowTop - desiredTop);
+    if (Math.abs(nextTop - el.scrollTop) > 0.5) {
+      el.scrollTo({ top: nextTop, behavior: "auto" });
+    }
+  }, []);
+
   const offsets = useMemo(() => {
     const arr: number[] = [];
     let acc = 0;
@@ -37,12 +62,20 @@ export function useVirtualList<T>({
       acc += heights.current.get(r.key) ?? estimateHeight(r.item);
     }
     return { offsets: arr, total: acc };
-  }, [rows, estimateHeight, measuredTick.current]);
-
-  const hasMeasured = measuredTick.current > 0;
+  }, [rows, estimateHeight, measuredVersion]);
 
   const onScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
-    setScrollTop(e.currentTarget.scrollTop);
+    const el = e.currentTarget;
+    // 自動で最下部を維持している最中でも、利用者が上へ動かしたら即座に解除する。
+    // wheel/pointer イベントだけではスクロールバー操作を取りこぼすため、位置差分でも判定する。
+    if (keepBottomRef.current && !autoScrollInFlightRef.current) {
+      const maxScrollTop = Math.max(0, el.scrollHeight - el.clientHeight);
+      if (el.scrollTop < maxScrollTop - 2) {
+        anchorRef.current = null;
+        keepBottomRef.current = false;
+      }
+    }
+    setScrollTop(el.scrollTop);
   }, []);
 
   // 可視ウィンドウを二分探索で算出
@@ -69,22 +102,25 @@ export function useVirtualList<T>({
     return { startIdx, endIdx };
   }, [scrollTop, offsets, overscan]);
 
-  const measure = useCallback((key: string, el: HTMLElement | null) => {
-    if (!el) return;
-    const h = el.offsetHeight;
-    const prev = heights.current.get(key);
-    if (prev !== h) {
-      heights.current.set(key, h);
-      // 同一フレーム内の計測変更を 1 再描画に統合（画像遅延ロード時の再描画連鎖を抑制）
-      if (tickScheduled.current) return;
-      tickScheduled.current = true;
-      requestAnimationFrame(() => {
-        tickScheduled.current = false;
-        measuredTick.current++;
-        setMeasuredTick((t) => t + 1);
-      });
-    }
-  }, []);
+  const measure = useCallback(
+    (key: string, el: HTMLElement | null) => {
+      if (!el) return;
+      const h = el.offsetHeight;
+      const prev = heights.current.get(key);
+      if (prev !== h) {
+        heights.current.set(key, h);
+        // 同一フレーム内の計測変更を 1 再描画に統合（画像遅延ロード時の再描画連鎖を抑制）
+        if (tickScheduled.current) return;
+        tickScheduled.current = true;
+        requestAnimationFrame(() => {
+          tickScheduled.current = false;
+          setMeasuredVersion((version) => version + 1);
+          requestAnimationFrame(preserveInitialPosition);
+        });
+      }
+    },
+    [preserveInitialPosition],
+  );
 
   // 行キーごとに安定した ref を返す（毎レンダーの ref 再アタッチ → 再計測の連鎖を防ぐ）
   const rowRef = useCallback(
@@ -122,10 +158,35 @@ export function useVirtualList<T>({
   }, [rows]);
 
   useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const cancelAutoPosition = () => {
+      anchorRef.current = null;
+      keepBottomRef.current = false;
+    };
+    el.addEventListener("wheel", cancelAutoPosition, { passive: true });
+    el.addEventListener("touchstart", cancelAutoPosition, { passive: true });
+    el.addEventListener("pointerdown", cancelAutoPosition, { passive: true });
+    return () => {
+      el.removeEventListener("wheel", cancelAutoPosition);
+      el.removeEventListener("touchstart", cancelAutoPosition);
+      el.removeEventListener("pointerdown", cancelAutoPosition);
+    };
+  }, []);
+
+  useEffect(() => {
     return () => {
       for (const observer of observers.current.values()) observer.disconnect();
     };
   }, []);
+
+  // 同期で行が追加されても、既存行の高さが変わらなければ measure は呼ばれない。
+  // その場合も下部スペーサー更新後に最下部へ追従する。
+  useLayoutEffect(() => {
+    if (!keepBottomRef.current && !anchorRef.current) return;
+    const frame = requestAnimationFrame(preserveInitialPosition);
+    return () => cancelAnimationFrame(frame);
+  }, [offsets, preserveInitialPosition, rows]);
 
   // 行キー → スクロール位置（center: 可視中央に寄せる）
   const scrollToKey = useCallback(
@@ -141,56 +202,67 @@ export function useVirtualList<T>({
     [rows, offsets],
   );
 
-  // メッセージ行の位置へ移動する共通ヘルパー。
   const scrollToMessagePosition = useCallback(
     (
       messageId: string,
       opts: { behavior?: ScrollBehavior; center?: boolean } = {},
-      rowKey?: string,
+      rowKey = `msg-${messageId}`,
     ) => {
-      const key = rowKey ?? `msg-${messageId}`;
-      scrollToKey(key, opts);
+      anchorRef.current = { key: rowKey, center: opts.center === true };
+      keepBottomRef.current = false;
+      scrollToKey(rowKey, opts);
 
       const correctToRenderedRow = () => {
         const el = containerRef.current;
-        const row = document.getElementById(key);
+        const row = document.getElementById(rowKey);
         if (!el || !row) return;
         const rowTop = row.getBoundingClientRect().top - el.getBoundingClientRect().top;
-        const top = Math.max(0, el.scrollTop + rowTop - (opts.center ? el.clientHeight / 2 : 0));
-        el.scrollTo({ top, behavior: opts.behavior ?? "smooth" });
+        const desiredTop = opts.center ? el.clientHeight / 2 : 0;
+        el.scrollTo({
+          top: Math.max(0, el.scrollTop + rowTop - desiredTop),
+          behavior: opts.behavior ?? "smooth",
+        });
+        preserveInitialPosition();
       };
 
-      // 推定値で対象行を仮想ウィンドウ内へ出し、描画後の実座標で補正する。
-      requestAnimationFrame(() =>
-        requestAnimationFrame(() => requestAnimationFrame(correctToRenderedRow)),
-      );
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          requestAnimationFrame(correctToRenderedRow);
+        });
+      });
     },
-    [containerRef, scrollToKey],
+    [preserveInitialPosition, scrollToKey],
   );
 
   const scrollToBottom = useCallback((behavior: ScrollBehavior = "auto") => {
     const el = containerRef.current;
     if (!el) return;
+    anchorRef.current = null;
+    keepBottomRef.current = true;
     const scroll = () => {
       const maxScrollTop = Math.max(0, el.scrollHeight - el.clientHeight);
+      autoScrollInFlightRef.current = true;
       el.scrollTo({ top: maxScrollTop, behavior });
+      requestAnimationFrame(() => {
+        autoScrollInFlightRef.current = false;
+      });
     };
     scroll();
-    // 仮想ウィンドウの切り替えや遅延画像で高さが変わった後にも末尾を保証する。
     requestAnimationFrame(() => requestAnimationFrame(scroll));
   }, []);
 
   const visibleRows = useMemo(() => rows.slice(visible.startIdx, visible.endIdx), [rows, visible]);
-  const topSpacer = hasMeasured ? (offsets.offsets[visible.startIdx] ?? 0) : 0;
-  const bottomSpacer = hasMeasured
-    ? offsets.total - (offsets.offsets[visible.endIdx] ?? offsets.total)
-    : 0;
+  const topSpacer = offsets.offsets[visible.startIdx] ?? 0;
+  const bottomSpacer = Math.max(
+    0,
+    offsets.total - (offsets.offsets[visible.endIdx] ?? offsets.total),
+  );
 
   return {
     containerRef,
     onScroll,
-    hasMeasured,
     visibleRows,
+    hasMeasured: measuredVersion > 0,
     topSpacer,
     bottomSpacer,
     measure,


### PR DESCRIPTION
## Summary

- Wait for virtual-list measurement before choosing the initial viewport.
- Follow the bottom only when the user was already near the bottom.
- Preserve manual scrolling while synchronized rows and measured heights change.

## Verification

- `bun run typecheck` ✅
- `bun run lint` ✅
- Desktop build ✅
- `git diff --check` ✅
- Browser verification completed for chat switching and reload behavior where authenticated.

## Notes

An authenticated browser session for 出前館 was unavailable, so no message was sent or modified there.