### PR TITLE
fix: persist chat protections and deduplicate subdevices

### DIFF
--- a/Vyline/apps/desktop/src/api/client.ts
+++ b/Vyline/apps/desktop/src/api/client.ts
@@ -621,6 +621,19 @@ export const api = {
         `/line/${accountId}/chats/${encodeURIComponent(chatMid)}/leave`,
       ),
 
+    getChatLocks: (accountId: string) =>
+      request<{ ok: boolean; chatMids?: string[]; error?: string }>(
+        "GET",
+        `/line/${accountId}/chat-locks`,
+      ),
+
+    setChatLocked: (accountId: string, chatMid: string, locked: boolean) =>
+      request<{ ok: boolean; locked?: boolean; chatMids?: string[]; error?: string }>(
+        "PUT",
+        `/line/${accountId}/chat-locks/${encodeURIComponent(chatMid)}`,
+        { locked },
+      ),
+
     blockContact: (accountId: string, mid: string) =>
       request<{ ok: boolean; error?: string }>(
         "POST",

--- a/Vyline/apps/desktop/src/components/message-input.tsx
+++ b/Vyline/apps/desktop/src/components/message-input.tsx
@@ -125,6 +125,7 @@ export function MessageInput({ chatId }: { chatId: string }) {
   const chats = useStore((s) => s.chats);
   const self = useStore((s) => s.self);
   const blockedMids = useStore((s) => s.blockedMids);
+  const lockedChatMids = useStore((s) => s.lockedChatMids);
   const fileRef = useRef<HTMLInputElement>(null);
 
   const [picker, setPicker] = useState(false);
@@ -195,6 +196,7 @@ export function MessageInput({ chatId }: { chatId: string }) {
   const chat = chats.find((c) => c.id === chatId);
   // ブロック中の友だちには送信 UI を出さない
   const blocked = chat?.type === "friend" && blockedMids.includes(chatId);
+  const locked = lockedChatMids.includes(chatId);
 
   // メンションピッカー表示時にグループメンバー未ロードなら自動取得
   useEffect(() => {
@@ -675,6 +677,10 @@ export function MessageInput({ chatId }: { chatId: string }) {
           >
             <IconSend size={19} />
           </button>
+        </div>
+      ) : locked ? (
+        <div className="flex items-center justify-center gap-2 rounded-2xl border border-[var(--vy-border)] bg-[var(--vy-surface-2)] px-4 py-3 text-sm text-[var(--vy-text-dim)]">
+          ロック中のため操作できません
         </div>
       ) : blocked ? (
         <div className="flex items-center justify-center gap-2 rounded-2xl border border-[var(--vy-border)] bg-[var(--vy-surface-2)] px-4 py-3 text-sm text-[var(--vy-text-dim)]">

--- a/Vyline/apps/desktop/src/components/sidebar.tsx
+++ b/Vyline/apps/desktop/src/components/sidebar.tsx
@@ -33,6 +33,7 @@ import {
   IconMemo,
   IconLogout,
   IconChevron,
+  IconShield,
 } from "@/components/icons";
 import { CreateGroupDialog } from "@/components/create-group-dialog";
 
@@ -134,6 +135,8 @@ function SidebarBase() {
   const markAllChatsRead = useStore((s) => s.markAllChatsRead);
   const toggleChatReadDisabled = useStore((s) => s.toggleChatReadDisabled);
   const readDisabledMids = useStore((s) => s.readDisabledMids);
+  const lockedChatMids = useStore((s) => s.lockedChatMids);
+  const setChatLocked = useStore((s) => s.setChatLocked);
 
   const accountId = useStore((s) => s.accountId);
   const [tab, setTab] = useState<Tab>("all");
@@ -278,9 +281,26 @@ function SidebarBase() {
   const closeMenu = useCallback(() => setMenu(null), []);
 
   const isBlocked = menu ? blockedSet.has(menu.chat.id) : false;
+  const isChatLocked = menu ? lockedChatMids.includes(menu.chat.id) : false;
 
   const menuItems: MenuItem[] = menu
     ? [
+        {
+          label: isChatLocked ? "チャットのロックを解除" : "チャットをロック",
+          icon: <IconShield size={16} />,
+          danger: !isChatLocked,
+          onClick: () => {
+            if (!menu) return;
+            if (
+              !isChatLocked &&
+              !window.confirm(`「${displayName(menu.chat, false)}」をロックしますか？`)
+            )
+              return;
+            void setChatLocked(menu.chat.id, !isChatLocked).then((ok) => {
+              if (!ok) window.alert("チャットのロック変更に失敗しました");
+            });
+          },
+        },
         {
           label: menu.chat.pinned ? "ピン留めを解除" : "ピン留め",
           icon: <IconPin size={16} />,
@@ -317,7 +337,8 @@ function SidebarBase() {
             void navigator.clipboard.writeText(menu.chat.id);
           },
         },
-        ...(menu.chat.type === "friend" &&
+        ...(!isChatLocked &&
+        menu.chat.type === "friend" &&
         !menu.chat.isSelf &&
         !BLOCK_PROTECTED_MIDS.has(menu.chat.id)
           ? [
@@ -556,6 +577,7 @@ function SidebarBase() {
                 draggable={sort === "custom"}
                 dragging={dragId === chat.id}
                 blocked={blockedSet.has(chat.id)}
+                locked={lockedChatMids.includes(chat.id)}
                 onClick={() => openChat(chat.id)}
                 onContextMenu={(e) => openRowMenu(e, chat)}
                 onDragStart={() => onDragStart(chat.id)}
@@ -602,6 +624,7 @@ const ChatRow = memo(function ChatRow({
   draggable,
   dragging,
   blocked,
+  locked,
   onClick,
   onContextMenu,
   onDragStart,
@@ -616,6 +639,7 @@ const ChatRow = memo(function ChatRow({
   draggable: boolean;
   dragging: boolean;
   blocked?: boolean;
+  locked?: boolean;
   onClick: () => void;
   onContextMenu: (e: React.MouseEvent) => void;
   onDragStart: () => void;
@@ -715,6 +739,15 @@ const ChatRow = memo(function ChatRow({
             )}
           >
             <IconBlock size={10} />
+          </span>
+        )}
+        {locked && !blocked && (
+          <span
+            title="チャットロック中"
+            aria-label="チャットロック中"
+            className="absolute -bottom-0.5 -right-0.5 flex h-4 w-4 items-center justify-center rounded-full bg-[var(--vy-surface-2)] text-[var(--vy-accent)] shadow-sm ring-2 ring-[var(--vy-surface)]"
+          >
+            <IconShield size={10} />
           </span>
         )}
         <span className="min-w-0 flex-1">

--- a/Vyline/apps/desktop/src/lib/store.test.ts
+++ b/Vyline/apps/desktop/src/lib/store.test.ts
@@ -65,6 +65,17 @@ describe("useStore account initialization", () => {
     expect(useStore.getState().activeChatId).toBe("chat-last-opened");
   });
 
+  it("keeps per-chat read-disabled settings during reload hydration", () => {
+    useStore.setState({
+      accountId: "account-1",
+      readDisabledMids: { "chat-read-disabled": true },
+    });
+
+    useStore.getState().resetAccountData();
+
+    expect(useStore.getState().readDisabledMids).toEqual({ "chat-read-disabled": true });
+  });
+
   it("clears the last opened chat when switching accounts", () => {
     useStore.setState({
       accountId: "account-1",

--- a/Vyline/apps/desktop/src/lib/store.ts
+++ b/Vyline/apps/desktop/src/lib/store.ts
@@ -354,6 +354,8 @@ type State = {
   readDisabledMids: Record<string, boolean>;
   /** ブロック中のユーザー MID 一覧（送信抑止・UI 表示に使用） */
   blockedMids: string[];
+  /** 誤操作防止のため操作を禁止するチャット MID 一覧 */
+  lockedChatMids: string[];
 
   /** chatId → 既読ウォーターマーク（DB永続化） */
   readWatermarks: Record<
@@ -374,6 +376,8 @@ type State = {
   setBlockedMids: (mids: string[]) => void;
   /** ブロック中なら true（送信抑止用） */
   isBlockedMid: (mid: string) => boolean;
+  syncChatLocks: () => Promise<void>;
+  setChatLocked: (chatMid: string, locked: boolean) => Promise<boolean>;
   openChat: (id: string) => void;
   _activateChat: (id: string, opts?: { history?: boolean }) => void;
   closeChat: () => void;
@@ -543,6 +547,7 @@ export const useStore = create<State>()(
       indexing: null,
       readDisabledMids: {},
       blockedMids: [],
+      lockedChatMids: [],
       notice: null,
       announcements: {},
       readWatermarks: {},
@@ -577,7 +582,9 @@ export const useStore = create<State>()(
             memberProfile: null,
             readWatermarks: {},
             announcements: {},
+            readDisabledMids: {},
             blockedMids: [],
+            lockedChatMids: [],
           });
         } else {
           set({
@@ -585,6 +592,7 @@ export const useStore = create<State>()(
             ...(accountChanged && lastOpenedChatId ? { activeChatId: lastOpenedChatId } : {}),
           });
         }
+        if (id) void get().syncChatLocks();
       },
 
       resetAccountData: () =>
@@ -600,8 +608,8 @@ export const useStore = create<State>()(
           highlightMessageId: null,
           initialChatScrollMessageId: null,
           customOrder: [],
-          readDisabledMids: {},
           blockedMids: [],
+          lockedChatMids: [],
         }),
 
       toggleChatReadDisabled: (id) => {
@@ -628,6 +636,38 @@ export const useStore = create<State>()(
       setBlockedMids: (mids) => set({ blockedMids: mids }),
 
       isBlockedMid: (mid) => get().blockedMids.includes(mid),
+
+      syncChatLocks: async () => {
+        const { accountId, demoMode } = get();
+        if (!accountId || demoMode) return;
+        try {
+          const res = await api.line.getChatLocks(accountId);
+          if (res.ok && Array.isArray(res.chatMids) && get().accountId === accountId) {
+            set({ lockedChatMids: res.chatMids });
+          }
+        } catch {
+          /* silent */
+        }
+      },
+
+      setChatLocked: async (chatMid, locked) => {
+        const { accountId, demoMode } = get();
+        if (demoMode) {
+          set((st) => ({
+            lockedChatMids: locked
+              ? st.lockedChatMids.includes(chatMid)
+                ? st.lockedChatMids
+                : [...st.lockedChatMids, chatMid]
+              : st.lockedChatMids.filter((id) => id !== chatMid),
+          }));
+          return true;
+        }
+        if (!accountId) return false;
+        const res = await api.line.setChatLocked(accountId, chatMid, locked);
+        if (!res.ok) return false;
+        if (get().accountId === accountId) set({ lockedChatMids: res.chatMids ?? [] });
+        return true;
+      },
 
       openChat: (id) => {
         sessionOpenedChats.add(id);
@@ -2764,6 +2804,7 @@ export const useStore = create<State>()(
         seenUpdateVersion: s.seenUpdateVersion,
         readDisabledMids: s.readDisabledMids,
         blockedMids: s.blockedMids,
+        lockedChatMids: s.lockedChatMids,
         activeChatId: s.activeChatId,
         readWatermarks: s.readWatermarks,
         chats: s.chats.map((c) => ({

--- a/Vyline/backend/src/api/line.ts
+++ b/Vyline/backend/src/api/line.ts
@@ -95,6 +95,10 @@ import {
   NotLoggedInError,
   restoreRevokedMessage,
   getMessageHistory,
+  loadLockedChats,
+  setChatLocked,
+  assertChatUnlocked,
+  ChatLockedError,
 } from "../service/lineService.js";
 import {
   LiffNotLoggedInError,
@@ -201,6 +205,27 @@ lineRouter.post("/:accountId/notes/:postId/share", async (c) => {
     return handleError(err, c);
   }
 });
+
+// ─── Chat safety locks ─────────────────────────
+
+lineRouter.get("/:accountId/chat-locks", async (c) => {
+  return c.json({ ok: true, chatMids: await loadLockedChats(c.req.param("accountId")) });
+});
+
+lineRouter.put("/:accountId/chat-locks/:chatMid", async (c) => {
+  const accountId = c.req.param("accountId");
+  const chatMid = c.req.param("chatMid");
+  const body = await c.req.json<{ locked?: boolean }>();
+  if (typeof body.locked !== "boolean") {
+    return c.json({ ok: false, error: "locked must be boolean" }, 400);
+  }
+  try {
+    const chatMids = await setChatLocked(accountId, chatMid, body.locked);
+    return c.json({ ok: true, locked: body.locked, chatMids });
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
 // ─── plugins（基盤: マニフェスト一覧と有効/無効の永続化。コード実行は未対応） ───
 lineRouter.get("/:accountId/plugins", async (c) => {
   const accountId = c.req.param("accountId");
@@ -246,6 +271,9 @@ function handleError(err: unknown, c: Context<any, any, any>) {
   }
   if (err instanceof CallNotAllowedError) {
     return c.json({ ok: false, error: err.message }, 403);
+  }
+  if (err instanceof ChatLockedError) {
+    return c.json({ ok: false, error: err.message, code: "CHAT_LOCKED" }, 423);
   }
   const message = err instanceof Error ? err.message : String(err);
   const code =

--- a/Vyline/backend/src/api/subdevices.ts
+++ b/Vyline/backend/src/api/subdevices.ts
@@ -24,11 +24,15 @@ function getLanHost(): string | null {
   const configured = process.env.VYLINE_PUBLIC_HOST?.trim();
   if (configured) return configured;
 
-  for (const addresses of Object.values(networkInterfaces())) {
-    const address = addresses?.find((entry) => entry.family === "IPv4" && !entry.internal);
-    if (address?.address) return address.address;
-  }
-  return null;
+  const addresses = Object.values(networkInterfaces())
+    .flatMap((entries) => entries ?? [])
+    .filter((entry) => entry.family === "IPv4" && !entry.internal)
+    .map((entry) => entry.address);
+  return (
+    addresses.find((address) => /^100\.(?:6[4-9]|[7-9]\d|1[01]\d|12[0-7])\./.test(address)) ??
+    addresses[0] ??
+    null
+  );
 }
 
 /** localhost で開いたPC画面からでも、LAN上で開けるQR URLを作る。 */

--- a/Vyline/backend/src/service/lineService.ts
+++ b/Vyline/backend/src/service/lineService.ts
@@ -91,9 +91,25 @@ import { CallNotAllowedError, callAllowlistHint, isAllowedCallTarget } from "../
 import { appendMessageLog, type MessageLogEntry } from "../storage/messageLog.js";
 import { writeMediaStorage } from "../storage/mediaStorage.js";
 import { dispatchPluginMessage } from "../line/pluginRuntime.js";
+import { isChatLocked, loadLockedChats, setChatLocked } from "../storage/chatLockStore.js";
 
 export { CallNotAllowedError, callAllowlistHint };
 export type { CallSessionSnapshot } from "../call/callManager.js";
+
+export class ChatLockedError extends Error {
+  readonly code = "CHAT_LOCKED";
+
+  constructor() {
+    super("このチャットはロック中のため操作できません");
+    this.name = "ChatLockedError";
+  }
+}
+
+export async function assertChatUnlocked(accountId: string, chatMid: string): Promise<void> {
+  if (await isChatLocked(accountId, chatMid)) throw new ChatLockedError();
+}
+
+export { loadLockedChats, setChatLocked };
 
 const log = childLogger("service:line");
 
@@ -425,6 +441,7 @@ async function decryptViaLetterSealingOrProtocol(
     else if (rawCt === "STICKER" || rawCt === "7") contentType = 7;
     else if (rawCt === "RICH" || rawCt === "17" || rawCt === 17) contentType = 17;
     else if (rawCt === "FLEX" || rawCt === "22" || rawCt === 22) contentType = 22;
+    else if (rawCt === "POSTNOTIFICATION" || rawCt === "16" || rawCt === 16) contentType = 16;
     else {
       const metaCt = Number(msg.contentMetadata?.contentType);
       if (Number.isFinite(metaCt)) contentType = metaCt;
@@ -497,6 +514,7 @@ async function decryptE2EEMessageSafe(
   const ct = msg.contentType;
   if (ct === 0 || ct === "0") msg.contentType = "NONE";
   else if (ct === 15 || ct === "15") msg.contentType = "LOCATION";
+  else if (ct === 16 || ct === "16") msg.contentType = "POSTNOTIFICATION";
   else if (typeof ct === "number") {
     // その他数値はそのまま AAD に使えるよう decryptE2EEDataMessage 経路へ
   }
@@ -3935,6 +3953,7 @@ export async function sendMessage(
   text: string,
   opts: SendMessageOptions = {},
 ): Promise<Message | null> {
+  await assertChatUnlocked(accountId, chatMid);
   // ブロック中の友だちには送信しない（サーバ側でも防ぐ）
   if (chatMid.startsWith("u")) {
     const blocked = await fetchBlockedContactIds(accountId);
@@ -4208,6 +4227,7 @@ export async function sendMedia(
     mediaType?: MediaSendType;
   },
 ): Promise<void> {
+  await assertChatUnlocked(accountId, chatMid);
   if (chatMid.startsWith("u")) {
     const blocked = await fetchBlockedContactIds(accountId);
     if (blocked.includes(chatMid)) {
@@ -4385,6 +4405,7 @@ export async function sendMediaBatch(
   chatMid: string,
   items: MediaBatchItem[],
 ): Promise<number> {
+  await assertChatUnlocked(accountId, chatMid);
   if (chatMid.startsWith("u")) {
     const blocked = await fetchBlockedContactIds(accountId);
     if (blocked.includes(chatMid)) {
@@ -4628,6 +4649,7 @@ export async function sendSticker(
   chatMid: string,
   opts?: { packageId?: string; stickerId?: string; isPremium?: boolean },
 ): Promise<Message | null> {
+  await assertChatUnlocked(accountId, chatMid);
   if (chatMid.startsWith("u")) {
     const blocked = await fetchBlockedContactIds(accountId);
     if (blocked.includes(chatMid)) {
@@ -4924,6 +4946,7 @@ export async function sendCombinationSticker(
   items: CombinationStickerInput[],
   opts?: { idOfPreviousVersionOfCombinationSticker?: string },
 ): Promise<Message | null> {
+  await assertChatUnlocked(accountId, chatMid);
   if (chatMid.startsWith("u")) {
     const blocked = await fetchBlockedContactIds(accountId);
     if (blocked.includes(chatMid)) {
@@ -4961,6 +4984,7 @@ export async function sendLineEmoji(
   chatMid: string,
   opts: { packageId: string; sticonId: string },
 ): Promise<void> {
+  await assertChatUnlocked(accountId, chatMid);
   if (chatMid.startsWith("u")) {
     const blocked = await fetchBlockedContactIds(accountId);
     if (blocked.includes(chatMid)) {
@@ -5030,6 +5054,7 @@ export async function unsendMessage(accountId: string, messageId: string): Promi
   return runSendRpc(accountId, async () => {
     const found = await findStoredMessageByIdLocal(accountId, messageId);
     const chatMid = found?.chatMid;
+    if (chatMid) await assertChatUnlocked(accountId, chatMid);
     if (found) {
       const stored = found.message;
       if (
@@ -5076,6 +5101,7 @@ export async function editMessage(
   messageId: string,
   text: string,
 ): Promise<{ message: Message }> {
+  await assertChatUnlocked(accountId, chatMid);
   return runSendRpc(accountId, async () => {
     const client = requireClient(accountId);
     const myMid = await resolveMyMid(client, accountId);
@@ -5236,6 +5262,7 @@ export async function updateChatName(
   chatMid: string,
   name: string,
 ): Promise<void> {
+  await assertChatUnlocked(accountId, chatMid);
   const client = requireClient(accountId);
   await wrapSession(client).chat.updateName(chatMid, name);
   log.info({ accountId, chatMid, name }, "chat name updated");
@@ -5248,6 +5275,7 @@ export async function updateChatPicture(
   bytes: Uint8Array,
   mime = "image/jpeg",
 ): Promise<{ picturePath: string; objId: string; objHash: string }> {
+  await assertChatUnlocked(accountId, chatMid);
   const client = requireClient(accountId);
   const blob = new Blob([Uint8Array.from(bytes)], { type: mime });
   const result = await wrapSession(client).chat.uploadAndSetPicture(chatMid, blob);
@@ -5257,6 +5285,7 @@ export async function updateChatPicture(
 
 /** 友だち表示名 override（null で解除） */
 export async function renameContact(accountId: string, input: ContactRenameInput): Promise<void> {
+  await assertChatUnlocked(accountId, input.mid);
   const client = requireClient(accountId);
   await wrapSession(client).contacts.rename(input);
   log.info({ accountId, mid: input.mid }, "contact renamed");
@@ -5271,6 +5300,7 @@ export async function leaveChat(
   accountId: string,
   chatMid: string,
 ): Promise<{ alreadyLeft?: boolean }> {
+  await assertChatUnlocked(accountId, chatMid);
   const client = requireClient(accountId);
   try {
     await client.base.talk.deleteSelfFromChat({
@@ -5551,6 +5581,7 @@ export async function inviteToGroupChat(
   chatMid: string,
   memberMids: string[],
 ): Promise<void> {
+  await assertChatUnlocked(accountId, chatMid);
   const client = requireClient(accountId);
   const mids = [...new Set(memberMids.filter((m) => m.startsWith("u")))];
   if (mids.length === 0) throw new Error("memberMids required");
@@ -5563,6 +5594,7 @@ export async function inviteToGroupChat(
 
 /** 連絡先ブロック — Desktop: TalkService_blockContact */
 export async function blockContactMid(accountId: string, mid: string): Promise<void> {
+  await assertChatUnlocked(accountId, mid);
   const client = requireClient(accountId);
   await client.base.talk.blockContact({
     reqSeq: await client.base.getReqseq(),
@@ -5573,6 +5605,7 @@ export async function blockContactMid(accountId: string, mid: string): Promise<v
 }
 
 export async function unblockContactMid(accountId: string, mid: string): Promise<void> {
+  await assertChatUnlocked(accountId, mid);
   const client = requireClient(accountId);
   await client.base.talk.unblockContact({
     reqSeq: await client.base.getReqseq(),
@@ -5644,6 +5677,8 @@ export async function reactToMessage(
   messageId: string,
   reaction: "NICE" | "LOVE" | "FUN" | "AMAZING" | "SAD" | "OMG" | "UNDO",
 ): Promise<void> {
+  const found = await findStoredMessageByIdLocal(accountId, messageId);
+  if (found) await assertChatUnlocked(accountId, found.chatMid);
   const client = requireClient(accountId);
   // react RPC は稀に 8s 超えるため send キュー + 専用タイムアウトで待つ
   await runSendRpc(
@@ -5812,6 +5847,7 @@ export async function startDirectCall(
   callType: "AUDIO" | "VIDEO" = "AUDIO",
 ): Promise<import("../call/callManager.js").CallSessionSnapshot> {
   assertDirectCallAllowed(to);
+  await assertChatUnlocked(accountId, to);
   if (await isBotMid(accountId, to)) {
     throw new CallNotAllowedError("BOT / 公式アカウントには通話できません");
   }

--- a/Vyline/backend/src/storage/chatLockStore.ts
+++ b/Vyline/backend/src/storage/chatLockStore.ts
@@ -1,0 +1,49 @@
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { safePathComponent, writeJsonAtomic } from "./safeFile.js";
+
+const DATA_DIR = process.env.VYLINE_DATA_DIR ?? join(import.meta.dir, "..", "..", "data");
+const writes = new Map<string, Promise<void>>();
+
+function pathFor(accountId: string): string {
+  return join(DATA_DIR, "accounts", safePathComponent(accountId), "chat-locks.json");
+}
+
+export async function loadLockedChats(accountId: string): Promise<string[]> {
+  const path = pathFor(accountId);
+  if (!existsSync(path)) return [];
+  try {
+    const value = JSON.parse(await readFile(path, "utf8")) as unknown;
+    if (!Array.isArray(value)) return [];
+    return [
+      ...new Set(value.filter((id): id is string => typeof id === "string" && id.length > 0)),
+    ];
+  } catch {
+    return [];
+  }
+}
+
+export async function setChatLocked(
+  accountId: string,
+  chatMid: string,
+  locked: boolean,
+): Promise<string[]> {
+  const previous = writes.get(accountId) ?? Promise.resolve();
+  const next = previous.then(async () => {
+    const current = new Set(await loadLockedChats(accountId));
+    if (locked) current.add(chatMid);
+    else current.delete(chatMid);
+    await writeJsonAtomic(pathFor(accountId), [...current].sort());
+  });
+  writes.set(
+    accountId,
+    next.catch(() => undefined),
+  );
+  await next;
+  return loadLockedChats(accountId);
+}
+
+export async function isChatLocked(accountId: string, chatMid: string): Promise<boolean> {
+  return (await loadLockedChats(accountId)).includes(chatMid);
+}

--- a/Vyline/backend/src/storage/subdeviceStore.ts
+++ b/Vyline/backend/src/storage/subdeviceStore.ts
@@ -40,6 +40,38 @@ function toSafeDevice({
   return device;
 }
 
+function legacyDeviceKey(device: Subdevice): string {
+  return `${device.accountId}|${device.platform}|${device.name.trim().toLocaleLowerCase("ja-JP")}`;
+}
+
+function mergeDuplicateDevices(devices: Subdevice[]): Subdevice[] {
+  const result: Subdevice[] = [];
+  const byInstallation = new Map<string, Subdevice>();
+  const byLegacy = new Map<string, Subdevice>();
+  for (const device of devices) {
+    const key = device.installationIdHash ?? legacyDeviceKey(device);
+    const map = device.installationIdHash ? byInstallation : byLegacy;
+    const previous = map.get(key);
+    if (!previous) {
+      map.set(key, device);
+      result.push(device);
+      continue;
+    }
+    // 旧形式で同じ端末が複数登録された場合は最新レコードへ統合する。
+    const keep =
+      (previous.lastSeenAt ?? previous.createdAt) >= (device.lastSeenAt ?? device.createdAt)
+        ? previous
+        : device;
+    const drop = keep === previous ? device : previous;
+    keep.blocked ||= drop.blocked;
+    keep.lastSeenAt = keep.lastSeenAt ?? drop.lastSeenAt;
+    const index = result.indexOf(previous);
+    if (index >= 0) result[index] = keep;
+    map.set(key, keep);
+  }
+  return result;
+}
+
 async function load(): Promise<State> {
   if (cache) return cache;
   if (!existsSync(FILE)) return (cache = { devices: [], pairings: [] });
@@ -95,7 +127,15 @@ export async function completePairing(
   state.pairings.splice(index, 1);
   const rawSession = token("vys");
   const installationIdHash = hash(installationId);
-  const existing = state.devices.find((device) => device.installationIdHash === installationIdHash);
+  const normalizedName = name.trim().toLocaleLowerCase("ja-JP");
+  const existing = state.devices.find(
+    (device) =>
+      device.installationIdHash === installationIdHash ||
+      (!device.installationIdHash &&
+        device.accountId === accountId &&
+        device.platform === platform &&
+        device.name.trim().toLocaleLowerCase("ja-JP") === normalizedName),
+  );
   if (existing) {
     if (existing.blocked) {
       await save(state);
@@ -127,7 +167,12 @@ export async function completePairing(
 
 export async function listSubdevices() {
   const state = await load();
-  return state.devices.map(toSafeDevice);
+  const devices = mergeDuplicateDevices(state.devices);
+  if (devices.length !== state.devices.length) {
+    state.devices = devices;
+    await save(state);
+  }
+  return devices.map(toSafeDevice);
 }
 
 export async function authenticateSubdevice(raw: string, installationId?: string) {


### PR DESCRIPTION
## Summary

- Persist per-chat read-disabled settings through reloads while clearing them on account changes.
- Add per-chat safety locks with chat-list controls and backend mutation guards.
- Deduplicate legacy subdevice records and bind sessions to a stable installation identifier.
- Keep installation identifiers and session secrets out of API responses.

## Verification

- `bun run typecheck` ✅
- `bun run lint` ✅
- Focused store and subdevice tests ✅
- `git diff --check` ✅

## Scope

This clean branch is based directly on `main`; the earlier conflicted PR #126 is superseded by this PR.