### PR TITLE
security: harden LAN isolation, account scoping, and backup paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Vyline — Bun ベースの軽量ランタイムイメージ
 # ビルド: docker build -t vyline .
-# 実行:  docker run -p 3000:3000 -v ./data:/app/data vyline
+# 実行:  docker run -p 127.0.0.1:3000:3000 -v ./data:/app/data vyline
 
 ARG BUN_VERSION=1.4.0
 ARG VYLINE_VERSION=dev

--- a/Vyline/backend/src/api/agentI.test.ts
+++ b/Vyline/backend/src/api/agentI.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { agentIRouter } from "./agentI.js";
+
+const previousLanAccess = process.env.VYLINE_LAN_ACCESS;
+
+afterEach(() => {
+  if (previousLanAccess === undefined) process.env.VYLINE_LAN_ACCESS = undefined;
+  else process.env.VYLINE_LAN_ACCESS = previousLanAccess;
+});
+
+describe("Agent I LAN authentication", () => {
+  test("rejects unauthenticated remote requests when LAN access is enabled", async () => {
+    process.env.VYLINE_LAN_ACCESS = "true";
+
+    const response = await agentIRouter.request("/u-test/history", {
+      headers: { "x-vyline-local-request": "0" },
+    });
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      ok: false,
+      error: "subdevice authentication required",
+    });
+  });
+
+  test("keeps trusted local requests available when LAN access is enabled", async () => {
+    process.env.VYLINE_LAN_ACCESS = "true";
+
+    const response = await agentIRouter.request("/u-test/history", {
+      headers: { "x-vyline-local-request": "1" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true, history: [] });
+  });
+});

--- a/Vyline/backend/src/api/agentI.test.ts
+++ b/Vyline/backend/src/api/agentI.test.ts
@@ -1,11 +1,25 @@
-import { afterEach, describe, expect, test } from "bun:test";
-import { agentIRouter } from "./agentI.js";
+import { afterAll, afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 const previousLanAccess = process.env.VYLINE_LAN_ACCESS;
+const previousDataDir = process.env.VYLINE_DATA_DIR;
+const testDataDir = await mkdtemp(join(tmpdir(), "vyline-agent-i-lan-"));
+process.env.VYLINE_DATA_DIR = testDataDir;
+
+const { agentIRouter } = await import("./agentI.js");
+const { completePairing, createPairing } = await import("../storage/subdeviceStore.js");
 
 afterEach(() => {
-  if (previousLanAccess === undefined) process.env.VYLINE_LAN_ACCESS = undefined;
+  if (previousLanAccess === undefined) delete process.env.VYLINE_LAN_ACCESS;
   else process.env.VYLINE_LAN_ACCESS = previousLanAccess;
+});
+
+afterAll(async () => {
+  if (previousDataDir === undefined) delete process.env.VYLINE_DATA_DIR;
+  else process.env.VYLINE_DATA_DIR = previousDataDir;
+  await rm(testDataDir, { recursive: true, force: true });
 });
 
 describe("Agent I LAN authentication", () => {
@@ -32,5 +46,26 @@ describe("Agent I LAN authentication", () => {
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ ok: true, history: [] });
+  });
+
+  test("allows only the account used when the subdevice was paired", async () => {
+    process.env.VYLINE_LAN_ACCESS = "true";
+    const installationId = crypto.randomUUID();
+    const pairing = await createPairing("account-a");
+    const completed = await completePairing(pairing.token, "Test tablet", "web", installationId);
+    expect(completed).not.toBeNull();
+
+    const headers = {
+      authorization: `Bearer ${completed!.sessionToken}`,
+      "x-vyline-installation-id": installationId,
+      "x-vyline-local-request": "0",
+    };
+
+    const allowed = await agentIRouter.request("/account-a/history", { headers });
+    expect(allowed.status).toBe(200);
+
+    const denied = await agentIRouter.request("/account-b/history", { headers });
+    expect(denied.status).toBe(403);
+    expect(await denied.json()).toEqual({ ok: false, error: "subdevice account mismatch" });
   });
 });

--- a/Vyline/backend/src/api/agentI.test.ts
+++ b/Vyline/backend/src/api/agentI.test.ts
@@ -12,12 +12,12 @@ const { agentIRouter } = await import("./agentI.js");
 const { completePairing, createPairing } = await import("../storage/subdeviceStore.js");
 
 afterEach(() => {
-  if (previousLanAccess === undefined) delete process.env.VYLINE_LAN_ACCESS;
+  if (previousLanAccess === undefined) process.env.VYLINE_LAN_ACCESS = undefined;
   else process.env.VYLINE_LAN_ACCESS = previousLanAccess;
 });
 
 afterAll(async () => {
-  if (previousDataDir === undefined) delete process.env.VYLINE_DATA_DIR;
+  if (previousDataDir === undefined) process.env.VYLINE_DATA_DIR = undefined;
   else process.env.VYLINE_DATA_DIR = previousDataDir;
   await rm(testDataDir, { recursive: true, force: true });
 });

--- a/Vyline/backend/src/api/agentI.ts
+++ b/Vyline/backend/src/api/agentI.ts
@@ -6,8 +6,25 @@ import {
   resetAgentISession,
   type AgentIHistoryItem,
 } from "../service/agentIService.js";
+import { isSubdeviceSessionValid } from "../storage/subdeviceStore.js";
 
 export const agentIRouter = new Hono();
+
+function isLanAccessEnabled() {
+  return process.env.VYLINE_LAN_ACCESS === "true";
+}
+
+agentIRouter.use("*", async (c, next) => {
+  if (!isLanAccessEnabled() || c.req.header("x-vyline-local-request") === "1") return next();
+
+  const auth = c.req.header("authorization") ?? "";
+  const session = auth.startsWith("Bearer ") ? auth.slice(7).trim() : "";
+  const installationId = c.req.header("x-vyline-installation-id");
+  if (!(await isSubdeviceSessionValid(session, installationId))) {
+    return c.json({ ok: false, error: "subdevice authentication required" }, 401);
+  }
+  return next();
+});
 
 function validHistory(value: unknown): AgentIHistoryItem[] {
   if (!Array.isArray(value)) return [];

--- a/Vyline/backend/src/api/agentI.ts
+++ b/Vyline/backend/src/api/agentI.ts
@@ -6,12 +6,22 @@ import {
   resetAgentISession,
   type AgentIHistoryItem,
 } from "../service/agentIService.js";
-import { isSubdeviceSessionValid } from "../storage/subdeviceStore.js";
+import { getSubdeviceSession } from "../storage/subdeviceStore.js";
 
 export const agentIRouter = new Hono();
 
 function isLanAccessEnabled() {
   return process.env.VYLINE_LAN_ACCESS === "true";
+}
+
+function accountIdFromPath(path: string): string {
+  const match = path.match(/\/([^/]+)\/(?:chat|history|session)$/);
+  if (!match) return "";
+  try {
+    return decodeURIComponent(match[1]!);
+  } catch {
+    return "";
+  }
 }
 
 agentIRouter.use("*", async (c, next) => {
@@ -20,8 +30,12 @@ agentIRouter.use("*", async (c, next) => {
   const auth = c.req.header("authorization") ?? "";
   const session = auth.startsWith("Bearer ") ? auth.slice(7).trim() : "";
   const installationId = c.req.header("x-vyline-installation-id");
-  if (!(await isSubdeviceSessionValid(session, installationId))) {
+  const device = await getSubdeviceSession(session, installationId);
+  if (!device) {
     return c.json({ ok: false, error: "subdevice authentication required" }, 401);
+  }
+  if (accountIdFromPath(c.req.path) !== device.accountId) {
+    return c.json({ ok: false, error: "subdevice account mismatch" }, 403);
   }
   return next();
 });

--- a/Vyline/backend/src/api/auth.ts
+++ b/Vyline/backend/src/api/auth.ts
@@ -273,9 +273,12 @@ authRouter.get("/accounts", async (c) => {
 });
 
 // ─────────────────────────────────────────────
-// GET /auth/token/:id — 現在の authToken 取得（ログイン中のみ）
+// GET /auth/token/:id — 現在の authToken 取得（PCローカルのみ）
 // ─────────────────────────────────────────────
 authRouter.get("/token/:id", async (c) => {
+  if (c.req.header("x-vyline-local-request") !== "1") {
+    return c.json({ ok: false, error: "local request required" }, 403);
+  }
   const accountId = c.req.param("id");
   const token = getAuthToken(accountId);
   if (!token) {

--- a/Vyline/backend/src/index.ts
+++ b/Vyline/backend/src/index.ts
@@ -26,7 +26,7 @@ import type { CallWsData } from "./call/callManager.js";
 import { ensureCdnCacheDir } from "./storage/cdnAssetCache.js";
 import { ensureMediaStorageDir } from "./storage/mediaStorage.js";
 import { subdeviceRouter } from "./api/subdevices.js";
-import { isSubdeviceSessionValid } from "./storage/subdeviceStore.js";
+import { getSubdeviceSession } from "./storage/subdeviceStore.js";
 import { accountSettingsRouter } from "./api/accountSettings.js";
 import { handoffRouter } from "./api/handoff.js";
 import { diagnosticsRouter } from "./api/diagnostics.js";
@@ -55,9 +55,28 @@ function subdeviceInstallationId(c: Context) {
   return c.req.header("x-vyline-installation-id");
 }
 
+function subdeviceBearer(c: Context) {
+  const auth = c.req.header("authorization") ?? "";
+  return auth.startsWith("Bearer ") ? auth.slice(7).trim() : "";
+}
+
 function isPublicPairingRequest(path: string, method: string) {
   if (method === "GET") return /^\/(?:api\/)?auth\/subdevices\/pairing\/[^/]+$/.test(path);
   return method === "POST" && /^\/(?:api\/)?auth\/subdevices\/pairing\/[^/]+\/complete$/.test(path);
+}
+
+function isSubdeviceAuthRequest(path: string) {
+  return /^\/(?:api\/)?auth\/subdevices(?:\/|$)/.test(path);
+}
+
+function scopedAccountId(path: string): string | null {
+  const match = path.match(/^\/(?:api\/)?(?:line|beta\/agent-i)\/([^/]+)(?:\/|$)/);
+  if (!match) return null;
+  try {
+    return decodeURIComponent(match[1]!);
+  } catch {
+    return "";
+  }
 }
 
 app.use(
@@ -73,35 +92,41 @@ app.use(
 
 async function requireLanSubdevice(c: Context, next: () => Promise<void>) {
   if (!LAN_ACCESS || c.req.header("x-vyline-local-request") === "1") return next();
-  const auth = c.req.header("authorization") ?? "";
-  const session = auth.startsWith("Bearer ") ? auth.slice(7).trim() : "";
-  if (!(await isSubdeviceSessionValid(session, subdeviceInstallationId(c))))
+  const device = await getSubdeviceSession(subdeviceBearer(c), subdeviceInstallationId(c));
+  if (!device) {
     return c.json({ ok: false, error: "subdevice authentication required" }, 401);
+  }
+  const accountId = scopedAccountId(c.req.path);
+  if (accountId !== null && accountId !== device.accountId) {
+    return c.json({ ok: false, error: "subdevice account mismatch" }, 403);
+  }
   return next();
 }
 
+async function requireLocalOnLan(c: Context, next: () => Promise<void>) {
+  if (!LAN_ACCESS || c.req.header("x-vyline-local-request") === "1") return next();
+  return c.json({ ok: false, error: "local request required" }, 403);
+}
+
 app.use("/line/*", requireLanSubdevice);
-app.use("/debug/*", requireLanSubdevice);
+app.use("/beta/agent-i/*", requireLanSubdevice);
+app.use("/debug/*", requireLocalOnLan);
 
 app.use("/api/*", async (c, next) => {
   if (!LAN_ACCESS || c.req.header("x-vyline-local-request") === "1") return next();
   if (isPublicPairingRequest(c.req.path, c.req.method)) return next();
-  const auth = c.req.header("authorization") ?? "";
-  const session = auth.startsWith("Bearer ") ? auth.slice(7).trim() : "";
-  if (!(await isSubdeviceSessionValid(session, subdeviceInstallationId(c)))) {
-    return c.json({ ok: false, error: "subdevice authentication required" }, 401);
+  if (/^\/api\/debug(?:\/|$)/.test(c.req.path)) return requireLocalOnLan(c, next);
+  if (/^\/api\/auth(?:\/|$)/.test(c.req.path)) {
+    if (!isSubdeviceAuthRequest(c.req.path)) return requireLocalOnLan(c, next);
+    return requireLanSubdevice(c, next);
   }
-  return next();
+  return requireLanSubdevice(c, next);
 });
 app.use("/auth/*", async (c, next) => {
   if (!LAN_ACCESS || c.req.header("x-vyline-local-request") === "1") return next();
   if (isPublicPairingRequest(c.req.path, c.req.method)) return next();
-  const auth = c.req.header("authorization") ?? "";
-  const session = auth.startsWith("Bearer ") ? auth.slice(7).trim() : "";
-  if (!(await isSubdeviceSessionValid(session, subdeviceInstallationId(c)))) {
-    return c.json({ ok: false, error: "subdevice authentication required" }, 401);
-  }
-  return next();
+  if (!isSubdeviceAuthRequest(c.req.path)) return requireLocalOnLan(c, next);
+  return requireLanSubdevice(c, next);
 });
 
 app.get("/healthz", (c) => c.json({ ok: true, status: "ready" }));
@@ -347,17 +372,24 @@ export default {
     const url = new URL(request.url);
     const m = url.pathname.match(/^\/line\/([^/]+)\/call\/ws$/);
     if (m && request.headers.get("upgrade")?.toLowerCase() === "websocket") {
-      if (
-        LAN_ACCESS &&
-        !local &&
-        !(await isSubdeviceSessionValid(
+      let accountId: string;
+      try {
+        accountId = decodeURIComponent(m[1]!);
+      } catch {
+        return new Response("invalid accountId", { status: 400 });
+      }
+      if (LAN_ACCESS && !local) {
+        const device = await getSubdeviceSession(
           (request.headers.get("authorization") ?? "").replace(/^Bearer\s+/i, ""),
           request.headers.get("x-vyline-installation-id") ?? undefined,
-        ))
-      ) {
-        return new Response("subdevice authentication required", { status: 401 });
+        );
+        if (!device) {
+          return new Response("subdevice authentication required", { status: 401 });
+        }
+        if (device.accountId !== accountId) {
+          return new Response("subdevice account mismatch", { status: 403 });
+        }
       }
-      const accountId = decodeURIComponent(m[1]!);
       const sessionId = url.searchParams.get("sessionId");
       if (!sessionId) {
         return new Response("sessionId required", { status: 400 });

--- a/Vyline/backend/src/index.ts
+++ b/Vyline/backend/src/index.ts
@@ -123,8 +123,10 @@ async function requireLocalOnLan(c: Context, next: () => Promise<void>) {
 }
 
 app.use("/line/*", requireLanSubdevice);
+app.use("/line/:accountId/proxy", requireLocalOnLan);
 app.use("/beta/agent-i/*", requireLanSubdevice);
 app.use("/debug/*", requireLocalOnLan);
+app.use("/api/line/:accountId/proxy", requireLocalOnLan);
 
 app.use("/api/*", async (c, next) => {
   if (!LAN_ACCESS || c.req.header("x-vyline-local-request") === "1") return next();

--- a/Vyline/backend/src/index.ts
+++ b/Vyline/backend/src/index.ts
@@ -19,7 +19,7 @@ import { debugRouter } from "./api/debug.js";
 import { cdnRouter } from "./api/cdn.js";
 import { publicRouter } from "./api/public.js";
 import { lineOpenApiSpec } from "./api/openapi.line.js";
-import { restoreAllSessions } from "./line/clientManager.js";
+import { getClient, restoreAllSessions } from "./line/clientManager.js";
 import { initVylineProfile } from "./vyline/profileBridge.js";
 import { warmAccountCache } from "./storage/chatStore.js";
 import type { CallWsData } from "./call/callManager.js";
@@ -69,13 +69,20 @@ function isSubdeviceAuthRequest(path: string) {
   return /^\/(?:api\/)?auth\/subdevices(?:\/|$)/.test(path);
 }
 
-function scopedAccountId(path: string): string | null {
-  const match = path.match(/^\/(?:api\/)?(?:line|beta\/agent-i)\/([^/]+)(?:\/|$)/);
+type AccountScope = { kind: "accountId" | "mid"; value: string };
+
+function scopedAccount(path: string): AccountScope | null {
+  const accountMatch = path.match(/^\/(?:api\/)?(?:line|beta\/agent-i)\/([^/]+)(?:\/|$)/);
+  const midMatch = path.match(/^\/api\/(?:settings\/accounts|handoff|diagnostics)\/([^/]+)(?:\/|$)/);
+  const match = accountMatch ?? midMatch;
   if (!match) return null;
   try {
-    return decodeURIComponent(match[1]!);
+    return {
+      kind: accountMatch ? "accountId" : "mid",
+      value: decodeURIComponent(match[1]!),
+    };
   } catch {
-    return "";
+    return { kind: accountMatch ? "accountId" : "mid", value: "" };
   }
 }
 
@@ -96,9 +103,16 @@ async function requireLanSubdevice(c: Context, next: () => Promise<void>) {
   if (!device) {
     return c.json({ ok: false, error: "subdevice authentication required" }, 401);
   }
-  const accountId = scopedAccountId(c.req.path);
-  if (accountId !== null && accountId !== device.accountId) {
+  const scope = scopedAccount(c.req.path);
+  if (scope?.kind === "accountId" && scope.value !== device.accountId) {
     return c.json({ ok: false, error: "subdevice account mismatch" }, 403);
+  }
+  if (scope?.kind === "mid") {
+    const clientMid = String(getClient(device.accountId)?.base.profile?.mid ?? "");
+    const ownMid = clientMid || (/^u[0-9a-f]{32}$/i.test(device.accountId) ? device.accountId : "");
+    if (!ownMid || scope.value !== ownMid) {
+      return c.json({ ok: false, error: "subdevice account mismatch" }, 403);
+    }
   }
   return next();
 }

--- a/Vyline/backend/src/service/backupService.security.test.ts
+++ b/Vyline/backend/src/service/backupService.security.test.ts
@@ -1,0 +1,27 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtemp, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const testRoot = await mkdtemp(join(tmpdir(), "vyline-backup-security-"));
+process.env.VYLINE_DATA_DIR = join(testRoot, "data");
+process.env.VYLINE_BACKUP_DIR = join(testRoot, "backups");
+
+const { createBackup, listBackups, readBackup } = await import("./backupService.js");
+
+afterAll(async () => {
+  await rm(testRoot, { recursive: true, force: true });
+});
+
+describe("VylineBackup path safety", () => {
+  test("sanitizes account IDs before using them in snapshot filenames", async () => {
+    const accountId = "../../outside";
+    const summary = await createBackup(accountId, { includeMedia: false });
+
+    expect(summary.id).not.toContain("..");
+    expect(summary.id).not.toMatch(/[\\/]/);
+    expect(await readdir(process.env.VYLINE_BACKUP_DIR!)).toEqual([`${summary.id}.json`]);
+    expect((await listBackups(accountId)).map((item) => item.id)).toContain(summary.id);
+    expect(await readBackup(accountId, summary.id)).not.toBeNull();
+  });
+});

--- a/Vyline/backend/src/service/backupService.ts
+++ b/Vyline/backend/src/service/backupService.ts
@@ -21,6 +21,7 @@ import {
   type StoredMessage,
 } from "../storage/chatStore.js";
 import { readMediaStorage, writeMediaStorage } from "../storage/mediaStorage.js";
+import { safePathComponent } from "../storage/safeFile.js";
 
 const log = childLogger("vyline-backup");
 
@@ -77,7 +78,8 @@ function snapshotPath(id: string): string {
 
 function idFor(accountId: string, date: Date): string {
   const stamp = date.toISOString().replace(/[:.]/g, "-");
-  return `vyline-backup-${accountId}-${stamp}`;
+  const safeAccountId = safePathComponent(accountId, "account");
+  return `vyline-backup-${safeAccountId}-${stamp}`;
 }
 
 function asString(v: unknown): string {
@@ -185,7 +187,7 @@ export async function createBackup(
 
 export async function listBackups(accountId: string): Promise<BackupSummary[]> {
   await ensureBackupDir();
-  const prefix = `vyline-backup-${accountId}-`;
+  const prefix = `vyline-backup-${safePathComponent(accountId, "account")}-`;
   let files: string[] = [];
   try {
     files = await readdir(BACKUP_DIR);

--- a/Vyline/backend/src/service/backupService.ts
+++ b/Vyline/backend/src/service/backupService.ts
@@ -76,10 +76,13 @@ function snapshotPath(id: string): string {
   return join(BACKUP_DIR, `${id}.json`);
 }
 
+function backupAccountComponent(accountId: string): string {
+  return safePathComponent(accountId, "account").replace(/\.+/g, "_");
+}
+
 function idFor(accountId: string, date: Date): string {
   const stamp = date.toISOString().replace(/[:.]/g, "-");
-  const safeAccountId = safePathComponent(accountId, "account");
-  return `vyline-backup-${safeAccountId}-${stamp}`;
+  return `vyline-backup-${backupAccountComponent(accountId)}-${stamp}`;
 }
 
 function asString(v: unknown): string {
@@ -187,7 +190,7 @@ export async function createBackup(
 
 export async function listBackups(accountId: string): Promise<BackupSummary[]> {
   await ensureBackupDir();
-  const prefix = `vyline-backup-${safePathComponent(accountId, "account")}-`;
+  const prefix = `vyline-backup-${backupAccountComponent(accountId)}-`;
   let files: string[] = [];
   try {
     files = await readdir(BACKUP_DIR);

--- a/Vyline/backend/src/storage/subdeviceStore.deviceBinding.test.ts
+++ b/Vyline/backend/src/storage/subdeviceStore.deviceBinding.test.ts
@@ -6,8 +6,13 @@ import { join } from "node:path";
 const testDataDir = await mkdtemp(join(tmpdir(), "vyline-subdevice-device-binding-"));
 process.env.VYLINE_DATA_DIR = testDataDir;
 
-const { authenticateSubdevice, completePairing, createPairing, isSubdeviceSessionValid } =
-  await import("./subdeviceStore.js");
+const {
+  authenticateSubdevice,
+  completePairing,
+  createPairing,
+  getSubdeviceSession,
+  isSubdeviceSessionValid,
+} = await import("./subdeviceStore.js");
 
 afterAll(async () => {
   await rm(testDataDir, { force: true, recursive: true });
@@ -25,5 +30,9 @@ describe("subdevice installation binding", () => {
     expect(await authenticateSubdevice(completed!.sessionToken, otherInstallationId)).toBeNull();
     expect(await isSubdeviceSessionValid(completed!.sessionToken, installationId)).toBe(true);
     expect(await isSubdeviceSessionValid(completed!.sessionToken, otherInstallationId)).toBe(false);
+    expect(await getSubdeviceSession(completed!.sessionToken, installationId)).toMatchObject({
+      accountId: "main",
+    });
+    expect(await getSubdeviceSession(completed!.sessionToken, otherInstallationId)).toBeNull();
   });
 });

--- a/Vyline/backend/src/storage/subdeviceStore.ts
+++ b/Vyline/backend/src/storage/subdeviceStore.ts
@@ -175,7 +175,10 @@ export async function listSubdevices() {
   return devices.map(toSafeDevice);
 }
 
-async function resolveSubdeviceSession(raw: string, installationId?: string): Promise<Subdevice | null> {
+async function resolveSubdeviceSession(
+  raw: string,
+  installationId?: string,
+): Promise<Subdevice | null> {
   const state = await load();
   const device = state.devices.find((d) => d.tokenHash === hash(raw));
   if (!device || device.blocked) return null;

--- a/Vyline/backend/src/storage/subdeviceStore.ts
+++ b/Vyline/backend/src/storage/subdeviceStore.ts
@@ -175,40 +175,41 @@ export async function listSubdevices() {
   return devices.map(toSafeDevice);
 }
 
-export async function authenticateSubdevice(raw: string, installationId?: string) {
+async function resolveSubdeviceSession(raw: string, installationId?: string): Promise<Subdevice | null> {
   const state = await load();
   const device = state.devices.find((d) => d.tokenHash === hash(raw));
   if (!device || device.blocked) return null;
-  if (device.installationIdHash) {
-    if (
-      !isValidInstallationId(installationId) ||
-      device.installationIdHash !== hash(installationId)
-    ) {
-      return null;
-    }
-  } else if (isValidInstallationId(installationId)) {
+  if (!device.installationIdHash) {
+    if (!isValidInstallationId(installationId)) return null;
     // One-time migration for a session created before installation binding existed.
     device.installationIdHash = hash(installationId);
+    await save(state);
+  } else if (
+    !isValidInstallationId(installationId) ||
+    device.installationIdHash !== hash(installationId)
+  ) {
+    return null;
   }
+  return device;
+}
+
+/** Validates a subdevice session without updating lastSeenAt, and returns its account scope. */
+export async function getSubdeviceSession(raw: string, installationId?: string) {
+  const device = await resolveSubdeviceSession(raw, installationId);
+  return device ? toSafeDevice(device) : null;
+}
+
+export async function authenticateSubdevice(raw: string, installationId?: string) {
+  const device = await resolveSubdeviceSession(raw, installationId);
+  if (!device) return null;
+  const state = await load();
   device.lastSeenAt = new Date().toISOString();
   await save(state);
   return toSafeDevice(device);
 }
 
 export async function isSubdeviceSessionValid(raw: string, installationId?: string) {
-  const state = await load();
-  const device = state.devices.find((d) => d.tokenHash === hash(raw));
-  if (!device || device.blocked) return false;
-  if (!device.installationIdHash) {
-    if (!isValidInstallationId(installationId)) return false;
-    // Bind legacy sessions at their first valid request so copied tokens cannot race a heartbeat.
-    device.installationIdHash = hash(installationId);
-    await save(state);
-    return true;
-  }
-  return (
-    isValidInstallationId(installationId) && device.installationIdHash === hash(installationId)
-  );
+  return Boolean(await resolveSubdeviceSession(raw, installationId));
 }
 
 export async function removeSubdevice(id: string) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,12 +4,14 @@ services:
     build: .
     pull_policy: missing
     ports:
-      - "3000:3000"
+      # Secure default: do not publish Vyline to the LAN unless explicitly opted in.
+      - "${VYLINE_BIND_ADDRESS:-127.0.0.1}:3000:3000"
     volumes:
       - ./data:/app/data
       - ./storage:/app/storage
     environment:
       - VYLINE_HOST=0.0.0.0
+      - VYLINE_LAN_ACCESS=${VYLINE_LAN_ACCESS:-false}
       - PORT=3000
       - VYLINE_DATA_DIR=/app/data
       - VYLINE_STORAGE_DIR=/app/storage

--- a/docs/subdevices.md
+++ b/docs/subdevices.md
@@ -13,7 +13,17 @@ $env:VYLINE_LAN_ACCESS = "true"
 bun run dev
 ```
 
-本番ビルドやDockerでは、同じ環境変数をサーバーの環境に設定します。`false`（既定）の場合、サーバーはlocalhostのみで待ち受けます。
+Docker Compose は安全のため既定でホストの `127.0.0.1:3000` にだけ公開します。LANから接続するときは、待受公開とサブデバイス認証をセットで有効にしてください。
+
+PowerShell:
+
+```powershell
+$env:VYLINE_BIND_ADDRESS = "0.0.0.0"
+$env:VYLINE_LAN_ACCESS = "true"
+docker compose up -d --build
+```
+
+`VYLINE_BIND_ADDRESS=0.0.0.0` だけを設定して認証を無効のまま公開しないでください。通常利用では両方とも未設定のままで構いません。
 
 ## 接続
 


### PR DESCRIPTION
Follow-up security hardening after #134.

## Confirmed findings

1. Docker Compose published `3000:3000` on all host interfaces while `VYLINE_LAN_ACCESS` remained disabled by default, making the BFF reachable from other LAN devices without subdevice authentication.
2. The legacy `/beta/agent-i/*` mount bypassed the LAN middleware that covered `/api/*`.
3. A paired LAN subdevice could reach `/auth/token/:id` and retrieve the PC-side LINE `authToken`.
4. A subdevice paired to one account could address another account's LINE, Agent I, and call WebSocket routes because session validation did not enforce the pairing account scope.
5. Paired LAN subdevices could reach PC-level auth/debug endpoints that should remain local-only.
6. Account-owned settings, handoff, and diagnostics routes were not bound to the pairing account's MID.
7. Backup snapshot filenames embedded raw `accountId`, allowing path-shaping/traversal input.

## Changes

- Bind Docker Compose to `127.0.0.1:3000` by default and require explicit LAN opt-in.
- Pass `VYLINE_LAN_ACCESS` through Docker Compose and make the direct `docker run` example loopback-only.
- Enforce paired-account scope for LINE, Agent I, account-owned setup/handoff/diagnostics, and call WebSocket access.
- Keep normal auth management and debug endpoints local-only during LAN mode while preserving subdevice pairing/heartbeat flows.
- Restrict `/auth/token/:id` to requests proven local by the backend request-IP boundary.
- Sanitize the account component used in backup filenames and use the same canonical component for listing/restoring snapshots.
- Add regression tests for device installation/account binding, Agent I cross-account denial, and backup path containment.
- Document the secure Docker LAN opt-in flow.

## Validation

- GitHub CI on the final head: TypeScript ✅, Lint ✅, Build ✅, Documentation ✅, Docker build + runtime smoke ✅.
- Security Scan: OSV dependency scan ✅.
- Trivy filesystem/container scans are intentionally skipped on pull requests by workflow policy.
- Regression test files are included; the repository's current CI workflow does not run `bun test`.
- No secrets or user data added.