### PR TITLE
Add Note/Album UI and iOS session support

### DIFF
--- a/Vyline/apps/desktop/src/api/client.ts
+++ b/Vyline/apps/desktop/src/api/client.ts
@@ -115,6 +115,26 @@ async function request<T>(
   }
 }
 
+async function requestBlob<T>(method: string, path: string, blob: Blob): Promise<T> {
+  const sessionToken =
+    typeof localStorage !== "undefined" ? localStorage.getItem("vyline:subdevice-session") : null;
+  const installationId = getSubdeviceInstallationId();
+  const res = await fetch(`${BASE}${path}`, {
+    method,
+    headers: {
+      "Content-Type": blob.type || "application/octet-stream",
+      ...(sessionToken ? { Authorization: `Bearer ${sessionToken}` } : {}),
+      ...(installationId ? { "X-Vyline-Installation-Id": installationId } : {}),
+    },
+    body: blob,
+  });
+  const text = await res.text();
+  if (!text.trim()) throw new Error(`サーバーが空の応答を返しました (HTTP ${res.status})`);
+  const parsed = JSON.parse(text) as T & { error?: string };
+  if (!res.ok) throw new Error(parsed.error ?? `HTTP ${res.status}`);
+  return parsed;
+}
+
 // ─── api ──────────────────────────────────────
 
 export const api = {
@@ -195,7 +215,17 @@ export const api = {
     loginQrPoll: (accountId: string) =>
       request<QrPollResponse>("GET", `/auth/login/qr/${accountId}`),
 
-    loginToken: (params: { accountId: string; authToken: string }) =>
+    contentQrStart: (accountId: string) =>
+      request<LoginResult>("POST", "/auth/content/qr", { accountId }),
+
+    contentQrPoll: (accountId: string) =>
+      request<QrPollResponse>("GET", `/auth/content/qr/${encodeURIComponent(accountId)}`),
+
+    loginToken: (params: {
+      accountId: string;
+      authToken: string;
+      deviceMode?: "IOS" | "IOSIPAD" | "ANDROIDSECONDARY" | "DESKTOPWIN" | "DESKTOPMAC";
+    }) =>
       request<LoginResult>("POST", "/auth/login/token", params),
 
     getToken: (accountId: string) =>
@@ -1156,6 +1186,157 @@ export const api = {
           "DELETE",
           `/line/${accountId}/announcements/${encodeURIComponent(chatMid)}/${seq}`,
         ),
+    },
+
+    notes: {
+      list: (accountId: string, homeId: string) =>
+        request<unknown>("GET", `/line/${accountId}/notes?homeId=${encodeURIComponent(homeId)}`),
+      updates: (accountId: string, revision: number) =>
+        request<unknown>(
+          "POST",
+          `/line/${accountId}/notes/updates?revision=${encodeURIComponent(String(revision))}`,
+        ),
+      get: (accountId: string, homeId: string, postId: string) =>
+        request<unknown>(
+          "GET",
+          `/line/${accountId}/notes/${encodeURIComponent(postId)}?homeId=${encodeURIComponent(homeId)}`,
+        ),
+        create: (
+          accountId: string,
+          input: {
+            homeId: string;
+            text?: string;
+          sharedPostId?: string;
+          stickerIds?: string[];
+            stickerPackageIds?: string[];
+            mediaObjectIds?: string[];
+            mediaObjectTypes?: string[];
+            contents?: Record<string, unknown>;
+            postInfo?: Record<string, unknown>;
+          },
+        ) => request<unknown>("POST", `/line/${accountId}/notes`, input),
+      update: (
+        accountId: string,
+        postId: string,
+        input: {
+          homeId: string;
+          text?: string;
+          sharedPostId?: string;
+          stickerIds?: string[];
+            stickerPackageIds?: string[];
+            mediaObjectIds?: string[];
+            mediaObjectTypes?: string[];
+            contents?: Record<string, unknown>;
+            postInfo?: Record<string, unknown>;
+          },
+        ) => request<unknown>("PATCH", `/line/${accountId}/notes/${encodeURIComponent(postId)}`, input),
+      remove: (accountId: string, homeId: string, postId: string) =>
+        request<unknown>(
+          "DELETE",
+          `/line/${accountId}/notes/${encodeURIComponent(postId)}?homeId=${encodeURIComponent(homeId)}`,
+        ),
+        share: (accountId: string, postId: string, homeId: string) =>
+          request<unknown>("POST", `/line/${accountId}/notes/${encodeURIComponent(postId)}/share`, {
+            homeId,
+          }),
+      like: (accountId: string, postId: string, homeId: string, likeType?: string) =>
+          request<unknown>("POST", `/line/${accountId}/notes/${encodeURIComponent(postId)}/like`, {
+            homeId,
+            likeType,
+          }),
+        unlike: (accountId: string, postId: string, homeId: string) =>
+          request<unknown>(
+            "DELETE",
+            `/line/${accountId}/notes/${encodeURIComponent(postId)}/like?homeId=${encodeURIComponent(homeId)}`,
+          ),
+        getLike: (accountId: string, postId: string, homeId: string) =>
+          request<unknown>(
+            "GET",
+            `/line/${accountId}/notes/${encodeURIComponent(postId)}/like?homeId=${encodeURIComponent(homeId)}`,
+          ),
+        listLikes: (accountId: string, postId: string, homeId: string) =>
+          request<unknown>(
+            "GET",
+            `/line/${accountId}/notes/${encodeURIComponent(postId)}/likes?homeId=${encodeURIComponent(homeId)}`,
+          ),
+      comment: (
+        accountId: string,
+        postId: string,
+        homeId: string,
+        text?: string,
+        imageObjectId?: string,
+      ) =>
+        request<unknown>("POST", `/line/${accountId}/notes/${encodeURIComponent(postId)}/comments`, {
+          homeId,
+          text,
+          imageObjectId,
+        }),
+      uploadMedia: (accountId: string, type: "image" | "video", blob: Blob) =>
+        requestBlob<{ objId: string; objHash: string }>(
+          "POST",
+          `/line/${accountId}/notes/media/${type}`,
+          blob,
+        ),
+      uploadCommentImage: (accountId: string, blob: Blob) =>
+        requestBlob<{ objId: string; objHash: string }>(
+          "POST",
+          `/line/${accountId}/notes/comment-image`,
+          blob,
+        ),
+    },
+
+      albums: {
+        list: (accountId: string, query: Record<string, string> = {}) => {
+          const qs = new URLSearchParams(query).toString();
+          return request<unknown>("GET", `/line/${accountId}/albums${qs ? `?${qs}` : ""}`);
+        },
+        preview: (accountId: string, chatId: string) =>
+          request<unknown>("GET", `/line/${accountId}/albums/preview?chatId=${encodeURIComponent(chatId)}`),
+        create: (accountId: string, chatId: string, title: string) =>
+          request<unknown>("POST", `/line/${accountId}/albums`, { chatId, title }),
+        rename: (accountId: string, albumId: string, chatId: string, title: string) =>
+          request<unknown>("PATCH", `/line/${accountId}/albums/${encodeURIComponent(albumId)}`, { chatId, title }),
+        remove: (accountId: string, albumId: string, chatId: string) =>
+          request<unknown>(
+            "DELETE",
+            `/line/${accountId}/albums/${encodeURIComponent(albumId)}?chatId=${encodeURIComponent(chatId)}`,
+          ),
+        share: (accountId: string, albumId: string, chatId: string) =>
+          request<unknown>("POST", `/line/${accountId}/albums/${encodeURIComponent(albumId)}/share`, { chatId }),
+        uploadMedia: (accountId: string, albumId: string, chatId: string, blob: Blob) =>
+          requestBlob<{ oid: string }>(
+            "POST",
+            `/line/${accountId}/albums/${encodeURIComponent(albumId)}/media?chatId=${encodeURIComponent(chatId)}`,
+            blob,
+          ),
+        addPhotos: (
+          accountId: string,
+          albumId: string,
+          chatId: string,
+          photos: Array<{
+            obsResourceId: { oid: string; sid?: string; svc?: string };
+            width: number;
+            height: number;
+            shotTime?: number;
+            resourceType?: string;
+          }>,
+        ) => request<unknown>("POST", `/line/${accountId}/albums/${encodeURIComponent(albumId)}/photos`, { chatId, photos }),
+        deletePhotos: (accountId: string, albumId: string, chatId: string, photoIds: string[]) =>
+          request<unknown>("DELETE", `/line/${accountId}/albums/${encodeURIComponent(albumId)}/photos`, { chatId, photoIds }),
+      photos: (accountId: string, albumId: string, chatId: string, query: Record<string, string> = {}) => {
+        const qs = new URLSearchParams({ chatId, ...query }).toString();
+        return request<unknown>(
+          "GET",
+          `/line/${accountId}/albums/${encodeURIComponent(albumId)}/photos?${qs}`,
+        );
+      },
+      mediaUrl: (
+        accountId: string,
+        albumId: string,
+        oid: string,
+        chatId: string,
+        mediaType: "image" | "video" = "image",
+      ) => `/api/line/${accountId}/albums/${encodeURIComponent(albumId)}/media/${encodeURIComponent(oid)}?${new URLSearchParams({ chatId, mediaType })}`,
     },
   },
   debug: {

--- a/Vyline/apps/desktop/src/api/client.ts
+++ b/Vyline/apps/desktop/src/api/client.ts
@@ -225,8 +225,7 @@ export const api = {
       accountId: string;
       authToken: string;
       deviceMode?: "IOS" | "IOSIPAD" | "ANDROIDSECONDARY" | "DESKTOPWIN" | "DESKTOPMAC";
-    }) =>
-      request<LoginResult>("POST", "/auth/login/token", params),
+    }) => request<LoginResult>("POST", "/auth/login/token", params),
 
     getToken: (accountId: string) =>
       request<{ ok: boolean; token?: string; error?: string }>(
@@ -1201,20 +1200,20 @@ export const api = {
           "GET",
           `/line/${accountId}/notes/${encodeURIComponent(postId)}?homeId=${encodeURIComponent(homeId)}`,
         ),
-        create: (
-          accountId: string,
-          input: {
-            homeId: string;
-            text?: string;
+      create: (
+        accountId: string,
+        input: {
+          homeId: string;
+          text?: string;
           sharedPostId?: string;
           stickerIds?: string[];
-            stickerPackageIds?: string[];
-            mediaObjectIds?: string[];
-            mediaObjectTypes?: string[];
-            contents?: Record<string, unknown>;
-            postInfo?: Record<string, unknown>;
-          },
-        ) => request<unknown>("POST", `/line/${accountId}/notes`, input),
+          stickerPackageIds?: string[];
+          mediaObjectIds?: string[];
+          mediaObjectTypes?: string[];
+          contents?: Record<string, unknown>;
+          postInfo?: Record<string, unknown>;
+        },
+      ) => request<unknown>("POST", `/line/${accountId}/notes`, input),
       update: (
         accountId: string,
         postId: string,
@@ -1223,42 +1222,43 @@ export const api = {
           text?: string;
           sharedPostId?: string;
           stickerIds?: string[];
-            stickerPackageIds?: string[];
-            mediaObjectIds?: string[];
-            mediaObjectTypes?: string[];
-            contents?: Record<string, unknown>;
-            postInfo?: Record<string, unknown>;
-          },
-        ) => request<unknown>("PATCH", `/line/${accountId}/notes/${encodeURIComponent(postId)}`, input),
+          stickerPackageIds?: string[];
+          mediaObjectIds?: string[];
+          mediaObjectTypes?: string[];
+          contents?: Record<string, unknown>;
+          postInfo?: Record<string, unknown>;
+        },
+      ) =>
+        request<unknown>("PATCH", `/line/${accountId}/notes/${encodeURIComponent(postId)}`, input),
       remove: (accountId: string, homeId: string, postId: string) =>
         request<unknown>(
           "DELETE",
           `/line/${accountId}/notes/${encodeURIComponent(postId)}?homeId=${encodeURIComponent(homeId)}`,
         ),
-        share: (accountId: string, postId: string, homeId: string) =>
-          request<unknown>("POST", `/line/${accountId}/notes/${encodeURIComponent(postId)}/share`, {
-            homeId,
-          }),
+      share: (accountId: string, postId: string, homeId: string) =>
+        request<unknown>("POST", `/line/${accountId}/notes/${encodeURIComponent(postId)}/share`, {
+          homeId,
+        }),
       like: (accountId: string, postId: string, homeId: string, likeType?: string) =>
-          request<unknown>("POST", `/line/${accountId}/notes/${encodeURIComponent(postId)}/like`, {
-            homeId,
-            likeType,
-          }),
-        unlike: (accountId: string, postId: string, homeId: string) =>
-          request<unknown>(
-            "DELETE",
-            `/line/${accountId}/notes/${encodeURIComponent(postId)}/like?homeId=${encodeURIComponent(homeId)}`,
-          ),
-        getLike: (accountId: string, postId: string, homeId: string) =>
-          request<unknown>(
-            "GET",
-            `/line/${accountId}/notes/${encodeURIComponent(postId)}/like?homeId=${encodeURIComponent(homeId)}`,
-          ),
-        listLikes: (accountId: string, postId: string, homeId: string) =>
-          request<unknown>(
-            "GET",
-            `/line/${accountId}/notes/${encodeURIComponent(postId)}/likes?homeId=${encodeURIComponent(homeId)}`,
-          ),
+        request<unknown>("POST", `/line/${accountId}/notes/${encodeURIComponent(postId)}/like`, {
+          homeId,
+          likeType,
+        }),
+      unlike: (accountId: string, postId: string, homeId: string) =>
+        request<unknown>(
+          "DELETE",
+          `/line/${accountId}/notes/${encodeURIComponent(postId)}/like?homeId=${encodeURIComponent(homeId)}`,
+        ),
+      getLike: (accountId: string, postId: string, homeId: string) =>
+        request<unknown>(
+          "GET",
+          `/line/${accountId}/notes/${encodeURIComponent(postId)}/like?homeId=${encodeURIComponent(homeId)}`,
+        ),
+      listLikes: (accountId: string, postId: string, homeId: string) =>
+        request<unknown>(
+          "GET",
+          `/line/${accountId}/notes/${encodeURIComponent(postId)}/likes?homeId=${encodeURIComponent(homeId)}`,
+        ),
       comment: (
         accountId: string,
         postId: string,
@@ -1266,11 +1266,15 @@ export const api = {
         text?: string,
         imageObjectId?: string,
       ) =>
-        request<unknown>("POST", `/line/${accountId}/notes/${encodeURIComponent(postId)}/comments`, {
-          homeId,
-          text,
-          imageObjectId,
-        }),
+        request<unknown>(
+          "POST",
+          `/line/${accountId}/notes/${encodeURIComponent(postId)}/comments`,
+          {
+            homeId,
+            text,
+            imageObjectId,
+          },
+        ),
       uploadMedia: (accountId: string, type: "image" | "video", blob: Blob) =>
         requestBlob<{ objId: string; objHash: string }>(
           "POST",
@@ -1285,45 +1289,67 @@ export const api = {
         ),
     },
 
-      albums: {
-        list: (accountId: string, query: Record<string, string> = {}) => {
-          const qs = new URLSearchParams(query).toString();
-          return request<unknown>("GET", `/line/${accountId}/albums${qs ? `?${qs}` : ""}`);
-        },
-        preview: (accountId: string, chatId: string) =>
-          request<unknown>("GET", `/line/${accountId}/albums/preview?chatId=${encodeURIComponent(chatId)}`),
-        create: (accountId: string, chatId: string, title: string) =>
-          request<unknown>("POST", `/line/${accountId}/albums`, { chatId, title }),
-        rename: (accountId: string, albumId: string, chatId: string, title: string) =>
-          request<unknown>("PATCH", `/line/${accountId}/albums/${encodeURIComponent(albumId)}`, { chatId, title }),
-        remove: (accountId: string, albumId: string, chatId: string) =>
-          request<unknown>(
-            "DELETE",
-            `/line/${accountId}/albums/${encodeURIComponent(albumId)}?chatId=${encodeURIComponent(chatId)}`,
-          ),
-        share: (accountId: string, albumId: string, chatId: string) =>
-          request<unknown>("POST", `/line/${accountId}/albums/${encodeURIComponent(albumId)}/share`, { chatId }),
-        uploadMedia: (accountId: string, albumId: string, chatId: string, blob: Blob) =>
-          requestBlob<{ oid: string }>(
-            "POST",
-            `/line/${accountId}/albums/${encodeURIComponent(albumId)}/media?chatId=${encodeURIComponent(chatId)}`,
-            blob,
-          ),
-        addPhotos: (
-          accountId: string,
-          albumId: string,
-          chatId: string,
-          photos: Array<{
-            obsResourceId: { oid: string; sid?: string; svc?: string };
-            width: number;
-            height: number;
-            shotTime?: number;
-            resourceType?: string;
-          }>,
-        ) => request<unknown>("POST", `/line/${accountId}/albums/${encodeURIComponent(albumId)}/photos`, { chatId, photos }),
-        deletePhotos: (accountId: string, albumId: string, chatId: string, photoIds: string[]) =>
-          request<unknown>("DELETE", `/line/${accountId}/albums/${encodeURIComponent(albumId)}/photos`, { chatId, photoIds }),
-      photos: (accountId: string, albumId: string, chatId: string, query: Record<string, string> = {}) => {
+    albums: {
+      list: (accountId: string, query: Record<string, string> = {}) => {
+        const qs = new URLSearchParams(query).toString();
+        return request<unknown>("GET", `/line/${accountId}/albums${qs ? `?${qs}` : ""}`);
+      },
+      preview: (accountId: string, chatId: string) =>
+        request<unknown>(
+          "GET",
+          `/line/${accountId}/albums/preview?chatId=${encodeURIComponent(chatId)}`,
+        ),
+      create: (accountId: string, chatId: string, title: string) =>
+        request<unknown>("POST", `/line/${accountId}/albums`, { chatId, title }),
+      rename: (accountId: string, albumId: string, chatId: string, title: string) =>
+        request<unknown>("PATCH", `/line/${accountId}/albums/${encodeURIComponent(albumId)}`, {
+          chatId,
+          title,
+        }),
+      remove: (accountId: string, albumId: string, chatId: string) =>
+        request<unknown>(
+          "DELETE",
+          `/line/${accountId}/albums/${encodeURIComponent(albumId)}?chatId=${encodeURIComponent(chatId)}`,
+        ),
+      share: (accountId: string, albumId: string, chatId: string) =>
+        request<unknown>("POST", `/line/${accountId}/albums/${encodeURIComponent(albumId)}/share`, {
+          chatId,
+        }),
+      uploadMedia: (accountId: string, albumId: string, chatId: string, blob: Blob) =>
+        requestBlob<{ oid: string }>(
+          "POST",
+          `/line/${accountId}/albums/${encodeURIComponent(albumId)}/media?chatId=${encodeURIComponent(chatId)}`,
+          blob,
+        ),
+      addPhotos: (
+        accountId: string,
+        albumId: string,
+        chatId: string,
+        photos: Array<{
+          obsResourceId: { oid: string; sid?: string; svc?: string };
+          width: number;
+          height: number;
+          shotTime?: number;
+          resourceType?: string;
+        }>,
+      ) =>
+        request<unknown>(
+          "POST",
+          `/line/${accountId}/albums/${encodeURIComponent(albumId)}/photos`,
+          { chatId, photos },
+        ),
+      deletePhotos: (accountId: string, albumId: string, chatId: string, photoIds: string[]) =>
+        request<unknown>(
+          "DELETE",
+          `/line/${accountId}/albums/${encodeURIComponent(albumId)}/photos`,
+          { chatId, photoIds },
+        ),
+      photos: (
+        accountId: string,
+        albumId: string,
+        chatId: string,
+        query: Record<string, string> = {},
+      ) => {
         const qs = new URLSearchParams({ chatId, ...query }).toString();
         return request<unknown>(
           "GET",
@@ -1336,7 +1362,8 @@ export const api = {
         oid: string,
         chatId: string,
         mediaType: "image" | "video" = "image",
-      ) => `/api/line/${accountId}/albums/${encodeURIComponent(albumId)}/media/${encodeURIComponent(oid)}?${new URLSearchParams({ chatId, mediaType })}`,
+      ) =>
+        `/api/line/${accountId}/albums/${encodeURIComponent(albumId)}/media/${encodeURIComponent(oid)}?${new URLSearchParams({ chatId, mediaType })}`,
     },
   },
   debug: {

--- a/Vyline/apps/desktop/src/components/message-bubble.tsx
+++ b/Vyline/apps/desktop/src/components/message-bubble.tsx
@@ -32,7 +32,11 @@ import {
   IconEdit,
 } from "@/components/icons";
 import { copyText, downloadUrl } from "@/utils/clipboard";
-import { segmentTextWithSticon, segmentUnicodeEmoji, type SticonResource } from "@/utils/lineSticon";
+import {
+  segmentTextWithSticon,
+  segmentUnicodeEmoji,
+  type SticonResource,
+} from "@/utils/lineSticon";
 import { lineCdnProxy, hideBrokenMedia, lineStickerUrl } from "@/utils/lineMedia";
 import { segmentTextWithMentions, type DraftSegment } from "@/utils/mention";
 
@@ -107,10 +111,12 @@ function findAlbumRecord(value: unknown, albumId: string): Record<string, unknow
   const result = objectRecord(root?.result) ?? root;
   const albums = result?.albums;
   if (!Array.isArray(albums)) return null;
-  return albums.find((album) => {
-    const record = objectRecord(album);
-    return String(record?.albumId ?? record?.id ?? "") === albumId;
-  }) as Record<string, unknown> | undefined ?? null;
+  return (
+    (albums.find((album) => {
+      const record = objectRecord(album);
+      return String(record?.albumId ?? record?.id ?? "") === albumId;
+    }) as Record<string, unknown> | undefined) ?? null
+  );
 }
 
 function noteSticons(post: Record<string, unknown> | null): SticonResource[] {
@@ -123,13 +129,15 @@ function noteSticons(post: Record<string, unknown> | null): SticonResource[] {
     if (!productId || !sticonId) return [];
     const S = Number(record?.S ?? record?.start);
     const E = Number(record?.E ?? record?.end);
-    return [{
-      productId,
-      sticonId,
-      ...(Number.isFinite(S) ? { S } : {}),
-      ...(Number.isFinite(E) ? { E } : {}),
-      ...(typeof record?.alt === "string" ? { alt: record.alt } : {}),
-    }];
+    return [
+      {
+        productId,
+        sticonId,
+        ...(Number.isFinite(S) ? { S } : {}),
+        ...(Number.isFinite(E) ? { E } : {}),
+        ...(typeof record?.alt === "string" ? { alt: record.alt } : {}),
+      },
+    ];
   });
 }
 
@@ -214,7 +222,9 @@ function PostNotificationCard({
               : "ノートが作成されました"}
           </p>
           {notification.kind === "album" && notification.mediaCount != null && (
-            <p className="mt-1 text-xs text-[var(--vy-text-dim)]">{notification.mediaCount}件のメディア</p>
+            <p className="mt-1 text-xs text-[var(--vy-text-dim)]">
+              {notification.mediaCount}件のメディア
+            </p>
           )}
           {loading && <p className="mt-2 text-xs text-[var(--vy-text-dim)]">読み込み中…</p>}
           {error && <p className="mt-2 text-xs text-[var(--vy-danger)]">{error}</p>}
@@ -247,7 +257,9 @@ function PostNotificationCard({
                 const objectId = String(item?.objectId ?? "");
                 const type = String(item?.type ?? "PHOTO").toUpperCase();
                 if (!objectId) return null;
-                const src = lineCdnProxy(`https://obs.line-apps.com/r/myhome/h/${encodeURIComponent(objectId)}`);
+                const src = lineCdnProxy(
+                  `https://obs.line-apps.com/r/myhome/h/${encodeURIComponent(objectId)}`,
+                );
                 return type === "VIDEO" ? (
                   <video
                     key={`${objectId}-${index}`}

--- a/Vyline/apps/desktop/src/components/message-bubble.tsx
+++ b/Vyline/apps/desktop/src/components/message-bubble.tsx
@@ -32,8 +32,8 @@ import {
   IconEdit,
 } from "@/components/icons";
 import { copyText, downloadUrl } from "@/utils/clipboard";
-import { segmentUnicodeEmoji } from "@/utils/lineSticon";
-import { lineCdnProxy, hideBrokenMedia } from "@/utils/lineMedia";
+import { segmentTextWithSticon, segmentUnicodeEmoji, type SticonResource } from "@/utils/lineSticon";
+import { lineCdnProxy, hideBrokenMedia, lineStickerUrl } from "@/utils/lineMedia";
 import { segmentTextWithMentions, type DraftSegment } from "@/utils/mention";
 
 function SpoilerMedia({ src, alt, video }: { src: string; alt: string; video?: boolean }) {
@@ -85,6 +85,200 @@ function LinkPreviewCard({ preview }: { preview: NonNullable<Message["linkPrevie
         <span className="line-clamp-2 block text-xs opacity-80">{preview.description}</span>
       </span>
     </a>
+  );
+}
+
+function objectRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function findPostRecord(value: unknown): Record<string, unknown> | null {
+  const root = objectRecord(value);
+  if (!root) return null;
+  const result = objectRecord(root.result) ?? root;
+  const post = objectRecord(result.post) ?? objectRecord(result.item) ?? result;
+  return objectRecord(post.contents) ?? post;
+}
+
+function findAlbumRecord(value: unknown, albumId: string): Record<string, unknown> | null {
+  const root = objectRecord(value);
+  const result = objectRecord(root?.result) ?? root;
+  const albums = result?.albums;
+  if (!Array.isArray(albums)) return null;
+  return albums.find((album) => {
+    const record = objectRecord(album);
+    return String(record?.albumId ?? record?.id ?? "") === albumId;
+  }) as Record<string, unknown> | undefined ?? null;
+}
+
+function noteSticons(post: Record<string, unknown> | null): SticonResource[] {
+  const raw = post?.sticonMetas;
+  if (!Array.isArray(raw)) return [];
+  return raw.flatMap((item) => {
+    const record = objectRecord(item);
+    const productId = String(record?.productId ?? record?.product_id ?? "");
+    const sticonId = String(record?.sticonId ?? record?.sticon_id ?? record?.id ?? "");
+    if (!productId || !sticonId) return [];
+    const S = Number(record?.S ?? record?.start);
+    const E = Number(record?.E ?? record?.end);
+    return [{
+      productId,
+      sticonId,
+      ...(Number.isFinite(S) ? { S } : {}),
+      ...(Number.isFinite(E) ? { E } : {}),
+      ...(typeof record?.alt === "string" ? { alt: record.alt } : {}),
+    }];
+  });
+}
+
+function NoteText({ text, sticons }: { text: string; sticons: SticonResource[] }) {
+  if (!sticons.length) return <Highlighted text={text} />;
+  return (
+    <>
+      {segmentTextWithSticon(text, sticons).map((segment, index) =>
+        segment.type === "sticon" ? (
+          <img
+            key={`${segment.url}-${index}`}
+            src={segment.url}
+            alt={segment.alt}
+            className="mx-0.5 inline-block h-6 w-6 align-text-bottom object-contain"
+            onError={hideBrokenMedia}
+          />
+        ) : (
+          <span key={index}>{segment.value}</span>
+        ),
+      )}
+    </>
+  );
+}
+
+function PostNotificationCard({
+  message,
+  accountId,
+}: {
+  message: Message;
+  accountId?: string;
+}) {
+  const notification = message.postNotification;
+  const [detail, setDetail] = useState<Record<string, unknown> | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  if (!notification || notification.kind === "unknown") return null;
+
+  const load = async () => {
+    if (!accountId || loading || detail) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const raw =
+        notification.kind === "note" && notification.homeId && notification.postId
+          ? await api.line.notes.get(accountId, notification.homeId, notification.postId)
+          : notification.kind === "album" && notification.albumId
+            ? await api.line.albums.list(accountId)
+            : null;
+      setDetail(
+        notification.kind === "album" && notification.albumId
+          ? findAlbumRecord(raw, notification.albumId)
+          : objectRecord(raw),
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const post = notification.kind === "note" ? findPostRecord(detail) : null;
+  const text = typeof post?.text === "string" ? post.text : undefined;
+  const stickers = Array.isArray(post?.stickers) ? post.stickers : [];
+  const media = Array.isArray(post?.media) ? post.media : [];
+  const sticons = noteSticons(post);
+  const sharedPostId = typeof post?.sharedPostId === "string" ? post.sharedPostId : undefined;
+
+  return (
+    <div className="my-1 flex w-full justify-center px-2">
+      <button
+        type="button"
+        onClick={() => void load()}
+        className="w-full max-w-[360px] overflow-hidden rounded-2xl border border-[var(--vy-border)] bg-[var(--vy-surface)] text-left shadow-sm transition-colors hover:bg-[var(--vy-surface-2)]"
+      >
+        <div className="px-4 py-3">
+          <p className="text-[11px] font-semibold uppercase tracking-wide text-[var(--vy-accent)]">
+            {notification.kind === "album" ? "Album" : "Note"}
+          </p>
+          <p className="mt-1 text-sm font-semibold text-[var(--vy-text)]">
+            {notification.kind === "album"
+              ? notification.title || "アルバムが更新されました"
+              : "ノートが作成されました"}
+          </p>
+          {notification.kind === "album" && notification.mediaCount != null && (
+            <p className="mt-1 text-xs text-[var(--vy-text-dim)]">{notification.mediaCount}件のメディア</p>
+          )}
+          {loading && <p className="mt-2 text-xs text-[var(--vy-text-dim)]">読み込み中…</p>}
+          {error && <p className="mt-2 text-xs text-[var(--vy-danger)]">{error}</p>}
+          {text && (
+            <p className="mt-2 whitespace-pre-wrap break-words text-sm text-[var(--vy-text)]">
+              <NoteText text={text} sticons={sticons} />
+            </p>
+          )}
+          {stickers.length > 0 && (
+            <div className="mt-2 flex flex-wrap gap-2">
+              {stickers.slice(0, 6).map((value, index) => {
+                const sticker = objectRecord(value);
+                const id = String(sticker?.id ?? sticker?.stickerId ?? "");
+                return id ? (
+                  <img
+                    key={`${id}-${index}`}
+                    src={lineStickerUrl(id)}
+                    alt="スタンプ"
+                    className="h-20 w-20 object-contain"
+                    onError={hideBrokenMedia}
+                  />
+                ) : null;
+              })}
+            </div>
+          )}
+          {media.length > 0 && (
+            <div className="mt-2 grid grid-cols-2 gap-1 overflow-hidden rounded-xl">
+              {media.slice(0, 6).map((value, index) => {
+                const item = objectRecord(value);
+                const objectId = String(item?.objectId ?? "");
+                const type = String(item?.type ?? "PHOTO").toUpperCase();
+                if (!objectId) return null;
+                const src = lineCdnProxy(`https://obs.line-apps.com/r/myhome/h/${encodeURIComponent(objectId)}`);
+                return type === "VIDEO" ? (
+                  <video
+                    key={`${objectId}-${index}`}
+                    src={src}
+                    controls
+                    preload="metadata"
+                    className="max-h-48 w-full bg-black object-contain"
+                  />
+                ) : (
+                  <img
+                    key={`${objectId}-${index}`}
+                    src={src}
+                    alt="ノート画像"
+                    className="max-h-48 w-full object-cover"
+                    onError={hideBrokenMedia}
+                  />
+                );
+              })}
+            </div>
+          )}
+          {sharedPostId && (
+            <p className="mt-2 rounded-lg bg-[var(--vy-surface-2)] px-3 py-2 text-xs text-[var(--vy-text-dim)]">
+              共有ノート: {sharedPostId}
+            </p>
+          )}
+          {!detail && !loading && (
+            <p className="mt-2 text-xs text-[var(--vy-text-dim)]">クリックして内容を表示</p>
+          )}
+        </div>
+      </button>
+    </div>
   );
 }
 
@@ -472,6 +666,7 @@ export const MessageBubble = memo(
     mediaGroup?: Message[];
   }) {
     const isMe = message.authorId === "me";
+    const accountId = useStore((s) => s.accountId);
     const settings = useStore((s) => s.settings);
     const streamerMode = settings.streamerMode;
     const revokeMessage = useStore((s) => s.revokeMessage);
@@ -920,6 +1115,10 @@ export const MessageBubble = memo(
 
     if (message.kind === "call" && !isRevoked) {
       return <CallEventMessage meta={message.callMeta} isMe={isMe} />;
+    }
+
+    if (message.postNotification && message.postNotification.kind !== "unknown" && !isRevoked) {
+      return <PostNotificationCard message={message} accountId={accountId ?? undefined} />;
     }
 
     if (message.kind === "system" && !isRevoked) {

--- a/Vyline/apps/desktop/src/components/plus-menu.tsx
+++ b/Vyline/apps/desktop/src/components/plus-menu.tsx
@@ -88,10 +88,14 @@ function ErrorText({ error }: { error: string | null }) {
 function collectAlbums(value: unknown): Array<Record<string, unknown>> {
   if (!value || typeof value !== "object") return [];
   const root = value as Record<string, unknown>;
-  const result = root.result && typeof root.result === "object" ? root.result as Record<string, unknown> : root;
+  const result =
+    root.result && typeof root.result === "object"
+      ? (root.result as Record<string, unknown>)
+      : root;
   for (const key of ["albums", "items", "albumList"]) {
     const list = result[key];
-    if (Array.isArray(list)) return list.filter((x): x is Record<string, unknown> => !!x && typeof x === "object");
+    if (Array.isArray(list))
+      return list.filter((x): x is Record<string, unknown> => !!x && typeof x === "object");
   }
   return [];
 }
@@ -99,14 +103,21 @@ function collectAlbums(value: unknown): Array<Record<string, unknown>> {
 function collectAlbumPhotos(value: unknown): Array<Record<string, unknown>> {
   if (!value || typeof value !== "object") return [];
   const root = value as Record<string, unknown>;
-  const result = root.result && typeof root.result === "object" ? root.result as Record<string, unknown> : root;
+  const result =
+    root.result && typeof root.result === "object"
+      ? (root.result as Record<string, unknown>)
+      : root;
   const photos = result.photos;
   return Array.isArray(photos)
     ? photos.filter((x): x is Record<string, unknown> => !!x && typeof x === "object")
     : [];
 }
 
-function AlbumModal({ accountId, chatId, onClose }: { accountId: string; chatId: string; onClose: () => void }) {
+function AlbumModal({
+  accountId,
+  chatId,
+  onClose,
+}: { accountId: string; chatId: string; onClose: () => void }) {
   const [albums, setAlbums] = useState<Array<Record<string, unknown>>>([]);
   const [selectedId, setSelectedId] = useState("");
   const [photos, setPhotos] = useState<Array<Record<string, unknown>>>([]);
@@ -126,7 +137,9 @@ function AlbumModal({ accountId, chatId, onClose }: { accountId: string; chatId:
     }
   };
 
-  useEffect(() => { void refresh(); }, [accountId, chatId]);
+  useEffect(() => {
+    void refresh();
+  }, [accountId, chatId]);
 
   const openAlbum = async (id: string) => {
     setSelectedId(id);
@@ -167,13 +180,15 @@ function AlbumModal({ accountId, chatId, onClose }: { accountId: string; chatId:
       });
       await runAlbum(async () => {
         const uploaded = await api.line.albums.uploadMedia(accountId, selectedId, chatId, file);
-        await api.line.albums.addPhotos(accountId, selectedId, chatId, [{
-          obsResourceId: { oid: uploaded.oid, sid: "a", svc: "album" },
-          width: dimensions.width,
-          height: dimensions.height,
-          shotTime: Date.now(),
-          resourceType: "IMAGE",
-        }]);
+        await api.line.albums.addPhotos(accountId, selectedId, chatId, [
+          {
+            obsResourceId: { oid: uploaded.oid, sid: "a", svc: "album" },
+            width: dimensions.width,
+            height: dimensions.height,
+            shotTime: Date.now(),
+            resourceType: "IMAGE",
+          },
+        ]);
       }, true);
     } finally {
       URL.revokeObjectURL(objectUrl);
@@ -184,49 +199,179 @@ function AlbumModal({ accountId, chatId, onClose }: { accountId: string; chatId:
     <Modal title="アルバム" onClose={onClose}>
       <ErrorText error={error} />
       <div className="mb-3 grid grid-cols-2 gap-2">
-        <button disabled={busy} className="rounded-lg border border-[var(--vy-border)] py-2 disabled:opacity-50" onClick={() => {
-          const title = window.prompt("アルバム名");
-          if (title?.trim()) void runAlbum(() => api.line.albums.create(accountId, chatId, title.trim()));
-        }}>新規作成</button>
-        <button disabled={busy} className="rounded-lg border border-[var(--vy-border)] py-2 disabled:opacity-50" onClick={() => void api.line.albums.preview(accountId, chatId).catch((e) => setError(e instanceof Error ? e.message : String(e)))}>プレビュー確認</button>
+        <button
+          type="button"
+          disabled={busy}
+          className="rounded-lg border border-[var(--vy-border)] py-2 disabled:opacity-50"
+          onClick={() => {
+            const title = window.prompt("アルバム名");
+            if (title?.trim())
+              void runAlbum(() => api.line.albums.create(accountId, chatId, title.trim()));
+          }}
+        >
+          新規作成
+        </button>
+        <button
+          type="button"
+          disabled={busy}
+          className="rounded-lg border border-[var(--vy-border)] py-2 disabled:opacity-50"
+          onClick={() =>
+            void api.line.albums
+              .preview(accountId, chatId)
+              .catch((e) => setError(e instanceof Error ? e.message : String(e)))
+          }
+        >
+          プレビュー確認
+        </button>
       </div>
       <div className="mb-3 flex items-center justify-between">
         <span className="text-xs text-[var(--vy-text-dim)]">アルバム一覧</span>
-        <button type="button" disabled={busy} className="text-xs text-[var(--vy-accent)] disabled:opacity-50" onClick={() => void refresh()}>再読み込み</button>
+        <button
+          type="button"
+          disabled={busy}
+          className="text-xs text-[var(--vy-accent)] disabled:opacity-50"
+          onClick={() => void refresh()}
+        >
+          再読み込み
+        </button>
       </div>
       <div className="max-h-56 space-y-1 overflow-y-auto">
-        {albums.length === 0 ? <p className="py-5 text-center text-xs text-[var(--vy-text-dim)]">アルバムがありません</p> : albums.map((album, index) => {
-          const id = String(album.albumId ?? album.id ?? "");
-          const title = String(album.title ?? album.name ?? `アルバム ${index + 1}`);
-          return <button key={id || index} type="button" className={cn("w-full rounded-lg border px-3 py-2 text-left", selectedId === id ? "border-[var(--vy-accent)]" : "border-[var(--vy-border)]")} onClick={() => id && void openAlbum(id)}><span className="block truncate text-sm">{title}</span><span className="block truncate text-[10px] text-[var(--vy-text-dim)]">{id}</span></button>;
-        })}
+        {albums.length === 0 ? (
+          <p className="py-5 text-center text-xs text-[var(--vy-text-dim)]">アルバムがありません</p>
+        ) : (
+          albums.map((album, index) => {
+            const id = String(album.albumId ?? album.id ?? "");
+            const title = String(album.title ?? album.name ?? `アルバム ${index + 1}`);
+            return (
+              <button
+                key={id || index}
+                type="button"
+                className={cn(
+                  "w-full rounded-lg border px-3 py-2 text-left",
+                  selectedId === id ? "border-[var(--vy-accent)]" : "border-[var(--vy-border)]",
+                )}
+                onClick={() => id && void openAlbum(id)}
+              >
+                <span className="block truncate text-sm">{title}</span>
+                <span className="block truncate text-[10px] text-[var(--vy-text-dim)]">{id}</span>
+              </button>
+            );
+          })
+        )}
       </div>
       {selectedId && (
         <>
-        <div className="mt-3 grid grid-cols-2 gap-2">
-          <button disabled={busy} className="rounded-lg border border-[var(--vy-border)] py-2 disabled:opacity-50" onClick={() => {
-            const title = window.prompt("新しいアルバム名");
-            if (title?.trim()) void runAlbum(() => api.line.albums.rename(accountId, selectedId, chatId, title.trim()));
-          }}>名前変更</button>
-          <button disabled={busy} className="rounded-lg border border-[var(--vy-border)] py-2 disabled:opacity-50" onClick={() => void runAlbum(() => api.line.albums.share(accountId, selectedId, chatId), false)}>共有</button>
-          <label className="cursor-pointer rounded-lg border border-[var(--vy-border)] py-2 text-center">写真追加<input className="hidden" type="file" accept="image/*" onChange={(e) => { const f = e.target.files?.[0]; if (f) void uploadAlbumImage(f); e.currentTarget.value = ""; }} /></label>
-          <button disabled={busy} className="rounded-lg border border-red-500/40 py-2 text-red-400 disabled:opacity-50" onClick={() => void runAlbum(async () => { await api.line.albums.remove(accountId, selectedId, chatId); setSelectedId(""); setPhotos([]); })}>アルバム削除</button>
-        </div>
-        <div className="mt-3 grid max-h-64 grid-cols-3 gap-2 overflow-y-auto rounded-lg border border-[var(--vy-border)] p-2">
-          {photos.length === 0 ? <p className="col-span-3 py-4 text-center text-xs text-[var(--vy-text-dim)]">写真がありません</p> : photos.map((photo, index) => {
-            const resource = photo.obsResourceId && typeof photo.obsResourceId === "object" ? photo.obsResourceId as Record<string, unknown> : null;
-            const oid = String(photo.oid ?? resource?.oid ?? "");
-            const photoId = String(photo.photoId ?? photo.id ?? oid);
-            const isVideo = String(photo.resourceType ?? resource?.sid ?? "").toLowerCase() === "v";
-            if (!oid) return null;
-            const src = api.line.albums.mediaUrl(accountId, selectedId, oid, chatId, isVideo ? "video" : "image");
-            return <div key={`${oid}-${index}`} className="relative">{isVideo
-              ? <video src={src} controls preload="metadata" className="aspect-square w-full rounded-md object-cover" />
-              : <img src={src} alt="アルバム写真" loading="lazy" className="aspect-square w-full rounded-md object-cover" />}
-              <button type="button" className="absolute right-1 top-1 rounded bg-black/70 px-1.5 py-0.5 text-[10px] text-white" onClick={() => void runAlbum(() => api.line.albums.deletePhotos(accountId, selectedId, chatId, [photoId]), true)}>削除</button>
-            </div>;
-          })}
-        </div>
+          <div className="mt-3 grid grid-cols-2 gap-2">
+            <button
+              type="button"
+              disabled={busy}
+              className="rounded-lg border border-[var(--vy-border)] py-2 disabled:opacity-50"
+              onClick={() => {
+                const title = window.prompt("新しいアルバム名");
+                if (title?.trim())
+                  void runAlbum(() =>
+                    api.line.albums.rename(accountId, selectedId, chatId, title.trim()),
+                  );
+              }}
+            >
+              名前変更
+            </button>
+            <button
+              type="button"
+              disabled={busy}
+              className="rounded-lg border border-[var(--vy-border)] py-2 disabled:opacity-50"
+              onClick={() =>
+                void runAlbum(() => api.line.albums.share(accountId, selectedId, chatId), false)
+              }
+            >
+              共有
+            </button>
+            <label className="cursor-pointer rounded-lg border border-[var(--vy-border)] py-2 text-center">
+              写真追加
+              <input
+                className="hidden"
+                type="file"
+                accept="image/*"
+                onChange={(e) => {
+                  const f = e.target.files?.[0];
+                  if (f) void uploadAlbumImage(f);
+                  e.currentTarget.value = "";
+                }}
+              />
+            </label>
+            <button
+              type="button"
+              disabled={busy}
+              className="rounded-lg border border-red-500/40 py-2 text-red-400 disabled:opacity-50"
+              onClick={() =>
+                void runAlbum(async () => {
+                  await api.line.albums.remove(accountId, selectedId, chatId);
+                  setSelectedId("");
+                  setPhotos([]);
+                })
+              }
+            >
+              アルバム削除
+            </button>
+          </div>
+          <div className="mt-3 grid max-h-64 grid-cols-3 gap-2 overflow-y-auto rounded-lg border border-[var(--vy-border)] p-2">
+            {photos.length === 0 ? (
+              <p className="col-span-3 py-4 text-center text-xs text-[var(--vy-text-dim)]">
+                写真がありません
+              </p>
+            ) : (
+              photos.map((photo, index) => {
+                const resource =
+                  photo.obsResourceId && typeof photo.obsResourceId === "object"
+                    ? (photo.obsResourceId as Record<string, unknown>)
+                    : null;
+                const oid = String(photo.oid ?? resource?.oid ?? "");
+                const photoId = String(photo.photoId ?? photo.id ?? oid);
+                const isVideo =
+                  String(photo.resourceType ?? resource?.sid ?? "").toLowerCase() === "v";
+                if (!oid) return null;
+                const src = api.line.albums.mediaUrl(
+                  accountId,
+                  selectedId,
+                  oid,
+                  chatId,
+                  isVideo ? "video" : "image",
+                );
+                return (
+                  <div key={`${oid}-${index}`} className="relative">
+                    {isVideo ? (
+                      <video
+                        src={src}
+                        controls
+                        preload="metadata"
+                        className="aspect-square w-full rounded-md object-cover"
+                      />
+                    ) : (
+                      <img
+                        src={src}
+                        alt="アルバム写真"
+                        loading="lazy"
+                        className="aspect-square w-full rounded-md object-cover"
+                      />
+                    )}
+                    <button
+                      type="button"
+                      className="absolute right-1 top-1 rounded bg-black/70 px-1.5 py-0.5 text-[10px] text-white"
+                      onClick={() =>
+                        void runAlbum(
+                          () =>
+                            api.line.albums.deletePhotos(accountId, selectedId, chatId, [photoId]),
+                          true,
+                        )
+                      }
+                    >
+                      削除
+                    </button>
+                  </div>
+                );
+              })
+            )}
+          </div>
         </>
       )}
     </Modal>
@@ -236,25 +381,34 @@ function AlbumModal({ accountId, chatId, onClose }: { accountId: string; chatId:
 function collectPosts(value: unknown): Array<Record<string, unknown>> {
   if (!value || typeof value !== "object") return [];
   const root = value as Record<string, unknown>;
-  const result = root.result && typeof root.result === "object" ? root.result as Record<string, unknown> : root;
+  const result =
+    root.result && typeof root.result === "object"
+      ? (root.result as Record<string, unknown>)
+      : root;
   for (const key of ["posts", "items", "postList", "feeds"]) {
     const list = result[key];
-    if (Array.isArray(list)) return list.filter((x): x is Record<string, unknown> => !!x && typeof x === "object");
+    if (Array.isArray(list))
+      return list.filter((x): x is Record<string, unknown> => !!x && typeof x === "object");
   }
   return [];
 }
 
 function noteSummary(post: Record<string, unknown>): { id: string; text: string } {
-  const contents = post.contents && typeof post.contents === "object"
-    ? post.contents as Record<string, unknown>
-    : post;
+  const contents =
+    post.contents && typeof post.contents === "object"
+      ? (post.contents as Record<string, unknown>)
+      : post;
   return {
     id: String(post.postId ?? post.id ?? contents.postId ?? ""),
     text: String(contents.text ?? post.text ?? "").trim(),
   };
 }
 
-function NoteModal({ accountId, chatId, onClose }: { accountId: string; chatId: string; onClose: () => void }) {
+function NoteModal({
+  accountId,
+  chatId,
+  onClose,
+}: { accountId: string; chatId: string; onClose: () => void }) {
   const [posts, setPosts] = useState<Array<Record<string, unknown>>>([]);
   const [selectedId, setSelectedId] = useState("");
   const [text, setText] = useState("");
@@ -277,14 +431,20 @@ function NoteModal({ accountId, chatId, onClose }: { accountId: string; chatId: 
     }
   };
 
-  useEffect(() => { void refresh(); }, [accountId, chatId]);
+  useEffect(() => {
+    void refresh();
+  }, [accountId, chatId]);
 
   const noteInput = () => ({
     homeId: chatId,
     ...(text.trim() ? { text: text.trim() } : {}),
     ...(sharedPostId.trim() ? { sharedPostId: sharedPostId.trim() } : {}),
-    ...(stickerId.trim() ? { stickerIds: [stickerId.trim()], stickerPackageIds: [stickerPackageId.trim() || "1"] } : {}),
-    ...(media.length ? { mediaObjectIds: media.map((m) => m.id), mediaObjectTypes: media.map((m) => m.type) } : {}),
+    ...(stickerId.trim()
+      ? { stickerIds: [stickerId.trim()], stickerPackageIds: [stickerPackageId.trim() || "1"] }
+      : {}),
+    ...(media.length
+      ? { mediaObjectIds: media.map((m) => m.id), mediaObjectTypes: media.map((m) => m.type) }
+      : {}),
   });
 
   const run = async (task: () => Promise<unknown>, after = true) => {
@@ -306,7 +466,10 @@ function NoteModal({ accountId, chatId, onClose }: { accountId: string; chatId: 
     try {
       const result = await api.line.notes.uploadMedia(accountId, type, file);
       if (!result.objId) throw new Error("メディアIDを取得できませんでした");
-      setMedia((prev) => [...prev, { id: result.objId, type: type === "video" ? "VIDEO" : "PHOTO" }]);
+      setMedia((prev) => [
+        ...prev,
+        { id: result.objId, type: type === "video" ? "VIDEO" : "PHOTO" },
+      ]);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
@@ -318,63 +481,227 @@ function NoteModal({ accountId, chatId, onClose }: { accountId: string; chatId: 
     <Modal title="ノート" onClose={onClose}>
       <ErrorText error={error} />
       <Field label="本文">
-        <textarea className={cn(inputCls, "min-h-24 resize-y")} value={text} onChange={(e) => setText(e.target.value)} placeholder="ノート本文" />
+        <textarea
+          className={cn(inputCls, "min-h-24 resize-y")}
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder="ノート本文"
+        />
       </Field>
       <div className="grid grid-cols-2 gap-2">
-        <Field label="スタンプID（任意）"><input className={inputCls} value={stickerId} onChange={(e) => setStickerId(e.target.value)} /></Field>
-        <Field label="パッケージID"><input className={inputCls} value={stickerPackageId} onChange={(e) => setStickerPackageId(e.target.value)} /></Field>
+        <Field label="スタンプID（任意）">
+          <input
+            className={inputCls}
+            value={stickerId}
+            onChange={(e) => setStickerId(e.target.value)}
+          />
+        </Field>
+        <Field label="パッケージID">
+          <input
+            className={inputCls}
+            value={stickerPackageId}
+            onChange={(e) => setStickerPackageId(e.target.value)}
+          />
+        </Field>
       </div>
-      <Field label="共有元 postId（任意）"><input className={inputCls} value={sharedPostId} onChange={(e) => setSharedPostId(e.target.value)} /></Field>
+      <Field label="共有元 postId（任意）">
+        <input
+          className={inputCls}
+          value={sharedPostId}
+          onChange={(e) => setSharedPostId(e.target.value)}
+        />
+      </Field>
       <Field label="画像・動画">
-        <input type="file" accept="image/*,video/*" multiple onChange={(e) => {
-          for (const file of Array.from(e.target.files ?? [])) void upload(file);
-          e.currentTarget.value = "";
-        }} />
-        {media.length > 0 && <p className="mt-1 text-xs text-[var(--vy-text-dim)]">アップロード済み {media.length}件</p>}
+        <input
+          type="file"
+          accept="image/*,video/*"
+          multiple
+          onChange={(e) => {
+            for (const file of Array.from(e.target.files ?? [])) void upload(file);
+            e.currentTarget.value = "";
+          }}
+        />
+        {media.length > 0 && (
+          <p className="mt-1 text-xs text-[var(--vy-text-dim)]">
+            アップロード済み {media.length}件
+          </p>
+        )}
       </Field>
       <div className="mb-4 grid grid-cols-2 gap-2">
-        <button disabled={busy} className="rounded-lg bg-[var(--vy-accent)] py-2 font-semibold text-[var(--vy-accent-contrast)] disabled:opacity-50" onClick={() => void run(() => api.line.notes.create(accountId, noteInput()))}>新規作成</button>
-        <button disabled={busy || !selectedId} className="rounded-lg border border-[var(--vy-border)] py-2 disabled:opacity-50" onClick={() => void run(() => api.line.notes.update(accountId, selectedId, noteInput()))}>選択ノートを更新</button>
+        <button
+          type="button"
+          disabled={busy}
+          className="rounded-lg bg-[var(--vy-accent)] py-2 font-semibold text-[var(--vy-accent-contrast)] disabled:opacity-50"
+          onClick={() => void run(() => api.line.notes.create(accountId, noteInput()))}
+        >
+          新規作成
+        </button>
+        <button
+          type="button"
+          disabled={busy || !selectedId}
+          className="rounded-lg border border-[var(--vy-border)] py-2 disabled:opacity-50"
+          onClick={() => void run(() => api.line.notes.update(accountId, selectedId, noteInput()))}
+        >
+          選択ノートを更新
+        </button>
       </div>
       <div className="mb-3 flex items-center justify-between">
         <span className="text-xs text-[var(--vy-text-dim)]">ノート一覧</span>
-        <button type="button" className="text-xs text-[var(--vy-accent)]" onClick={() => void refresh()}>再読み込み</button>
+        <button
+          type="button"
+          className="text-xs text-[var(--vy-accent)]"
+          onClick={() => void refresh()}
+        >
+          再読み込み
+        </button>
       </div>
       <div className="mb-4 max-h-48 space-y-1 overflow-y-auto">
-        {posts.length === 0 ? <p className="py-4 text-center text-xs text-[var(--vy-text-dim)]">ノートがありません</p> : posts.map((post, index) => {
-          const item = noteSummary(post);
-          return (
-            <button type="button" key={item.id || index} className={cn("w-full rounded-lg border px-3 py-2 text-left", selectedId === item.id ? "border-[var(--vy-accent)]" : "border-[var(--vy-border)]")} onClick={() => { setSelectedId(item.id); setText(item.text); }}>
-              <span className="block truncate text-sm">{item.text || "（メディア/スタンプノート）"}</span>
-              <span className="block truncate text-[10px] text-[var(--vy-text-dim)]">{item.id}</span>
-            </button>
-          );
-        })}
+        {posts.length === 0 ? (
+          <p className="py-4 text-center text-xs text-[var(--vy-text-dim)]">ノートがありません</p>
+        ) : (
+          posts.map((post, index) => {
+            const item = noteSummary(post);
+            return (
+              <button
+                type="button"
+                key={item.id || index}
+                className={cn(
+                  "w-full rounded-lg border px-3 py-2 text-left",
+                  selectedId === item.id
+                    ? "border-[var(--vy-accent)]"
+                    : "border-[var(--vy-border)]",
+                )}
+                onClick={() => {
+                  setSelectedId(item.id);
+                  setText(item.text);
+                }}
+              >
+                <span className="block truncate text-sm">
+                  {item.text || "（メディア/スタンプノート）"}
+                </span>
+                <span className="block truncate text-[10px] text-[var(--vy-text-dim)]">
+                  {item.id}
+                </span>
+              </button>
+            );
+          })
+        )}
       </div>
       <Field label="コメント">
-        <div className="flex gap-2"><input className={cn(inputCls, "flex-1")} value={comment} onChange={(e) => setComment(e.target.value)} /><button disabled={busy || !selectedId || !comment.trim()} className="rounded-lg border border-[var(--vy-border)] px-3 disabled:opacity-50" onClick={() => void run(() => api.line.notes.comment(accountId, selectedId, chatId, comment.trim()), false)}>送信</button></div>
+        <div className="flex gap-2">
+          <input
+            className={cn(inputCls, "flex-1")}
+            value={comment}
+            onChange={(e) => setComment(e.target.value)}
+          />
+          <button
+            type="button"
+            disabled={busy || !selectedId || !comment.trim()}
+            className="rounded-lg border border-[var(--vy-border)] px-3 disabled:opacity-50"
+            onClick={() =>
+              void run(
+                () => api.line.notes.comment(accountId, selectedId, chatId, comment.trim()),
+                false,
+              )
+            }
+          >
+            送信
+          </button>
+        </div>
       </Field>
       <div className="grid grid-cols-2 gap-2">
-        <select className={inputCls} value={likeType} onChange={(e) => setLikeType(e.target.value)}>{["1001", "1002", "1003", "1004", "1005", "1006"].map((v) => <option key={v} value={v}>リアクション {v}</option>)}</select>
-        <button disabled={busy || !selectedId} className="rounded-lg border border-[var(--vy-border)] py-2 disabled:opacity-50" onClick={() => void run(() => api.line.notes.like(accountId, selectedId, chatId, likeType), false)}>リアクション</button>
-        <button disabled={busy || !selectedId} className="rounded-lg border border-[var(--vy-border)] py-2 disabled:opacity-50" onClick={() => void run(() => api.line.notes.unlike(accountId, selectedId, chatId), false)}>リアクション解除</button>
-        <button disabled={busy || !selectedId} className="rounded-lg border border-[var(--vy-border)] py-2 disabled:opacity-50" onClick={() => void run(async () => { const [mine, list] = await Promise.all([api.line.notes.getLike(accountId, selectedId, chatId), api.line.notes.listLikes(accountId, selectedId, chatId)]); setLikeInfo(JSON.stringify({ mine, list })); }, false)}>リアクション確認</button>
-        <button disabled={busy || !selectedId} className="rounded-lg border border-[var(--vy-border)] py-2 disabled:opacity-50" onClick={() => void run(() => api.line.notes.share(accountId, selectedId, chatId), false)}>このチャットへ共有</button>
+        <select className={inputCls} value={likeType} onChange={(e) => setLikeType(e.target.value)}>
+          {["1001", "1002", "1003", "1004", "1005", "1006"].map((v) => (
+            <option key={v} value={v}>
+              リアクション {v}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          disabled={busy || !selectedId}
+          className="rounded-lg border border-[var(--vy-border)] py-2 disabled:opacity-50"
+          onClick={() =>
+            void run(() => api.line.notes.like(accountId, selectedId, chatId, likeType), false)
+          }
+        >
+          リアクション
+        </button>
+        <button
+          type="button"
+          disabled={busy || !selectedId}
+          className="rounded-lg border border-[var(--vy-border)] py-2 disabled:opacity-50"
+          onClick={() =>
+            void run(() => api.line.notes.unlike(accountId, selectedId, chatId), false)
+          }
+        >
+          リアクション解除
+        </button>
+        <button
+          type="button"
+          disabled={busy || !selectedId}
+          className="rounded-lg border border-[var(--vy-border)] py-2 disabled:opacity-50"
+          onClick={() =>
+            void run(async () => {
+              const [mine, list] = await Promise.all([
+                api.line.notes.getLike(accountId, selectedId, chatId),
+                api.line.notes.listLikes(accountId, selectedId, chatId),
+              ]);
+              setLikeInfo(JSON.stringify({ mine, list }));
+            }, false)
+          }
+        >
+          リアクション確認
+        </button>
+        <button
+          type="button"
+          disabled={busy || !selectedId}
+          className="rounded-lg border border-[var(--vy-border)] py-2 disabled:opacity-50"
+          onClick={() => void run(() => api.line.notes.share(accountId, selectedId, chatId), false)}
+        >
+          このチャットへ共有
+        </button>
         <label className="cursor-pointer rounded-lg border border-[var(--vy-border)] py-2 text-center">
           コメント画像
-          <input type="file" accept="image/*" className="hidden" onChange={(e) => {
-            const file = e.target.files?.[0];
-            if (!file || !selectedId) return;
-            void run(async () => {
-              const uploaded = await api.line.notes.uploadCommentImage(accountId, file);
-              await api.line.notes.comment(accountId, selectedId, chatId, comment.trim(), uploaded.objId);
-            }, false);
-            e.currentTarget.value = "";
-          }} />
+          <input
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              if (!file || !selectedId) return;
+              void run(async () => {
+                const uploaded = await api.line.notes.uploadCommentImage(accountId, file);
+                await api.line.notes.comment(
+                  accountId,
+                  selectedId,
+                  chatId,
+                  comment.trim(),
+                  uploaded.objId,
+                );
+              }, false);
+              e.currentTarget.value = "";
+            }}
+          />
         </label>
-        <button disabled={busy || !selectedId} className="rounded-lg border border-red-500/40 py-2 text-red-400 disabled:opacity-50" onClick={() => void run(async () => { await api.line.notes.remove(accountId, chatId, selectedId); setSelectedId(""); setText(""); })}>削除</button>
+        <button
+          type="button"
+          disabled={busy || !selectedId}
+          className="rounded-lg border border-red-500/40 py-2 text-red-400 disabled:opacity-50"
+          onClick={() =>
+            void run(async () => {
+              await api.line.notes.remove(accountId, chatId, selectedId);
+              setSelectedId("");
+              setText("");
+            })
+          }
+        >
+          削除
+        </button>
       </div>
-      {likeInfo && <p className="mt-2 break-all text-[10px] text-[var(--vy-text-dim)]">{likeInfo}</p>}
+      {likeInfo && (
+        <p className="mt-2 break-all text-[10px] text-[var(--vy-text-dim)]">{likeInfo}</p>
+      )}
     </Modal>
   );
 }

--- a/Vyline/apps/desktop/src/components/plus-menu.tsx
+++ b/Vyline/apps/desktop/src/components/plus-menu.tsx
@@ -85,6 +85,300 @@ function ErrorText({ error }: { error: string | null }) {
   return <p className="mb-3 rounded-lg bg-red-500/10 px-3 py-2 text-xs text-red-400">{error}</p>;
 }
 
+function collectAlbums(value: unknown): Array<Record<string, unknown>> {
+  if (!value || typeof value !== "object") return [];
+  const root = value as Record<string, unknown>;
+  const result = root.result && typeof root.result === "object" ? root.result as Record<string, unknown> : root;
+  for (const key of ["albums", "items", "albumList"]) {
+    const list = result[key];
+    if (Array.isArray(list)) return list.filter((x): x is Record<string, unknown> => !!x && typeof x === "object");
+  }
+  return [];
+}
+
+function collectAlbumPhotos(value: unknown): Array<Record<string, unknown>> {
+  if (!value || typeof value !== "object") return [];
+  const root = value as Record<string, unknown>;
+  const result = root.result && typeof root.result === "object" ? root.result as Record<string, unknown> : root;
+  const photos = result.photos;
+  return Array.isArray(photos)
+    ? photos.filter((x): x is Record<string, unknown> => !!x && typeof x === "object")
+    : [];
+}
+
+function AlbumModal({ accountId, chatId, onClose }: { accountId: string; chatId: string; onClose: () => void }) {
+  const [albums, setAlbums] = useState<Array<Record<string, unknown>>>([]);
+  const [selectedId, setSelectedId] = useState("");
+  const [photos, setPhotos] = useState<Array<Record<string, unknown>>>([]);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const result = await api.line.albums.list(accountId, { chatId });
+      setAlbums(collectAlbums(result));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  useEffect(() => { void refresh(); }, [accountId, chatId]);
+
+  const openAlbum = async (id: string) => {
+    setSelectedId(id);
+    setBusy(true);
+    setError(null);
+    try {
+      setPhotos(collectAlbumPhotos(await api.line.albums.photos(accountId, id, chatId)));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const runAlbum = async (task: () => Promise<unknown>, reopen = false) => {
+    setBusy(true);
+    setError(null);
+    try {
+      await task();
+      await refresh();
+      if (reopen && selectedId) await openAlbum(selectedId);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const uploadAlbumImage = async (file: File) => {
+    if (!selectedId) return;
+    const objectUrl = URL.createObjectURL(file);
+    try {
+      const dimensions = await new Promise<{ width: number; height: number }>((resolve, reject) => {
+        const image = new Image();
+        image.onload = () => resolve({ width: image.naturalWidth, height: image.naturalHeight });
+        image.onerror = () => reject(new Error("画像サイズを取得できませんでした"));
+        image.src = objectUrl;
+      });
+      await runAlbum(async () => {
+        const uploaded = await api.line.albums.uploadMedia(accountId, selectedId, chatId, file);
+        await api.line.albums.addPhotos(accountId, selectedId, chatId, [{
+          obsResourceId: { oid: uploaded.oid, sid: "a", svc: "album" },
+          width: dimensions.width,
+          height: dimensions.height,
+          shotTime: Date.now(),
+          resourceType: "IMAGE",
+        }]);
+      }, true);
+    } finally {
+      URL.revokeObjectURL(objectUrl);
+    }
+  };
+
+  return (
+    <Modal title="アルバム" onClose={onClose}>
+      <ErrorText error={error} />
+      <div className="mb-3 grid grid-cols-2 gap-2">
+        <button disabled={busy} className="rounded-lg border border-[var(--vy-border)] py-2 disabled:opacity-50" onClick={() => {
+          const title = window.prompt("アルバム名");
+          if (title?.trim()) void runAlbum(() => api.line.albums.create(accountId, chatId, title.trim()));
+        }}>新規作成</button>
+        <button disabled={busy} className="rounded-lg border border-[var(--vy-border)] py-2 disabled:opacity-50" onClick={() => void api.line.albums.preview(accountId, chatId).catch((e) => setError(e instanceof Error ? e.message : String(e)))}>プレビュー確認</button>
+      </div>
+      <div className="mb-3 flex items-center justify-between">
+        <span className="text-xs text-[var(--vy-text-dim)]">アルバム一覧</span>
+        <button type="button" disabled={busy} className="text-xs text-[var(--vy-accent)] disabled:opacity-50" onClick={() => void refresh()}>再読み込み</button>
+      </div>
+      <div className="max-h-56 space-y-1 overflow-y-auto">
+        {albums.length === 0 ? <p className="py-5 text-center text-xs text-[var(--vy-text-dim)]">アルバムがありません</p> : albums.map((album, index) => {
+          const id = String(album.albumId ?? album.id ?? "");
+          const title = String(album.title ?? album.name ?? `アルバム ${index + 1}`);
+          return <button key={id || index} type="button" className={cn("w-full rounded-lg border px-3 py-2 text-left", selectedId === id ? "border-[var(--vy-accent)]" : "border-[var(--vy-border)]")} onClick={() => id && void openAlbum(id)}><span className="block truncate text-sm">{title}</span><span className="block truncate text-[10px] text-[var(--vy-text-dim)]">{id}</span></button>;
+        })}
+      </div>
+      {selectedId && (
+        <>
+        <div className="mt-3 grid grid-cols-2 gap-2">
+          <button disabled={busy} className="rounded-lg border border-[var(--vy-border)] py-2 disabled:opacity-50" onClick={() => {
+            const title = window.prompt("新しいアルバム名");
+            if (title?.trim()) void runAlbum(() => api.line.albums.rename(accountId, selectedId, chatId, title.trim()));
+          }}>名前変更</button>
+          <button disabled={busy} className="rounded-lg border border-[var(--vy-border)] py-2 disabled:opacity-50" onClick={() => void runAlbum(() => api.line.albums.share(accountId, selectedId, chatId), false)}>共有</button>
+          <label className="cursor-pointer rounded-lg border border-[var(--vy-border)] py-2 text-center">写真追加<input className="hidden" type="file" accept="image/*" onChange={(e) => { const f = e.target.files?.[0]; if (f) void uploadAlbumImage(f); e.currentTarget.value = ""; }} /></label>
+          <button disabled={busy} className="rounded-lg border border-red-500/40 py-2 text-red-400 disabled:opacity-50" onClick={() => void runAlbum(async () => { await api.line.albums.remove(accountId, selectedId, chatId); setSelectedId(""); setPhotos([]); })}>アルバム削除</button>
+        </div>
+        <div className="mt-3 grid max-h-64 grid-cols-3 gap-2 overflow-y-auto rounded-lg border border-[var(--vy-border)] p-2">
+          {photos.length === 0 ? <p className="col-span-3 py-4 text-center text-xs text-[var(--vy-text-dim)]">写真がありません</p> : photos.map((photo, index) => {
+            const resource = photo.obsResourceId && typeof photo.obsResourceId === "object" ? photo.obsResourceId as Record<string, unknown> : null;
+            const oid = String(photo.oid ?? resource?.oid ?? "");
+            const photoId = String(photo.photoId ?? photo.id ?? oid);
+            const isVideo = String(photo.resourceType ?? resource?.sid ?? "").toLowerCase() === "v";
+            if (!oid) return null;
+            const src = api.line.albums.mediaUrl(accountId, selectedId, oid, chatId, isVideo ? "video" : "image");
+            return <div key={`${oid}-${index}`} className="relative">{isVideo
+              ? <video src={src} controls preload="metadata" className="aspect-square w-full rounded-md object-cover" />
+              : <img src={src} alt="アルバム写真" loading="lazy" className="aspect-square w-full rounded-md object-cover" />}
+              <button type="button" className="absolute right-1 top-1 rounded bg-black/70 px-1.5 py-0.5 text-[10px] text-white" onClick={() => void runAlbum(() => api.line.albums.deletePhotos(accountId, selectedId, chatId, [photoId]), true)}>削除</button>
+            </div>;
+          })}
+        </div>
+        </>
+      )}
+    </Modal>
+  );
+}
+
+function collectPosts(value: unknown): Array<Record<string, unknown>> {
+  if (!value || typeof value !== "object") return [];
+  const root = value as Record<string, unknown>;
+  const result = root.result && typeof root.result === "object" ? root.result as Record<string, unknown> : root;
+  for (const key of ["posts", "items", "postList", "feeds"]) {
+    const list = result[key];
+    if (Array.isArray(list)) return list.filter((x): x is Record<string, unknown> => !!x && typeof x === "object");
+  }
+  return [];
+}
+
+function noteSummary(post: Record<string, unknown>): { id: string; text: string } {
+  const contents = post.contents && typeof post.contents === "object"
+    ? post.contents as Record<string, unknown>
+    : post;
+  return {
+    id: String(post.postId ?? post.id ?? contents.postId ?? ""),
+    text: String(contents.text ?? post.text ?? "").trim(),
+  };
+}
+
+function NoteModal({ accountId, chatId, onClose }: { accountId: string; chatId: string; onClose: () => void }) {
+  const [posts, setPosts] = useState<Array<Record<string, unknown>>>([]);
+  const [selectedId, setSelectedId] = useState("");
+  const [text, setText] = useState("");
+  const [stickerId, setStickerId] = useState("");
+  const [stickerPackageId, setStickerPackageId] = useState("");
+  const [sharedPostId, setSharedPostId] = useState("");
+  const [comment, setComment] = useState("");
+  const [media, setMedia] = useState<Array<{ id: string; type: "PHOTO" | "VIDEO" }>>([]);
+  const [likeType, setLikeType] = useState("1001");
+  const [likeInfo, setLikeInfo] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = async () => {
+    setError(null);
+    try {
+      setPosts(collectPosts(await api.line.notes.list(accountId, chatId)));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  useEffect(() => { void refresh(); }, [accountId, chatId]);
+
+  const noteInput = () => ({
+    homeId: chatId,
+    ...(text.trim() ? { text: text.trim() } : {}),
+    ...(sharedPostId.trim() ? { sharedPostId: sharedPostId.trim() } : {}),
+    ...(stickerId.trim() ? { stickerIds: [stickerId.trim()], stickerPackageIds: [stickerPackageId.trim() || "1"] } : {}),
+    ...(media.length ? { mediaObjectIds: media.map((m) => m.id), mediaObjectTypes: media.map((m) => m.type) } : {}),
+  });
+
+  const run = async (task: () => Promise<unknown>, after = true) => {
+    setBusy(true);
+    setError(null);
+    try {
+      await task();
+      if (after) await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const upload = async (file: File) => {
+    const type = file.type.startsWith("video/") ? "video" : "image";
+    setBusy(true);
+    try {
+      const result = await api.line.notes.uploadMedia(accountId, type, file);
+      if (!result.objId) throw new Error("メディアIDを取得できませんでした");
+      setMedia((prev) => [...prev, { id: result.objId, type: type === "video" ? "VIDEO" : "PHOTO" }]);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Modal title="ノート" onClose={onClose}>
+      <ErrorText error={error} />
+      <Field label="本文">
+        <textarea className={cn(inputCls, "min-h-24 resize-y")} value={text} onChange={(e) => setText(e.target.value)} placeholder="ノート本文" />
+      </Field>
+      <div className="grid grid-cols-2 gap-2">
+        <Field label="スタンプID（任意）"><input className={inputCls} value={stickerId} onChange={(e) => setStickerId(e.target.value)} /></Field>
+        <Field label="パッケージID"><input className={inputCls} value={stickerPackageId} onChange={(e) => setStickerPackageId(e.target.value)} /></Field>
+      </div>
+      <Field label="共有元 postId（任意）"><input className={inputCls} value={sharedPostId} onChange={(e) => setSharedPostId(e.target.value)} /></Field>
+      <Field label="画像・動画">
+        <input type="file" accept="image/*,video/*" multiple onChange={(e) => {
+          for (const file of Array.from(e.target.files ?? [])) void upload(file);
+          e.currentTarget.value = "";
+        }} />
+        {media.length > 0 && <p className="mt-1 text-xs text-[var(--vy-text-dim)]">アップロード済み {media.length}件</p>}
+      </Field>
+      <div className="mb-4 grid grid-cols-2 gap-2">
+        <button disabled={busy} className="rounded-lg bg-[var(--vy-accent)] py-2 font-semibold text-[var(--vy-accent-contrast)] disabled:opacity-50" onClick={() => void run(() => api.line.notes.create(accountId, noteInput()))}>新規作成</button>
+        <button disabled={busy || !selectedId} className="rounded-lg border border-[var(--vy-border)] py-2 disabled:opacity-50" onClick={() => void run(() => api.line.notes.update(accountId, selectedId, noteInput()))}>選択ノートを更新</button>
+      </div>
+      <div className="mb-3 flex items-center justify-between">
+        <span className="text-xs text-[var(--vy-text-dim)]">ノート一覧</span>
+        <button type="button" className="text-xs text-[var(--vy-accent)]" onClick={() => void refresh()}>再読み込み</button>
+      </div>
+      <div className="mb-4 max-h-48 space-y-1 overflow-y-auto">
+        {posts.length === 0 ? <p className="py-4 text-center text-xs text-[var(--vy-text-dim)]">ノートがありません</p> : posts.map((post, index) => {
+          const item = noteSummary(post);
+          return (
+            <button type="button" key={item.id || index} className={cn("w-full rounded-lg border px-3 py-2 text-left", selectedId === item.id ? "border-[var(--vy-accent)]" : "border-[var(--vy-border)]")} onClick={() => { setSelectedId(item.id); setText(item.text); }}>
+              <span className="block truncate text-sm">{item.text || "（メディア/スタンプノート）"}</span>
+              <span className="block truncate text-[10px] text-[var(--vy-text-dim)]">{item.id}</span>
+            </button>
+          );
+        })}
+      </div>
+      <Field label="コメント">
+        <div className="flex gap-2"><input className={cn(inputCls, "flex-1")} value={comment} onChange={(e) => setComment(e.target.value)} /><button disabled={busy || !selectedId || !comment.trim()} className="rounded-lg border border-[var(--vy-border)] px-3 disabled:opacity-50" onClick={() => void run(() => api.line.notes.comment(accountId, selectedId, chatId, comment.trim()), false)}>送信</button></div>
+      </Field>
+      <div className="grid grid-cols-2 gap-2">
+        <select className={inputCls} value={likeType} onChange={(e) => setLikeType(e.target.value)}>{["1001", "1002", "1003", "1004", "1005", "1006"].map((v) => <option key={v} value={v}>リアクション {v}</option>)}</select>
+        <button disabled={busy || !selectedId} className="rounded-lg border border-[var(--vy-border)] py-2 disabled:opacity-50" onClick={() => void run(() => api.line.notes.like(accountId, selectedId, chatId, likeType), false)}>リアクション</button>
+        <button disabled={busy || !selectedId} className="rounded-lg border border-[var(--vy-border)] py-2 disabled:opacity-50" onClick={() => void run(() => api.line.notes.unlike(accountId, selectedId, chatId), false)}>リアクション解除</button>
+        <button disabled={busy || !selectedId} className="rounded-lg border border-[var(--vy-border)] py-2 disabled:opacity-50" onClick={() => void run(async () => { const [mine, list] = await Promise.all([api.line.notes.getLike(accountId, selectedId, chatId), api.line.notes.listLikes(accountId, selectedId, chatId)]); setLikeInfo(JSON.stringify({ mine, list })); }, false)}>リアクション確認</button>
+        <button disabled={busy || !selectedId} className="rounded-lg border border-[var(--vy-border)] py-2 disabled:opacity-50" onClick={() => void run(() => api.line.notes.share(accountId, selectedId, chatId), false)}>このチャットへ共有</button>
+        <label className="cursor-pointer rounded-lg border border-[var(--vy-border)] py-2 text-center">
+          コメント画像
+          <input type="file" accept="image/*" className="hidden" onChange={(e) => {
+            const file = e.target.files?.[0];
+            if (!file || !selectedId) return;
+            void run(async () => {
+              const uploaded = await api.line.notes.uploadCommentImage(accountId, file);
+              await api.line.notes.comment(accountId, selectedId, chatId, comment.trim(), uploaded.objId);
+            }, false);
+            e.currentTarget.value = "";
+          }} />
+        </label>
+        <button disabled={busy || !selectedId} className="rounded-lg border border-red-500/40 py-2 text-red-400 disabled:opacity-50" onClick={() => void run(async () => { await api.line.notes.remove(accountId, chatId, selectedId); setSelectedId(""); setText(""); })}>削除</button>
+      </div>
+      {likeInfo && <p className="mt-2 break-all text-[10px] text-[var(--vy-text-dim)]">{likeInfo}</p>}
+    </Modal>
+  );
+}
+
 // ── あみだくじ ──────────────────────────────────────────────
 
 function LadderModal({
@@ -522,10 +816,10 @@ export function PlusMenu({ chatId }: { chatId: string }) {
   const accountId = useStore((s) => s.accountId);
   const chat = useStore((s) => s.chats.find((c) => c.id === chatId));
   const [open, setOpen] = useState(false);
-  const [mode, setMode] = useState<"schedule" | "ladder" | "poll" | null>(null);
+  const [mode, setMode] = useState<"schedule" | "ladder" | "poll" | "note" | "album" | null>(null);
 
   const items: {
-    key: "schedule" | "ladder" | "poll";
+    key: "schedule" | "ladder" | "poll" | "note" | "album";
     label: string;
     icon: string;
     disabled?: boolean;
@@ -533,6 +827,8 @@ export function PlusMenu({ chatId }: { chatId: string }) {
     { key: "schedule", label: "イベントを作成", icon: "📅" },
     { key: "ladder", label: "あみだくじ", icon: "🎯", disabled: chat?.type !== "group" },
     { key: "poll", label: "アンケート", icon: "🗳️" },
+    { key: "note", label: "ノート", icon: "📝", disabled: chat?.type !== "group" },
+    { key: "album", label: "アルバム", icon: "🖼️", disabled: chat?.type !== "group" },
   ];
 
   return (
@@ -586,6 +882,12 @@ export function PlusMenu({ chatId }: { chatId: string }) {
       )}
       {mode === "poll" && accountId && (
         <PollModal accountId={accountId} chatId={chatId} onClose={() => setMode(null)} />
+      )}
+      {mode === "note" && accountId && (
+        <NoteModal accountId={accountId} chatId={chatId} onClose={() => setMode(null)} />
+      )}
+      {mode === "album" && accountId && (
+        <AlbumModal accountId={accountId} chatId={chatId} onClose={() => setMode(null)} />
       )}
     </>
   );

--- a/Vyline/apps/desktop/src/lib/mappers.ts
+++ b/Vyline/apps/desktop/src/lib/mappers.ts
@@ -71,8 +71,9 @@ function parsePostNotification(meta: Record<string, unknown> | null) {
   })();
   const homeId = String(meta.chatId ?? meta.homeId ?? params?.get("homeId") ?? "") || undefined;
   const albumId =
-    String(meta.cafeId ?? meta.albumId ?? params?.get("albumIdV2") ?? params?.get("albumId") ?? "") ||
-    undefined;
+    String(
+      meta.cafeId ?? meta.albumId ?? params?.get("albumIdV2") ?? params?.get("albumId") ?? "",
+    ) || undefined;
   const postId =
     String(meta.postId ?? meta.POST_ID ?? meta.noteId ?? params?.get("postId") ?? "") || undefined;
   const previewMedias = (() => {
@@ -87,10 +88,15 @@ function parsePostNotification(meta: Record<string, unknown> | null) {
           const media = item as Record<string, unknown>;
           const mediaOid = typeof media.mediaOid === "string" ? media.mediaOid : "";
           return mediaOid
-            ? { mediaOid, mediaType: typeof media.mediaType === "string" ? media.mediaType : undefined }
+            ? {
+                mediaOid,
+                mediaType: typeof media.mediaType === "string" ? media.mediaType : undefined,
+              }
             : null;
         })
-        .filter((item): item is { mediaOid: string; mediaType: string | undefined } => Boolean(item));
+        .filter((item): item is { mediaOid: string; mediaType: string | undefined } =>
+          Boolean(item),
+        );
     } catch {
       return undefined;
     }

--- a/Vyline/apps/desktop/src/lib/mappers.ts
+++ b/Vyline/apps/desktop/src/lib/mappers.ts
@@ -58,6 +58,59 @@ function sanitizeText(text: string | null | undefined): string | undefined {
   return cleaned || undefined;
 }
 
+function parsePostNotification(meta: Record<string, unknown> | null) {
+  if (!meta) return undefined;
+  const serviceType = String(meta.serviceType ?? meta.SERVICE_TYPE ?? "").toUpperCase();
+  const postEndUrl = typeof meta.postEndUrl === "string" ? meta.postEndUrl : "";
+  const params = (() => {
+    try {
+      return postEndUrl ? new URL(postEndUrl).searchParams : null;
+    } catch {
+      return null;
+    }
+  })();
+  const homeId = String(meta.chatId ?? meta.homeId ?? params?.get("homeId") ?? "") || undefined;
+  const albumId =
+    String(meta.cafeId ?? meta.albumId ?? params?.get("albumIdV2") ?? params?.get("albumId") ?? "") ||
+    undefined;
+  const postId =
+    String(meta.postId ?? meta.POST_ID ?? meta.noteId ?? params?.get("postId") ?? "") || undefined;
+  const previewMedias = (() => {
+    const raw = meta.previewMedias;
+    if (typeof raw !== "string" || !raw.trim()) return undefined;
+    try {
+      const parsed = JSON.parse(raw);
+      if (!Array.isArray(parsed)) return undefined;
+      return parsed
+        .map((item) => {
+          if (!item || typeof item !== "object") return null;
+          const media = item as Record<string, unknown>;
+          const mediaOid = typeof media.mediaOid === "string" ? media.mediaOid : "";
+          return mediaOid
+            ? { mediaOid, mediaType: typeof media.mediaType === "string" ? media.mediaType : undefined }
+            : null;
+        })
+        .filter((item): item is { mediaOid: string; mediaType: string | undefined } => Boolean(item));
+    } catch {
+      return undefined;
+    }
+  })();
+  if (serviceType === "AB" || albumId) {
+    return {
+      kind: "album" as const,
+      homeId,
+      albumId,
+      title: typeof meta.albumName === "string" ? meta.albumName : undefined,
+      mediaCount: Number(meta.mediaCount) || undefined,
+      previewMedias,
+    };
+  }
+  if (postId || serviceType === "NOTE" || serviceType === "NT") {
+    return { kind: "note" as const, homeId, postId };
+  }
+  return { kind: "unknown" as const, homeId };
+}
+
 function resolveDisplayName(
   raw: string | null | undefined,
   fallbackMid: string,
@@ -352,6 +405,10 @@ export function mapMessage(
         ? parseMentions(m.contentMetadata as Record<string, unknown> | null)
         : undefined,
     callMeta: kind === "call" ? parseCallMeta(m.contentType, meta) : undefined,
+    postNotification:
+      String(m.contentType ?? "").toUpperCase() === "POSTNOTIFICATION"
+        ? parsePostNotification(meta)
+        : undefined,
     createdAt: m.createdTime,
     status: messageStatus(m),
     read,

--- a/Vyline/apps/desktop/src/lib/store-types.ts
+++ b/Vyline/apps/desktop/src/lib/store-types.ts
@@ -78,6 +78,16 @@ export type Message = {
   mentions?: MentionInfo[];
   /** 通話イベント用 */
   callMeta?: CallMessageMeta;
+  /** ノート/アルバム作成時の POSTNOTIFICATION */
+  postNotification?: {
+    kind: "note" | "album" | "unknown";
+    homeId?: string;
+    postId?: string;
+    albumId?: string;
+    title?: string;
+    mediaCount?: number;
+    previewMedias?: Array<{ mediaOid: string; mediaType?: string }>;
+  };
   createdAt: number;
   status: MessageStatus;
   read: boolean;

--- a/Vyline/backend/src/api/auth.ts
+++ b/Vyline/backend/src/api/auth.ts
@@ -200,7 +200,9 @@ authRouter.post("/content/qr", async (c) => {
     log.info({ accountId: body.accountId, urlReady: Boolean(url) }, "content QR URL ready");
   })
     .then(() => log.info({ accountId: body.accountId }, "content QR login completed"))
-    .catch((err: unknown) => log.error({ accountId: body.accountId, err }, "content QR login failed"));
+    .catch((err: unknown) =>
+      log.error({ accountId: body.accountId, err }, "content QR login failed"),
+    );
 
   return c.json({
     ok: true,
@@ -260,7 +262,13 @@ authRouter.post("/login/token", async (c) => {
 
   try {
     const deviceMode = body.deviceMode?.trim().toUpperCase();
-    const allowedDeviceModes = new Set(["IOS", "IOSIPAD", "ANDROIDSECONDARY", "DESKTOPWIN", "DESKTOPMAC"]);
+    const allowedDeviceModes = new Set([
+      "IOS",
+      "IOSIPAD",
+      "ANDROIDSECONDARY",
+      "DESKTOPWIN",
+      "DESKTOPMAC",
+    ]);
     if (deviceMode && !allowedDeviceModes.has(deviceMode)) {
       return c.json({ ok: false, error: "invalid deviceMode" }, 400);
     }

--- a/Vyline/backend/src/api/auth.ts
+++ b/Vyline/backend/src/api/auth.ts
@@ -25,6 +25,8 @@ import {
   getQrState,
   getLoggedInAt,
   getAuthToken,
+  getContentQrState,
+  loginContentWithQRCode,
   removeClient,
 } from "../line/clientManager.js";
 import { deleteToken, loadTokens, listSavedSessions } from "../storage/tokenStore.js";
@@ -185,6 +187,49 @@ authRouter.get("/login/qr/:id", (c) => {
 });
 
 // ─────────────────────────────────────────────
+// POST /auth/content/qr
+// Note / Album 用の ANDROIDSECONDARY セッションを正式登録する
+// ─────────────────────────────────────────────
+authRouter.post("/content/qr", async (c) => {
+  const body = await c.req.json<{ accountId: string }>();
+  if (!body.accountId) {
+    return c.json({ ok: false, error: "accountId required" }, 400);
+  }
+
+  loginContentWithQRCode(body.accountId, (url) => {
+    log.info({ accountId: body.accountId, urlReady: Boolean(url) }, "content QR URL ready");
+  })
+    .then(() => log.info({ accountId: body.accountId }, "content QR login completed"))
+    .catch((err: unknown) => log.error({ accountId: body.accountId, err }, "content QR login failed"));
+
+  return c.json({
+    ok: true,
+    message: "Content QR login started — poll GET /auth/content/qr/:id",
+    accountId: body.accountId,
+  });
+});
+
+authRouter.get("/content/qr/:id", (c) => {
+  const accountId = c.req.param("id");
+  const state = getContentQrState(accountId);
+  const status = state.ready
+    ? "completed"
+    : state.expired
+      ? "expired"
+      : state.url
+        ? "pending"
+        : state.inProgress
+          ? "waiting"
+          : "idle";
+  return c.json({
+    ok: true,
+    status,
+    qrUrl: state.url,
+    pincode: state.pincode,
+  });
+});
+
+// ─────────────────────────────────────────────
 // POST /auth/restore
 // body: { accountId }  — 保存済みトークンで復元
 // ─────────────────────────────────────────────
@@ -208,17 +253,22 @@ authRouter.post("/restore", async (c) => {
 // body: { accountId, authToken }  — トークン直接指定でログイン
 // ─────────────────────────────────────────────
 authRouter.post("/login/token", async (c) => {
-  const body = await c.req.json<{ accountId: string; authToken: string }>();
+  const body = await c.req.json<{ accountId: string; authToken: string; deviceMode?: string }>();
   if (!body.accountId || !body.authToken) {
     return c.json({ ok: false, error: "accountId and authToken required" }, 400);
   }
 
   try {
-    await loginWithAuthToken(body.accountId, body.authToken);
+    const deviceMode = body.deviceMode?.trim().toUpperCase();
+    const allowedDeviceModes = new Set(["IOS", "IOSIPAD", "ANDROIDSECONDARY", "DESKTOPWIN", "DESKTOPMAC"]);
+    if (deviceMode && !allowedDeviceModes.has(deviceMode)) {
+      return c.json({ ok: false, error: "invalid deviceMode" }, 400);
+    }
+    await loginWithAuthToken(body.accountId, body.authToken, deviceMode);
 
     // トークンを保存（次回から restore で復元可能）
     const { saveToken } = await import("../storage/tokenStore.js");
-    await saveToken(body.accountId, body.authToken, {});
+    await saveToken(body.accountId, body.authToken, deviceMode ? { deviceMode } : {});
 
     log.info({ accountId: body.accountId }, "token login success");
     return c.json({ ok: true, accountId: body.accountId });

--- a/Vyline/backend/src/api/line.ts
+++ b/Vyline/backend/src/api/line.ts
@@ -188,18 +188,25 @@ lineRouter.post("/:accountId/notes/updates", async (c) => {
 
 lineRouter.post("/:accountId/notes", async (c) => {
   const accountId = c.req.param("accountId");
-    const body = await c.req.json<{
-      homeId?: string;
+  const body = await c.req.json<{
+    homeId?: string;
     text?: string;
     sharedPostId?: string;
     stickerIds?: string[];
     stickerPackageIds?: string[];
     mediaObjectIds?: string[];
-      mediaObjectTypes?: string[];
-      contents?: Record<string, unknown>;
-      postInfo?: Record<string, unknown>;
-    }>();
-  if (!body.homeId || (!body.text && !body.sharedPostId && !body.stickerIds?.length && !body.mediaObjectIds?.length && !body.contents)) {
+    mediaObjectTypes?: string[];
+    contents?: Record<string, unknown>;
+    postInfo?: Record<string, unknown>;
+  }>();
+  if (
+    !body.homeId ||
+    (!body.text &&
+      !body.sharedPostId &&
+      !body.stickerIds?.length &&
+      !body.mediaObjectIds?.length &&
+      !body.contents)
+  ) {
     return c.json({ ok: false, error: "homeId and note content required" }, 400);
   }
   try {
@@ -228,11 +235,15 @@ lineRouter.patch("/:accountId/notes/:postId", async (c) => {
       ...(Array.isArray(raw.stickerPackageIds)
         ? { stickerPackageIds: raw.stickerPackageIds.map(String) }
         : {}),
-      ...(Array.isArray(raw.mediaObjectIds) ? { mediaObjectIds: raw.mediaObjectIds.map(String) } : {}),
+      ...(Array.isArray(raw.mediaObjectIds)
+        ? { mediaObjectIds: raw.mediaObjectIds.map(String) }
+        : {}),
       ...(Array.isArray(raw.mediaObjectTypes)
         ? { mediaObjectTypes: raw.mediaObjectTypes.map(String) }
         : {}),
-      ...(raw.contents && typeof raw.contents === "object" ? { contents: raw.contents as Record<string, unknown> } : {}),
+      ...(raw.contents && typeof raw.contents === "object"
+        ? { contents: raw.contents as Record<string, unknown> }
+        : {}),
     };
     return c.json(await updateNote(client, homeId, postId, input));
   } catch (err) {
@@ -252,7 +263,14 @@ lineRouter.post("/:accountId/notes/:postId/like", async (c) => {
   try {
     const client = await getContentClient(accountId);
     if (!client) return c.json({ ok: false, error: "not logged in" }, 401);
-    return c.json(await likeNote(client, body.homeId, postId, body.likeType as "1001" | "1002" | "1003" | "1004" | "1005" | "1006" | undefined));
+    return c.json(
+      await likeNote(
+        client,
+        body.homeId,
+        postId,
+        body.likeType as "1001" | "1002" | "1003" | "1004" | "1005" | "1006" | undefined,
+      ),
+    );
   } catch (err) {
     return handleError(err, c);
   }
@@ -266,7 +284,9 @@ lineRouter.delete("/:accountId/notes/:postId/like", async (c) => {
   try {
     const client = await getContentClient(accountId);
     return c.json(await unlikeNote(client, homeId, postId));
-  } catch (err) { return handleError(err, c); }
+  } catch (err) {
+    return handleError(err, c);
+  }
 });
 
 lineRouter.get("/:accountId/notes/:postId/like", async (c) => {
@@ -277,7 +297,9 @@ lineRouter.get("/:accountId/notes/:postId/like", async (c) => {
   try {
     const client = await getContentClient(accountId);
     return c.json(await getNoteLike(client, homeId, postId));
-  } catch (err) { return handleError(err, c); }
+  } catch (err) {
+    return handleError(err, c);
+  }
 });
 
 lineRouter.get("/:accountId/notes/:postId/likes", async (c) => {
@@ -288,7 +310,9 @@ lineRouter.get("/:accountId/notes/:postId/likes", async (c) => {
   try {
     const client = await getContentClient(accountId);
     return c.json(await listNoteLikes(client, homeId, postId));
-  } catch (err) { return handleError(err, c); }
+  } catch (err) {
+    return handleError(err, c);
+  }
 });
 
 lineRouter.post("/:accountId/notes/:postId/comments", async (c) => {
@@ -302,15 +326,17 @@ lineRouter.post("/:accountId/notes/:postId/comments", async (c) => {
     const client = await getContentClient(accountId);
     if (!client) return c.json({ ok: false, error: "not logged in" }, 401);
     const contentsList = body.imageObjectId
-      ? [{
-          categoryId: "media",
-          extData: {
-            objectId: body.imageObjectId,
-            type: "PHOTO",
-            obsNamespace: "cmt",
-            serviceName: "myhome",
+      ? [
+          {
+            categoryId: "media",
+            extData: {
+              objectId: body.imageObjectId,
+              type: "PHOTO",
+              obsNamespace: "cmt",
+              serviceName: "myhome",
+            },
           },
-        }]
+        ]
       : undefined;
     return c.json(await commentNote(client, body.homeId, postId, body.text ?? "", contentsList));
   } catch (err) {
@@ -409,8 +435,15 @@ lineRouter.get("/:accountId/albums", async (c) => {
     if (!client) return c.json({ ok: false, error: "not logged in" }, 401);
     const query = albumQuery(c);
     if (!query.chatId) return c.json({ ok: false, error: "chatId required" }, 400);
-    return c.json(await listAlbums(client, query as { chatId: string; cursor?: string; orderBy?: string; include?: string }));
-  } catch (err) { return handleError(err, c); }
+    return c.json(
+      await listAlbums(
+        client,
+        query as { chatId: string; cursor?: string; orderBy?: string; include?: string },
+      ),
+    );
+  } catch (err) {
+    return handleError(err, c);
+  }
 });
 lineRouter.get("/:accountId/albums/preview", async (c) => {
   try {
@@ -418,30 +451,56 @@ lineRouter.get("/:accountId/albums/preview", async (c) => {
     if (!client) return c.json({ ok: false, error: "not logged in" }, 401);
     const query = albumQuery(c);
     if (!query.chatId) return c.json({ ok: false, error: "chatId required" }, 400);
-    return c.json(await previewAlbums(client, query as { chatId: string; pageSize?: string; thumbnailCount?: string; viewType?: string }));
-  } catch (err) { return handleError(err, c); }
+    return c.json(
+      await previewAlbums(
+        client,
+        query as { chatId: string; pageSize?: string; thumbnailCount?: string; viewType?: string },
+      ),
+    );
+  } catch (err) {
+    return handleError(err, c);
+  }
 });
 lineRouter.post("/:accountId/albums", async (c) => {
-  const body = await c.req.json<{ chatId?: string; title?: string; modifyDuplicateTitle?: boolean }>();
-  if (!body.chatId || !body.title?.trim()) return c.json({ ok: false, error: "chatId and title required" }, 400);
+  const body = await c.req.json<{
+    chatId?: string;
+    title?: string;
+    modifyDuplicateTitle?: boolean;
+  }>();
+  if (!body.chatId || !body.title?.trim())
+    return c.json({ ok: false, error: "chatId and title required" }, 400);
   try {
     const client = await albumClient(c);
     if (!client) return c.json({ ok: false, error: "not logged in" }, 401);
-    return c.json(await createAlbum(client, {
-      chatId: body.chatId,
-      title: body.title.trim(),
-      ...(body.modifyDuplicateTitle !== undefined ? { modifyDuplicateTitle: body.modifyDuplicateTitle } : {}),
-    }));
-  } catch (err) { return handleError(err, c); }
+    return c.json(
+      await createAlbum(client, {
+        chatId: body.chatId,
+        title: body.title.trim(),
+        ...(body.modifyDuplicateTitle !== undefined
+          ? { modifyDuplicateTitle: body.modifyDuplicateTitle }
+          : {}),
+      }),
+    );
+  } catch (err) {
+    return handleError(err, c);
+  }
 });
 lineRouter.patch("/:accountId/albums/:albumId", async (c) => {
   const body = await c.req.json<{ chatId?: string; title?: string }>();
-  if (!body.chatId || !body.title?.trim()) return c.json({ ok: false, error: "chatId and title required" }, 400);
+  if (!body.chatId || !body.title?.trim())
+    return c.json({ ok: false, error: "chatId and title required" }, 400);
   try {
     const client = await albumClient(c);
     if (!client) return c.json({ ok: false, error: "not logged in" }, 401);
-    return c.json(await updateAlbum(client, c.req.param("albumId"), { chatId: body.chatId, title: body.title.trim() }));
-  } catch (err) { return handleError(err, c); }
+    return c.json(
+      await updateAlbum(client, c.req.param("albumId"), {
+        chatId: body.chatId,
+        title: body.title.trim(),
+      }),
+    );
+  } catch (err) {
+    return handleError(err, c);
+  }
 });
 lineRouter.delete("/:accountId/albums/:albumId", async (c) => {
   const chatId = c.req.query("chatId");
@@ -450,7 +509,9 @@ lineRouter.delete("/:accountId/albums/:albumId", async (c) => {
     const client = await albumClient(c);
     if (!client) return c.json({ ok: false, error: "not logged in" }, 401);
     return c.json(await deleteAlbum(client, c.req.param("albumId"), chatId));
-  } catch (err) { return handleError(err, c); }
+  } catch (err) {
+    return handleError(err, c);
+  }
 });
 lineRouter.post("/:accountId/albums/:albumId/share", async (c) => {
   const body = await c.req.json<{ chatId?: string }>();
@@ -459,7 +520,9 @@ lineRouter.post("/:accountId/albums/:albumId/share", async (c) => {
     const client = await albumClient(c);
     if (!client) return c.json({ ok: false, error: "not logged in" }, 401);
     return c.json(await shareAlbum(client, c.req.param("albumId"), body.chatId));
-  } catch (err) { return handleError(err, c); }
+  } catch (err) {
+    return handleError(err, c);
+  }
 });
 lineRouter.post("/:accountId/albums/:albumId/media", async (c) => {
   const chatId = c.req.query("chatId");
@@ -468,30 +531,51 @@ lineRouter.post("/:accountId/albums/:albumId/media", async (c) => {
     const client = await albumClient(c);
     if (!client) return c.json({ ok: false, error: "not logged in" }, 401);
     const contentType = c.req.header("content-type");
-    return c.json(await uploadAlbumMedia(client, c.req.param("albumId"), {
-      chatId,
-      data: await c.req.blob(),
-      ...(contentType ? { contentType } : {}),
-    }));
-  } catch (err) { return handleError(err, c); }
+    return c.json(
+      await uploadAlbumMedia(client, c.req.param("albumId"), {
+        chatId,
+        data: await c.req.blob(),
+        ...(contentType ? { contentType } : {}),
+      }),
+    );
+  } catch (err) {
+    return handleError(err, c);
+  }
 });
 lineRouter.post("/:accountId/albums/:albumId/photos", async (c) => {
-  const body = await c.req.json<{ chatId?: string; photos?: Parameters<typeof addAlbumPhotos>[2]["photos"] }>();
-  if (!body.chatId || !body.photos?.length) return c.json({ ok: false, error: "chatId and photos required" }, 400);
+  const body = await c.req.json<{
+    chatId?: string;
+    photos?: Parameters<typeof addAlbumPhotos>[2]["photos"];
+  }>();
+  if (!body.chatId || !body.photos?.length)
+    return c.json({ ok: false, error: "chatId and photos required" }, 400);
   try {
     const client = await albumClient(c);
     if (!client) return c.json({ ok: false, error: "not logged in" }, 401);
-    return c.json(await addAlbumPhotos(client, c.req.param("albumId"), { chatId: body.chatId, albumId: c.req.param("albumId"), photos: body.photos }));
-  } catch (err) { return handleError(err, c); }
+    return c.json(
+      await addAlbumPhotos(client, c.req.param("albumId"), {
+        chatId: body.chatId,
+        albumId: c.req.param("albumId"),
+        photos: body.photos,
+      }),
+    );
+  } catch (err) {
+    return handleError(err, c);
+  }
 });
 lineRouter.delete("/:accountId/albums/:albumId/photos", async (c) => {
   const body = await c.req.json<{ chatId?: string; photoIds?: string[] }>();
-  if (!body.chatId || !body.photoIds?.length) return c.json({ ok: false, error: "chatId and photoIds required" }, 400);
+  if (!body.chatId || !body.photoIds?.length)
+    return c.json({ ok: false, error: "chatId and photoIds required" }, 400);
   try {
     const client = await albumClient(c);
     if (!client) return c.json({ ok: false, error: "not logged in" }, 401);
-    return c.json(await deleteAlbumPhotos(client, c.req.param("albumId"), body.chatId, body.photoIds));
-  } catch (err) { return handleError(err, c); }
+    return c.json(
+      await deleteAlbumPhotos(client, c.req.param("albumId"), body.chatId, body.photoIds),
+    );
+  } catch (err) {
+    return handleError(err, c);
+  }
 });
 lineRouter.get("/:accountId/albums/:albumId/photos", async (c) => {
   try {
@@ -499,16 +583,20 @@ lineRouter.get("/:accountId/albums/:albumId/photos", async (c) => {
     if (!client) return c.json({ ok: false, error: "not logged in" }, 401);
     const query = albumQuery(c);
     if (!query.chatId) return c.json({ ok: false, error: "chatId required" }, 400);
-    return c.json(await listAlbumPhotos(client, c.req.param("albumId"), {
-      chatId: query.chatId,
-      ...(query.cursor !== undefined ? { cursor: query.cursor } : {}),
-      ...(query.pageSize !== undefined ? { pageSize: query.pageSize } : {}),
-      ...(query.orderBy !== undefined ? { orderBy: query.orderBy } : {}),
-      ...(query.include !== undefined ? { include: query.include } : {}),
-      ...(query.filterType !== undefined ? { filterType: query.filterType } : {}),
-      ...(query.targetUser !== undefined ? { targetUser: query.targetUser } : {}),
-    }));
-  } catch (err) { return handleError(err, c); }
+    return c.json(
+      await listAlbumPhotos(client, c.req.param("albumId"), {
+        chatId: query.chatId,
+        ...(query.cursor !== undefined ? { cursor: query.cursor } : {}),
+        ...(query.pageSize !== undefined ? { pageSize: query.pageSize } : {}),
+        ...(query.orderBy !== undefined ? { orderBy: query.orderBy } : {}),
+        ...(query.include !== undefined ? { include: query.include } : {}),
+        ...(query.filterType !== undefined ? { filterType: query.filterType } : {}),
+        ...(query.targetUser !== undefined ? { targetUser: query.targetUser } : {}),
+      }),
+    );
+  } catch (err) {
+    return handleError(err, c);
+  }
 });
 lineRouter.get("/:accountId/albums/:albumId/media/:oid", async (c) => {
   try {
@@ -525,11 +613,15 @@ lineRouter.get("/:accountId/albums/:albumId/media/:oid", async (c) => {
     return new Response(response.body, {
       status: 200,
       headers: {
-        "content-type": response.headers.get("content-type") ?? (mediaType === "video" ? "video/mp4" : "image/jpeg"),
+        "content-type":
+          response.headers.get("content-type") ??
+          (mediaType === "video" ? "video/mp4" : "image/jpeg"),
         "cache-control": "private, max-age=300",
       },
     });
-  } catch (err) { return handleError(err, c); }
+  } catch (err) {
+    return handleError(err, c);
+  }
 });
 
 // ─── Chat safety locks ─────────────────────────

--- a/Vyline/backend/src/api/line.ts
+++ b/Vyline/backend/src/api/line.ts
@@ -31,13 +31,35 @@ import { getFeatureLocks, unbanCreateGroup } from "../storage/featureLocks.js";
 import { getPluginStates, listPlugins, setPluginState } from "../line/pluginManager.js";
 import { isPluginActive } from "../line/pluginRuntime.js";
 import {
+  commentNote,
   createNote,
   deleteNote,
   getNote,
+  getNoteLike,
+  getGroupHomeUpdates,
+  likeNote,
   listNotes,
+  listNoteLikes,
   shareNoteToChat,
+  unlikeNote,
+  updateNote,
+  uploadNoteCommentImage,
+  uploadNoteMedia,
 } from "../service/noteService.js";
-import { getClient } from "../line/clientManager.js";
+import {
+  addAlbumPhotos,
+  createAlbum,
+  deleteAlbum,
+  deleteAlbumPhotos,
+  downloadAlbumMedia,
+  listAlbumPhotos,
+  listAlbums,
+  previewAlbums,
+  shareAlbum,
+  updateAlbum,
+  uploadAlbumMedia,
+} from "../service/albumService.js";
+import { getClient, getContentClient } from "../line/clientManager.js";
 import {
   fetchProfile,
   fetchContactProfile,
@@ -140,7 +162,7 @@ lineRouter.get("/:accountId/notes", async (c) => {
   const homeId = c.req.query("homeId");
   if (!homeId) return c.json({ ok: false, error: "homeId required" }, 400);
   try {
-    const client = getClient(accountId);
+    const client = await getContentClient(accountId);
     if (!client) return c.json({ ok: false, error: "not logged in" }, 401);
     return c.json(await listNotes(accountId, client, homeId));
   } catch (err) {
@@ -148,16 +170,175 @@ lineRouter.get("/:accountId/notes", async (c) => {
   }
 });
 
-lineRouter.post("/:accountId/notes", async (c) => {
+lineRouter.post("/:accountId/notes/updates", async (c) => {
   const accountId = c.req.param("accountId");
-  const body = await c.req.json<{ homeId?: string; text?: string }>();
-  if (!body.homeId || !body.text) {
-    return c.json({ ok: false, error: "homeId and text required" }, 400);
+  const revisionRaw = c.req.query("revision");
+  const revision = Number(revisionRaw);
+  if (!revisionRaw || !Number.isSafeInteger(revision) || revision < 0) {
+    return c.json({ ok: false, error: "revision must be a non-negative integer" }, 400);
   }
   try {
-    const client = getClient(accountId);
+    const client = await getContentClient(accountId);
     if (!client) return c.json({ ok: false, error: "not logged in" }, 401);
-    return c.json(await createNote(accountId, client, body.homeId, body.text));
+    return c.json(await getGroupHomeUpdates(client, revision));
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+lineRouter.post("/:accountId/notes", async (c) => {
+  const accountId = c.req.param("accountId");
+    const body = await c.req.json<{
+      homeId?: string;
+    text?: string;
+    sharedPostId?: string;
+    stickerIds?: string[];
+    stickerPackageIds?: string[];
+    mediaObjectIds?: string[];
+      mediaObjectTypes?: string[];
+      contents?: Record<string, unknown>;
+      postInfo?: Record<string, unknown>;
+    }>();
+  if (!body.homeId || (!body.text && !body.sharedPostId && !body.stickerIds?.length && !body.mediaObjectIds?.length && !body.contents)) {
+    return c.json({ ok: false, error: "homeId and note content required" }, 400);
+  }
+  try {
+    const client = await getContentClient(accountId);
+    if (!client) return c.json({ ok: false, error: "not logged in" }, 401);
+    const { homeId, ...input } = body;
+    return c.json(await createNote(accountId, client, homeId, input));
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+lineRouter.patch("/:accountId/notes/:postId", async (c) => {
+  const accountId = c.req.param("accountId");
+  const postId = c.req.param("postId");
+  const body = await c.req.json<Record<string, unknown> & { homeId?: string }>();
+  if (!body.homeId) return c.json({ ok: false, error: "homeId required" }, 400);
+  try {
+    const client = await getContentClient(accountId);
+    if (!client) return c.json({ ok: false, error: "not logged in" }, 401);
+    const { homeId, ...raw } = body;
+    const input = {
+      ...(typeof raw.text === "string" ? { text: raw.text } : {}),
+      ...(typeof raw.sharedPostId === "string" ? { sharedPostId: raw.sharedPostId } : {}),
+      ...(Array.isArray(raw.stickerIds) ? { stickerIds: raw.stickerIds.map(String) } : {}),
+      ...(Array.isArray(raw.stickerPackageIds)
+        ? { stickerPackageIds: raw.stickerPackageIds.map(String) }
+        : {}),
+      ...(Array.isArray(raw.mediaObjectIds) ? { mediaObjectIds: raw.mediaObjectIds.map(String) } : {}),
+      ...(Array.isArray(raw.mediaObjectTypes)
+        ? { mediaObjectTypes: raw.mediaObjectTypes.map(String) }
+        : {}),
+      ...(raw.contents && typeof raw.contents === "object" ? { contents: raw.contents as Record<string, unknown> } : {}),
+    };
+    return c.json(await updateNote(client, homeId, postId, input));
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+lineRouter.post("/:accountId/notes/:postId/like", async (c) => {
+  const accountId = c.req.param("accountId");
+  const postId = c.req.param("postId");
+  const body = await c.req.json<{ homeId?: string; likeType?: string }>();
+  if (!body.homeId) return c.json({ ok: false, error: "homeId required" }, 400);
+  const allowed = new Set(["1001", "1002", "1003", "1004", "1005", "1006"]);
+  if (body.likeType && !allowed.has(body.likeType)) {
+    return c.json({ ok: false, error: "invalid likeType" }, 400);
+  }
+  try {
+    const client = await getContentClient(accountId);
+    if (!client) return c.json({ ok: false, error: "not logged in" }, 401);
+    return c.json(await likeNote(client, body.homeId, postId, body.likeType as "1001" | "1002" | "1003" | "1004" | "1005" | "1006" | undefined));
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+lineRouter.delete("/:accountId/notes/:postId/like", async (c) => {
+  const accountId = c.req.param("accountId");
+  const postId = c.req.param("postId");
+  const homeId = c.req.query("homeId");
+  if (!homeId) return c.json({ ok: false, error: "homeId required" }, 400);
+  try {
+    const client = await getContentClient(accountId);
+    return c.json(await unlikeNote(client, homeId, postId));
+  } catch (err) { return handleError(err, c); }
+});
+
+lineRouter.get("/:accountId/notes/:postId/like", async (c) => {
+  const accountId = c.req.param("accountId");
+  const postId = c.req.param("postId");
+  const homeId = c.req.query("homeId");
+  if (!homeId) return c.json({ ok: false, error: "homeId required" }, 400);
+  try {
+    const client = await getContentClient(accountId);
+    return c.json(await getNoteLike(client, homeId, postId));
+  } catch (err) { return handleError(err, c); }
+});
+
+lineRouter.get("/:accountId/notes/:postId/likes", async (c) => {
+  const accountId = c.req.param("accountId");
+  const postId = c.req.param("postId");
+  const homeId = c.req.query("homeId");
+  if (!homeId) return c.json({ ok: false, error: "homeId required" }, 400);
+  try {
+    const client = await getContentClient(accountId);
+    return c.json(await listNoteLikes(client, homeId, postId));
+  } catch (err) { return handleError(err, c); }
+});
+
+lineRouter.post("/:accountId/notes/:postId/comments", async (c) => {
+  const accountId = c.req.param("accountId");
+  const postId = c.req.param("postId");
+  const body = await c.req.json<{ homeId?: string; text?: string; imageObjectId?: string }>();
+  if (!body.homeId || (!body.text && !body.imageObjectId)) {
+    return c.json({ ok: false, error: "homeId and comment content required" }, 400);
+  }
+  try {
+    const client = await getContentClient(accountId);
+    if (!client) return c.json({ ok: false, error: "not logged in" }, 401);
+    const contentsList = body.imageObjectId
+      ? [{
+          categoryId: "media",
+          extData: {
+            objectId: body.imageObjectId,
+            type: "PHOTO",
+            obsNamespace: "cmt",
+            serviceName: "myhome",
+          },
+        }]
+      : undefined;
+    return c.json(await commentNote(client, body.homeId, postId, body.text ?? "", contentsList));
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+lineRouter.post("/:accountId/notes/media/:type", async (c) => {
+  const accountId = c.req.param("accountId");
+  const type = c.req.param("type");
+  if (type !== "image" && type !== "video") {
+    return c.json({ ok: false, error: "type must be image or video" }, 400);
+  }
+  try {
+    const client = await getContentClient(accountId);
+    if (!client) return c.json({ ok: false, error: "not logged in" }, 401);
+    return c.json(await uploadNoteMedia(client, type, await c.req.blob()));
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+lineRouter.post("/:accountId/notes/comment-image", async (c) => {
+  const accountId = c.req.param("accountId");
+  try {
+    const client = await getContentClient(accountId);
+    if (!client) return c.json({ ok: false, error: "not logged in" }, 401);
+    return c.json(await uploadNoteCommentImage(client, await c.req.blob()));
   } catch (err) {
     return handleError(err, c);
   }
@@ -169,7 +350,7 @@ lineRouter.get("/:accountId/notes/:postId", async (c) => {
   const homeId = c.req.query("homeId");
   if (!homeId) return c.json({ ok: false, error: "homeId required" }, 400);
   try {
-    const client = getClient(accountId);
+    const client = await getContentClient(accountId);
     if (!client) return c.json({ ok: false, error: "not logged in" }, 401);
     return c.json(await getNote(accountId, client, homeId, postId));
   } catch (err) {
@@ -183,7 +364,7 @@ lineRouter.delete("/:accountId/notes/:postId", async (c) => {
   const homeId = c.req.query("homeId");
   if (!homeId) return c.json({ ok: false, error: "homeId required" }, 400);
   try {
-    const client = getClient(accountId);
+    const client = await getContentClient(accountId);
     if (!client) return c.json({ ok: false, error: "not logged in" }, 401);
     return c.json(await deleteNote(accountId, client, homeId, postId));
   } catch (err) {
@@ -194,17 +375,161 @@ lineRouter.delete("/:accountId/notes/:postId", async (c) => {
 lineRouter.post("/:accountId/notes/:postId/share", async (c) => {
   const accountId = c.req.param("accountId");
   const postId = c.req.param("postId");
-  const body = await c.req.json<{ homeId?: string; chatMid?: string }>();
-  if (!body.homeId || !body.chatMid) {
-    return c.json({ ok: false, error: "homeId and chatMid required" }, 400);
+  const body = await c.req.json<{ homeId?: string }>();
+  if (!body.homeId) {
+    return c.json({ ok: false, error: "homeId required" }, 400);
   }
   try {
-    const client = getClient(accountId);
+    const client = await getContentClient(accountId);
     if (!client) return c.json({ ok: false, error: "not logged in" }, 401);
-    return c.json(await shareNoteToChat(accountId, client, body.homeId, postId, body.chatMid));
+    return c.json(await shareNoteToChat(accountId, client, body.homeId, postId));
   } catch (err) {
     return handleError(err, c);
   }
+});
+
+// ─── albums（固定操作のみ公開し、任意 path proxy は持たない） ───
+function albumQuery(c: Context): Record<string, string> {
+  return Object.fromEntries(new URL(c.req.url).searchParams.entries());
+}
+
+async function albumClient(c: Context) {
+  const accountId = c.req.param("accountId");
+  if (!accountId) return null;
+  try {
+    return await getContentClient(accountId);
+  } catch {
+    return null;
+  }
+}
+
+lineRouter.get("/:accountId/albums", async (c) => {
+  try {
+    const client = await albumClient(c);
+    if (!client) return c.json({ ok: false, error: "not logged in" }, 401);
+    const query = albumQuery(c);
+    if (!query.chatId) return c.json({ ok: false, error: "chatId required" }, 400);
+    return c.json(await listAlbums(client, query as { chatId: string; cursor?: string; orderBy?: string; include?: string }));
+  } catch (err) { return handleError(err, c); }
+});
+lineRouter.get("/:accountId/albums/preview", async (c) => {
+  try {
+    const client = await albumClient(c);
+    if (!client) return c.json({ ok: false, error: "not logged in" }, 401);
+    const query = albumQuery(c);
+    if (!query.chatId) return c.json({ ok: false, error: "chatId required" }, 400);
+    return c.json(await previewAlbums(client, query as { chatId: string; pageSize?: string; thumbnailCount?: string; viewType?: string }));
+  } catch (err) { return handleError(err, c); }
+});
+lineRouter.post("/:accountId/albums", async (c) => {
+  const body = await c.req.json<{ chatId?: string; title?: string; modifyDuplicateTitle?: boolean }>();
+  if (!body.chatId || !body.title?.trim()) return c.json({ ok: false, error: "chatId and title required" }, 400);
+  try {
+    const client = await albumClient(c);
+    if (!client) return c.json({ ok: false, error: "not logged in" }, 401);
+    return c.json(await createAlbum(client, {
+      chatId: body.chatId,
+      title: body.title.trim(),
+      ...(body.modifyDuplicateTitle !== undefined ? { modifyDuplicateTitle: body.modifyDuplicateTitle } : {}),
+    }));
+  } catch (err) { return handleError(err, c); }
+});
+lineRouter.patch("/:accountId/albums/:albumId", async (c) => {
+  const body = await c.req.json<{ chatId?: string; title?: string }>();
+  if (!body.chatId || !body.title?.trim()) return c.json({ ok: false, error: "chatId and title required" }, 400);
+  try {
+    const client = await albumClient(c);
+    if (!client) return c.json({ ok: false, error: "not logged in" }, 401);
+    return c.json(await updateAlbum(client, c.req.param("albumId"), { chatId: body.chatId, title: body.title.trim() }));
+  } catch (err) { return handleError(err, c); }
+});
+lineRouter.delete("/:accountId/albums/:albumId", async (c) => {
+  const chatId = c.req.query("chatId");
+  if (!chatId) return c.json({ ok: false, error: "chatId required" }, 400);
+  try {
+    const client = await albumClient(c);
+    if (!client) return c.json({ ok: false, error: "not logged in" }, 401);
+    return c.json(await deleteAlbum(client, c.req.param("albumId"), chatId));
+  } catch (err) { return handleError(err, c); }
+});
+lineRouter.post("/:accountId/albums/:albumId/share", async (c) => {
+  const body = await c.req.json<{ chatId?: string }>();
+  if (!body.chatId) return c.json({ ok: false, error: "chatId required" }, 400);
+  try {
+    const client = await albumClient(c);
+    if (!client) return c.json({ ok: false, error: "not logged in" }, 401);
+    return c.json(await shareAlbum(client, c.req.param("albumId"), body.chatId));
+  } catch (err) { return handleError(err, c); }
+});
+lineRouter.post("/:accountId/albums/:albumId/media", async (c) => {
+  const chatId = c.req.query("chatId");
+  if (!chatId) return c.json({ ok: false, error: "chatId required" }, 400);
+  try {
+    const client = await albumClient(c);
+    if (!client) return c.json({ ok: false, error: "not logged in" }, 401);
+    const contentType = c.req.header("content-type");
+    return c.json(await uploadAlbumMedia(client, c.req.param("albumId"), {
+      chatId,
+      data: await c.req.blob(),
+      ...(contentType ? { contentType } : {}),
+    }));
+  } catch (err) { return handleError(err, c); }
+});
+lineRouter.post("/:accountId/albums/:albumId/photos", async (c) => {
+  const body = await c.req.json<{ chatId?: string; photos?: Parameters<typeof addAlbumPhotos>[2]["photos"] }>();
+  if (!body.chatId || !body.photos?.length) return c.json({ ok: false, error: "chatId and photos required" }, 400);
+  try {
+    const client = await albumClient(c);
+    if (!client) return c.json({ ok: false, error: "not logged in" }, 401);
+    return c.json(await addAlbumPhotos(client, c.req.param("albumId"), { chatId: body.chatId, albumId: c.req.param("albumId"), photos: body.photos }));
+  } catch (err) { return handleError(err, c); }
+});
+lineRouter.delete("/:accountId/albums/:albumId/photos", async (c) => {
+  const body = await c.req.json<{ chatId?: string; photoIds?: string[] }>();
+  if (!body.chatId || !body.photoIds?.length) return c.json({ ok: false, error: "chatId and photoIds required" }, 400);
+  try {
+    const client = await albumClient(c);
+    if (!client) return c.json({ ok: false, error: "not logged in" }, 401);
+    return c.json(await deleteAlbumPhotos(client, c.req.param("albumId"), body.chatId, body.photoIds));
+  } catch (err) { return handleError(err, c); }
+});
+lineRouter.get("/:accountId/albums/:albumId/photos", async (c) => {
+  try {
+    const client = await albumClient(c);
+    if (!client) return c.json({ ok: false, error: "not logged in" }, 401);
+    const query = albumQuery(c);
+    if (!query.chatId) return c.json({ ok: false, error: "chatId required" }, 400);
+    return c.json(await listAlbumPhotos(client, c.req.param("albumId"), {
+      chatId: query.chatId,
+      ...(query.cursor !== undefined ? { cursor: query.cursor } : {}),
+      ...(query.pageSize !== undefined ? { pageSize: query.pageSize } : {}),
+      ...(query.orderBy !== undefined ? { orderBy: query.orderBy } : {}),
+      ...(query.include !== undefined ? { include: query.include } : {}),
+      ...(query.filterType !== undefined ? { filterType: query.filterType } : {}),
+      ...(query.targetUser !== undefined ? { targetUser: query.targetUser } : {}),
+    }));
+  } catch (err) { return handleError(err, c); }
+});
+lineRouter.get("/:accountId/albums/:albumId/media/:oid", async (c) => {
+  try {
+    const client = await albumClient(c);
+    if (!client) return c.json({ ok: false, error: "not logged in" }, 401);
+    const query = albumQuery(c);
+    if (!query.chatId) return c.json({ ok: false, error: "chatId required" }, 400);
+    const mediaType = query.mediaType === "video" ? "video" : "image";
+    const response = await downloadAlbumMedia(client, c.req.param("albumId"), {
+      chatId: query.chatId,
+      oid: c.req.param("oid"),
+      mediaType,
+    });
+    return new Response(response.body, {
+      status: 200,
+      headers: {
+        "content-type": response.headers.get("content-type") ?? (mediaType === "video" ? "video/mp4" : "image/jpeg"),
+        "cache-control": "private, max-age=300",
+      },
+    });
+  } catch (err) { return handleError(err, c); }
 });
 
 // ─── Chat safety locks ─────────────────────────

--- a/Vyline/backend/src/api/openapi.line.ts
+++ b/Vyline/backend/src/api/openapi.line.ts
@@ -36,6 +36,15 @@ const pathParam = (name: string, description: string) =>
     description,
   }) as const;
 
+const queryParam = (name: string, description: string, required = false) =>
+  ({
+    name,
+    in: "query",
+    required,
+    schema: { type: "string" },
+    description,
+  }) as const;
+
 const ok = {
   type: "object",
   properties: { ok: { type: "boolean" } },
@@ -70,7 +79,7 @@ const body = (required: string[], properties: Record<string, unknown>, descripti
 // [routePath, method, tag, spec]
 // operationId は LINE 関数名準拠（Vyline 拡張は description に明記）
 
-type Method = "get" | "post" | "put" | "delete";
+type Method = "get" | "post" | "put" | "patch" | "delete";
 interface OpSpec {
   /** operationId — LINE 関数名（canonicalName）準拠 */
   op: string;
@@ -722,8 +731,20 @@ const routes: Array<[string, Method, OpSpec]> = [
       op: "getNotes",
       summary: "ノート一覧取得",
       tags: ["notes"],
-      params: [acc],
+      params: [acc, queryParam("homeId", "対象グループ / ホーム ID", true)],
       responses: { "200": jsonRes("ノート配列") },
+    },
+  ],
+  [
+    "/line/{accountId}/notes/updates",
+    "post",
+    {
+      op: "getGroupHomeUpdates",
+      summary: "ノート・アルバム更新差分取得",
+      description: "iOS 実機の grouphome/isnew API。revision 以降に更新されたホームを返す。",
+      tags: ["notes", "albums"],
+      params: [acc, queryParam("revision", "前回取得した revision", true)],
+      responses: { "200": jsonRes("更新差分") },
     },
   ],
   [
@@ -734,9 +755,16 @@ const routes: Array<[string, Method, OpSpec]> = [
       summary: "ノート投稿",
       tags: ["notes"],
       params: [acc],
-      requestBody: body(["homeId", "text"], {
+      requestBody: body(["homeId"], {
         homeId: { type: "string", description: "投稿先ホーム MID" },
         text: { type: "string" },
+        sharedPostId: { type: "string" },
+        stickerIds: { type: "array", items: { type: "string" } },
+        stickerPackageIds: { type: "array", items: { type: "string" } },
+        mediaObjectIds: { type: "array", items: { type: "string" } },
+        mediaObjectTypes: { type: "array", items: { type: "string", enum: ["PHOTO", "VIDEO"] } },
+        contents: { type: "object" },
+        postInfo: { type: "object" },
       }),
       responses: { "200": jsonRes("作成結果") },
     },
@@ -748,8 +776,28 @@ const routes: Array<[string, Method, OpSpec]> = [
       op: "getNoteDetail",
       summary: "ノート詳細取得",
       tags: ["notes"],
-      params: [acc, pathParam("postId", "ノート ID")],
+      params: [acc, pathParam("postId", "ノート ID"), queryParam("homeId", "対象ホーム ID", true)],
       responses: { "200": jsonRes("ノート") },
+    },
+  ],
+  [
+    "/line/{accountId}/notes/{postId}",
+    "patch",
+    {
+      op: "updateNote",
+      summary: "ノート更新",
+      tags: ["notes"],
+      params: [acc, pathParam("postId", "ノート ID"), queryParam("homeId", "対象ホーム ID", true)],
+      requestBody: body(["homeId"], {
+        homeId: { type: "string" },
+        text: { type: "string" },
+        sharedPostId: { type: "string" },
+        stickerIds: { type: "array", items: { type: "string" } },
+        stickerPackageIds: { type: "array", items: { type: "string" } },
+        mediaObjectIds: { type: "array", items: { type: "string" } },
+        mediaObjectTypes: { type: "array", items: { type: "string", enum: ["PHOTO", "VIDEO"] } },
+      }),
+      responses: { "200": jsonRes("更新結果") },
     },
   ],
   [
@@ -764,6 +812,273 @@ const routes: Array<[string, Method, OpSpec]> = [
     },
   ],
   [
+    "/line/{accountId}/notes/{postId}/like",
+    "post",
+    {
+      op: "likeNote",
+      summary: "ノートにリアクション",
+      tags: ["notes"],
+      params: [acc, pathParam("postId", "ノート ID")],
+      requestBody: body(["homeId"], {
+        homeId: { type: "string" },
+        likeType: { type: "string", enum: ["1001", "1002", "1003", "1004", "1005", "1006"] },
+      }),
+      responses: { "200": jsonRes("リアクション結果") },
+    },
+  ],
+  [
+    "/line/{accountId}/notes/{postId}/like",
+    "delete",
+    {
+      op: "unlikeNote",
+      summary: "ノートのリアクション解除",
+      tags: ["notes"],
+      params: [acc, pathParam("postId", "ノート ID"), queryParam("homeId", "対象ホーム ID", true)],
+      responses: { "200": jsonRes("解除結果") },
+    },
+  ],
+  [
+    "/line/{accountId}/notes/{postId}/like",
+    "get",
+    {
+      op: "getNoteLike",
+      summary: "自分のノートリアクション取得",
+      tags: ["notes"],
+      params: [acc, pathParam("postId", "ノート ID"), queryParam("homeId", "対象ホーム ID", true)],
+      responses: { "200": jsonRes("リアクション") },
+    },
+  ],
+  [
+    "/line/{accountId}/notes/{postId}/likes",
+    "get",
+    {
+      op: "listNoteLikes",
+      summary: "ノートのリアクション一覧取得",
+      tags: ["notes"],
+      params: [acc, pathParam("postId", "ノート ID"), queryParam("homeId", "対象ホーム ID", true)],
+      responses: { "200": jsonRes("リアクション一覧") },
+    },
+  ],
+  [
+    "/line/{accountId}/notes/{postId}/comments",
+    "post",
+    {
+      op: "commentNote",
+      summary: "ノートへコメント",
+      tags: ["notes"],
+      params: [acc, pathParam("postId", "ノート ID")],
+      requestBody: body(["homeId"], {
+        homeId: { type: "string" },
+        text: { type: "string" },
+        imageObjectId: { type: "string" },
+      }),
+      responses: { "200": jsonRes("コメント作成結果") },
+    },
+  ],
+  [
+    "/line/{accountId}/notes/media/{type}",
+    "post",
+    {
+      op: "uploadNoteMedia",
+      summary: "ノート用画像・動画アップロード",
+      tags: ["notes"],
+      params: [acc, pathParam("type", "image または video")],
+      requestBody: {
+        required: true,
+        content: { "application/octet-stream": { schema: { type: "string", format: "binary" } } },
+      },
+      responses: { "200": jsonRes("OBS object ID") },
+    },
+  ],
+  [
+    "/line/{accountId}/notes/comment-image",
+    "post",
+    {
+      op: "uploadNoteCommentImage",
+      summary: "ノートコメント用画像アップロード",
+      tags: ["notes"],
+      params: [acc],
+      requestBody: {
+        required: true,
+        content: { "application/octet-stream": { schema: { type: "string", format: "binary" } } },
+      },
+      responses: { "200": jsonRes("OBS object ID") },
+    },
+  ],
+
+  // ── albums ──────────────────────────────────────────────
+  [
+    "/line/{accountId}/albums",
+    "get",
+    {
+      op: "listAlbums",
+      summary: "アルバム一覧取得",
+      tags: ["albums"],
+      params: [
+        acc,
+        queryParam("chatId", "対象チャット ID", true),
+        queryParam("cursor", "ページング cursor"),
+        queryParam("orderBy", "並び順"),
+        queryParam("include", "追加取得フィールド"),
+      ],
+      responses: { "200": jsonRes("アルバム一覧") },
+    },
+  ],
+  [
+    "/line/{accountId}/albums/preview",
+    "get",
+    {
+      op: "previewAlbums",
+      summary: "アルバムプレビュー取得",
+      tags: ["albums"],
+      params: [
+        acc,
+        queryParam("chatId", "対象チャット ID", true),
+        queryParam("pageSize", "取得件数"),
+        queryParam("thumbnailCount", "サムネイル数"),
+        queryParam("viewType", "表示種別"),
+      ],
+      responses: { "200": jsonRes("アルバムプレビュー") },
+    },
+  ],
+  [
+    "/line/{accountId}/albums",
+    "post",
+    {
+      op: "createAlbum",
+      summary: "アルバム作成",
+      tags: ["albums"],
+      params: [acc],
+      requestBody: body(["chatId", "title"], {
+        chatId: { type: "string" },
+        title: { type: "string" },
+        modifyDuplicateTitle: { type: "boolean" },
+      }),
+      responses: { "200": jsonRes("作成結果") },
+    },
+  ],
+  [
+    "/line/{accountId}/albums/{albumId}",
+    "patch",
+    {
+      op: "updateAlbum",
+      summary: "アルバム名変更",
+      tags: ["albums"],
+      params: [acc, pathParam("albumId", "アルバム ID")],
+      requestBody: body(["chatId", "title"], {
+        chatId: { type: "string" },
+        title: { type: "string" },
+      }),
+      responses: { "200": jsonRes("更新結果") },
+    },
+  ],
+  [
+    "/line/{accountId}/albums/{albumId}",
+    "delete",
+    {
+      op: "deleteAlbum",
+      summary: "アルバム削除",
+      tags: ["albums"],
+      params: [acc, pathParam("albumId", "アルバム ID"), queryParam("chatId", "対象チャット ID", true)],
+      responses: { "200": jsonRes("削除結果") },
+    },
+  ],
+  [
+    "/line/{accountId}/albums/{albumId}/share",
+    "post",
+    {
+      op: "shareAlbum",
+      summary: "アルバムをチャットへ共有",
+      tags: ["albums"],
+      params: [acc, pathParam("albumId", "アルバム ID")],
+      requestBody: body(["chatId"], { chatId: { type: "string" } }),
+      responses: { "200": jsonRes("共有結果") },
+    },
+  ],
+  [
+    "/line/{accountId}/albums/{albumId}/media",
+    "post",
+    {
+      op: "uploadAlbumMedia",
+      summary: "アルバム用画像・動画アップロード",
+      tags: ["albums"],
+      params: [acc, pathParam("albumId", "アルバム ID"), queryParam("chatId", "対象チャット ID", true)],
+      requestBody: {
+        required: true,
+        content: { "application/octet-stream": { schema: { type: "string", format: "binary" } } },
+      },
+      responses: { "200": jsonRes("OBS object ID") },
+    },
+  ],
+  [
+    "/line/{accountId}/albums/{albumId}/photos",
+    "post",
+    {
+      op: "addAlbumPhotos",
+      summary: "アルバムへ写真・動画追加",
+      tags: ["albums"],
+      params: [acc, pathParam("albumId", "アルバム ID")],
+      requestBody: body(["chatId", "photos"], {
+        chatId: { type: "string" },
+        photos: { type: "array", items: { type: "object" } },
+      }),
+      responses: { "200": jsonRes("追加結果") },
+    },
+  ],
+  [
+    "/line/{accountId}/albums/{albumId}/photos",
+    "delete",
+    {
+      op: "deleteAlbumPhotos",
+      summary: "アルバム内写真・動画削除",
+      tags: ["albums"],
+      params: [acc, pathParam("albumId", "アルバム ID")],
+      requestBody: body(["chatId", "photoIds"], {
+        chatId: { type: "string" },
+        photoIds: { type: "array", items: { type: "string" } },
+      }),
+      responses: { "200": jsonRes("削除結果") },
+    },
+  ],
+  [
+    "/line/{accountId}/albums/{albumId}/photos",
+    "get",
+    {
+      op: "listAlbumPhotos",
+      summary: "アルバム内写真・動画一覧",
+      tags: ["albums"],
+      params: [
+        acc,
+        pathParam("albumId", "アルバム ID"),
+        queryParam("chatId", "対象チャット ID", true),
+        queryParam("cursor", "ページング cursor"),
+        queryParam("pageSize", "取得件数"),
+        queryParam("orderBy", "並び順"),
+        queryParam("include", "追加取得フィールド"),
+        queryParam("filterType", "メディア種別フィルタ"),
+        queryParam("targetUser", "投稿者フィルタ"),
+      ],
+      responses: { "200": jsonRes("写真・動画一覧") },
+    },
+  ],
+  [
+    "/line/{accountId}/albums/{albumId}/media/{oid}",
+    "get",
+    {
+      op: "downloadAlbumMedia",
+      summary: "アルバム原寸メディア取得",
+      tags: ["albums"],
+      params: [
+        acc,
+        pathParam("albumId", "アルバム ID"),
+        pathParam("oid", "メディア object ID"),
+        queryParam("chatId", "対象チャット ID", true),
+        queryParam("mediaType", "image または video"),
+      ],
+      responses: { "200": { description: "原寸メディア" } },
+    },
+  ],
+  [
     "/line/{accountId}/notes/{postId}/share",
     "post",
     {
@@ -771,7 +1086,8 @@ const routes: Array<[string, Method, OpSpec]> = [
       summary: "ノート共有",
       tags: ["notes"],
       params: [acc, pathParam("postId", "ノート ID")],
-      responses: { "200": okRes() },
+      requestBody: body(["homeId"], { homeId: { type: "string" } }),
+      responses: { "200": jsonRes("共有結果") },
     },
   ],
 
@@ -1441,6 +1757,7 @@ export const lineOpenApiSpec = {
     { name: "stickers", description: "スタンプ・絵文字・コンビネーションスタンプ" },
     { name: "contacts", description: "連絡先・ブロック" },
     { name: "notes", description: "ノート" },
+    { name: "albums", description: "アルバム" },
     { name: "polls", description: "アンケート" },
     { name: "schedule", description: "予定" },
     { name: "announcements", description: "アナウンス" },

--- a/Vyline/backend/src/api/openapi.line.ts
+++ b/Vyline/backend/src/api/openapi.line.ts
@@ -979,7 +979,11 @@ const routes: Array<[string, Method, OpSpec]> = [
       op: "deleteAlbum",
       summary: "アルバム削除",
       tags: ["albums"],
-      params: [acc, pathParam("albumId", "アルバム ID"), queryParam("chatId", "対象チャット ID", true)],
+      params: [
+        acc,
+        pathParam("albumId", "アルバム ID"),
+        queryParam("chatId", "対象チャット ID", true),
+      ],
       responses: { "200": jsonRes("削除結果") },
     },
   ],
@@ -1002,7 +1006,11 @@ const routes: Array<[string, Method, OpSpec]> = [
       op: "uploadAlbumMedia",
       summary: "アルバム用画像・動画アップロード",
       tags: ["albums"],
-      params: [acc, pathParam("albumId", "アルバム ID"), queryParam("chatId", "対象チャット ID", true)],
+      params: [
+        acc,
+        pathParam("albumId", "アルバム ID"),
+        queryParam("chatId", "対象チャット ID", true),
+      ],
       requestBody: {
         required: true,
         content: { "application/octet-stream": { schema: { type: "string", format: "binary" } } },

--- a/Vyline/backend/src/line/clientManager.ts
+++ b/Vyline/backend/src/line/clientManager.ts
@@ -646,7 +646,12 @@ export async function loginContentWithQRCode(
 ): Promise<VylineClient> {
   if (!clients.get(accountId)?.client) throw new Error("not logged in");
 
-  const state: { url: string | null; expired: boolean; pincode: string | null; inProgress: boolean } = {
+  const state: {
+    url: string | null;
+    expired: boolean;
+    pincode: string | null;
+    inProgress: boolean;
+  } = {
     url: null,
     expired: false,
     pincode: null,

--- a/Vyline/backend/src/line/clientManager.ts
+++ b/Vyline/backend/src/line/clientManager.ts
@@ -9,6 +9,7 @@ import {
   loginWithEmail as vylineLoginEmail,
   loginWithQR as vylineLoginQR,
   loginWithToken as vylineLoginToken,
+  loginWithStoredRefreshToken as vylineLoginStoredRefreshToken,
   resolveDeviceMode,
   kicksOfficialDesktop,
   patchGroupKeyLookup,
@@ -46,6 +47,12 @@ interface ManagedClient {
 }
 
 const clients = new Map<string, ManagedClient>();
+const contentClients = new Map<string, Promise<VylineClient>>();
+const contentQrState = new Map<
+  string,
+  { url: string | null; expired: boolean; pincode: string | null; inProgress: boolean }
+>();
+const contentTokenId = (accountId: string) => `${accountId}:content`;
 
 function restorePluginsForSession(accountId: string): void {
   void restoreEnabledPlugins(accountId).catch((error) =>
@@ -345,7 +352,9 @@ function watchAuthToken(client: VylineClient, accountId: string): void {
       displayName?: string;
       picturePath?: string;
       statusMessage?: string;
+      deviceMode?: string;
     } = {};
+    meta.deviceMode = String(client.base.device);
     if (profile?.mid) meta.mid = String(profile.mid);
     if (profile?.displayName) meta.displayName = String(profile.displayName);
     const pic =
@@ -536,6 +545,7 @@ export async function loginWithToken(accountId: string): Promise<VylineClient> {
   const client = await vylineLoginToken(entry.authToken, {
     profile: getVylineProfile(),
     storagePath: entry.storageFile,
+    ...(entry.deviceMode ? { deviceMode: entry.deviceMode } : {}),
   });
 
   watchAuthToken(client, accountId);
@@ -556,6 +566,7 @@ export async function loginWithToken(accountId: string): Promise<VylineClient> {
 export async function loginWithAuthToken(
   accountId: string,
   authToken: string,
+  deviceMode?: string,
 ): Promise<VylineClient> {
   const { dirname, join } = await import("node:path");
   const { fileURLToPath } = await import("node:url");
@@ -568,6 +579,7 @@ export async function loginWithAuthToken(
   const client = await vylineLoginToken(authToken, {
     profile: getVylineProfile(),
     storagePath,
+    ...(deviceMode ? { deviceMode } : {}),
   });
 
   watchAuthToken(client, accountId);
@@ -587,7 +599,7 @@ export async function loginWithAuthToken(
 
 export async function restoreAllSessions(): Promise<void> {
   const tokens = await loadTokens();
-  const ids = Object.keys(tokens);
+  const ids = Object.keys(tokens).filter((id) => !id.endsWith(":content"));
   if (ids.length === 0) {
     log.info("no saved sessions to restore");
     return;
@@ -620,6 +632,81 @@ export async function restoreAllSessions(): Promise<void> {
 
 export function getClient(accountId: string): VylineClient | undefined {
   return clients.get(accountId)?.client;
+}
+
+export async function getContentClient(accountId: string): Promise<VylineClient> {
+  const active = clients.get(accountId)?.client;
+  if (!active) throw new Error("not logged in");
+  return active;
+}
+
+export async function loginContentWithQRCode(
+  accountId: string,
+  onQrUrl: (url: string) => void,
+): Promise<VylineClient> {
+  if (!clients.get(accountId)?.client) throw new Error("not logged in");
+
+  const state: { url: string | null; expired: boolean; pincode: string | null; inProgress: boolean } = {
+    url: null,
+    expired: false,
+    pincode: null,
+    inProgress: true,
+  };
+  contentQrState.set(accountId, state);
+  try {
+    const client = await vylineLoginQR(
+      {
+        onReceiveQRUrl(url: string) {
+          state.url = url;
+          state.expired = false;
+          onQrUrl(url);
+        },
+        onPincodeRequest(pin: string) {
+          state.pincode = pin;
+        },
+      },
+      {
+        profile: getVylineProfile(),
+        storagePath: `${storagePathFor(accountId)}.content-secondary`,
+        deviceMode: "ANDROIDSECONDARY",
+      },
+    );
+
+    const token = client.authToken ?? client.base.authToken;
+    if (!token) throw new Error("content login completed without auth token");
+    await saveToken(contentTokenId(accountId), token, {
+      storageFile: `${storagePathFor(accountId)}.content-secondary`,
+    });
+    contentClients.set(accountId, Promise.resolve(client));
+    state.url = null;
+    state.pincode = null;
+    state.inProgress = false;
+    log.info({ accountId }, "content secondary QR login success");
+    return client;
+  } catch (error) {
+    state.url = null;
+    state.pincode = null;
+    state.inProgress = false;
+    state.expired = true;
+    throw error;
+  }
+}
+
+export function getContentQrState(accountId: string): {
+  url: string | null;
+  expired: boolean;
+  pincode: string | null;
+  inProgress: boolean;
+  ready: boolean;
+} {
+  const state = contentQrState.get(accountId);
+  return {
+    url: state?.url ?? null,
+    expired: state?.expired ?? false,
+    pincode: state?.pincode ?? null,
+    inProgress: state?.inProgress ?? false,
+    ready: contentClients.has(accountId),
+  };
 }
 
 export function listAccounts(): string[] {
@@ -667,5 +754,7 @@ export function removeClient(accountId: string): void {
     tokenWatchIntervals.delete(accountId);
   }
   clients.delete(accountId);
+  contentClients.delete(accountId);
+  contentQrState.delete(accountId);
   log.info({ accountId }, "client removed");
 }

--- a/Vyline/backend/src/service/albumService.ts
+++ b/Vyline/backend/src/service/albumService.ts
@@ -1,9 +1,23 @@
 import type { VylineClient } from "@vyline/protocol";
 
 type AlbumClient = {
-  list(options: { chatId: string; cursor?: string; orderBy?: string; include?: string }): Promise<unknown>;
-  preview(options: { chatId: string; pageSize?: number; thumbnailCount?: number; viewType?: string }): Promise<unknown>;
-  create(options: { chatId: string; title: string; modifyDuplicateTitle?: boolean }): Promise<unknown>;
+  list(options: {
+    chatId: string;
+    cursor?: string;
+    orderBy?: string;
+    include?: string;
+  }): Promise<unknown>;
+  preview(options: {
+    chatId: string;
+    pageSize?: number;
+    thumbnailCount?: number;
+    viewType?: string;
+  }): Promise<unknown>;
+  create(options: {
+    chatId: string;
+    title: string;
+    modifyDuplicateTitle?: boolean;
+  }): Promise<unknown>;
   update(options: { chatId: string; albumId: string; title: string }): Promise<unknown>;
   delete(options: { chatId: string; albumId: string }): Promise<unknown>;
   share(options: { chatId: string; albumId: string }): Promise<unknown>;
@@ -54,7 +68,10 @@ export function listAlbums(
   return albumClient(client).list(query);
 }
 
-export function previewAlbums(client: VylineClient, query: { chatId: string; pageSize?: string; thumbnailCount?: string; viewType?: string }) {
+export function previewAlbums(
+  client: VylineClient,
+  query: { chatId: string; pageSize?: string; thumbnailCount?: string; viewType?: string },
+) {
   return albumClient(client).preview({
     chatId: query.chatId,
     ...(query.pageSize ? { pageSize: Number(query.pageSize) } : {}),
@@ -63,11 +80,18 @@ export function previewAlbums(client: VylineClient, query: { chatId: string; pag
   });
 }
 
-export function createAlbum(client: VylineClient, input: { chatId: string; title: string; modifyDuplicateTitle?: boolean }) {
+export function createAlbum(
+  client: VylineClient,
+  input: { chatId: string; title: string; modifyDuplicateTitle?: boolean },
+) {
   return albumClient(client).create(input);
 }
 
-export function updateAlbum(client: VylineClient, albumId: string, input: { chatId: string; title: string }) {
+export function updateAlbum(
+  client: VylineClient,
+  albumId: string,
+  input: { chatId: string; title: string },
+) {
   return albumClient(client).update({ albumId, ...input });
 }
 
@@ -104,11 +128,20 @@ export function listAlbumPhotos(
   });
 }
 
-export function addAlbumPhotos(client: VylineClient, albumId: string, input: Parameters<AlbumClient["addPhotos"]>[0]) {
+export function addAlbumPhotos(
+  client: VylineClient,
+  albumId: string,
+  input: Parameters<AlbumClient["addPhotos"]>[0],
+) {
   return albumClient(client).addPhotos({ ...input, albumId });
 }
 
-export function deleteAlbumPhotos(client: VylineClient, albumId: string, chatId: string, photoIds: string[]) {
+export function deleteAlbumPhotos(
+  client: VylineClient,
+  albumId: string,
+  chatId: string,
+  photoIds: string[],
+) {
   return albumClient(client).deletePhotos({ albumId, chatId, photoIds });
 }
 

--- a/Vyline/backend/src/service/albumService.ts
+++ b/Vyline/backend/src/service/albumService.ts
@@ -1,42 +1,140 @@
 import type { VylineClient } from "@vyline/protocol";
 
-const ALBUM_PATHS = new Set([
-  "/api/v1.0/initialize",
-  "/api/v1.0/album/create",
-  "/api/v1.0/album/update",
-  "/api/v1.0/album/delete",
-  "/api/v1.0/album/list",
-  "/api/v1.0/album/get",
-  "/api/v1.0/album/content/add",
-  "/api/v1.0/album/content/delete",
-  "/api/v1.0/album/content/list",
-]);
+type AlbumClient = {
+  list(options: { chatId: string; cursor?: string; orderBy?: string; include?: string }): Promise<unknown>;
+  preview(options: { chatId: string; pageSize?: number; thumbnailCount?: number; viewType?: string }): Promise<unknown>;
+  create(options: { chatId: string; title: string; modifyDuplicateTitle?: boolean }): Promise<unknown>;
+  update(options: { chatId: string; albumId: string; title: string }): Promise<unknown>;
+  delete(options: { chatId: string; albumId: string }): Promise<unknown>;
+  share(options: { chatId: string; albumId: string }): Promise<unknown>;
+  photos(options: {
+    chatId: string;
+    albumId: string;
+    cursor?: string;
+    pageSize?: number;
+    orderBy?: string;
+    include?: string;
+    filterType?: string;
+    targetUser?: string;
+  }): Promise<unknown>;
+  addPhotos(options: {
+    chatId: string;
+    albumId: string;
+    photos: Array<{
+      obsResourceId: { oid: string; sid?: string; svc?: string };
+      width: number;
+      height: number;
+      shotTime?: number;
+      resourceType?: string;
+    }>;
+  }): Promise<unknown>;
+  deletePhotos(options: { chatId: string; albumId: string; photoIds: string[] }): Promise<unknown>;
+  upload(options: {
+    chatId: string;
+    albumId: string;
+    oid: string;
+    data: Blob;
+    contentType?: string;
+  }): Promise<{ oid: string }>;
+  download(options: {
+    chatId: string;
+    albumId: string;
+    oid: string;
+    mediaType?: "image" | "video";
+  }): Promise<Response>;
+};
 
-export async function callAlbum(
+const albumClient = (client: VylineClient) =>
+  (client.base as typeof client.base & { album: AlbumClient }).album;
+
+export function listAlbums(
   client: VylineClient,
-  path: string,
-  method: "GET" | "POST" | "PUT" | "DELETE" = "GET",
-  query?: Record<string, string>,
-  body?: Record<string, unknown>,
-): Promise<unknown> {
-  const normalized = path.startsWith("/") ? path : `/${path}`;
-  if (!ALBUM_PATHS.has(normalized)) throw new Error("unsupported album operation");
-  const album = (
-    client.base as typeof client.base & {
-      album: {
-        call(options: {
-          path: string;
-          method: "GET" | "POST" | "PUT" | "DELETE";
-          query?: Record<string, string>;
-          body?: Record<string, unknown>;
-        }): Promise<unknown>;
-      };
-    }
-  ).album;
-  return await album.call({
-    path: normalized,
-    method,
-    ...(query ? { query } : {}),
-    ...(body ? { body } : {}),
+  query: { chatId: string; cursor?: string; orderBy?: string; include?: string },
+) {
+  return albumClient(client).list(query);
+}
+
+export function previewAlbums(client: VylineClient, query: { chatId: string; pageSize?: string; thumbnailCount?: string; viewType?: string }) {
+  return albumClient(client).preview({
+    chatId: query.chatId,
+    ...(query.pageSize ? { pageSize: Number(query.pageSize) } : {}),
+    ...(query.thumbnailCount ? { thumbnailCount: Number(query.thumbnailCount) } : {}),
+    ...(query.viewType ? { viewType: query.viewType } : {}),
   });
+}
+
+export function createAlbum(client: VylineClient, input: { chatId: string; title: string; modifyDuplicateTitle?: boolean }) {
+  return albumClient(client).create(input);
+}
+
+export function updateAlbum(client: VylineClient, albumId: string, input: { chatId: string; title: string }) {
+  return albumClient(client).update({ albumId, ...input });
+}
+
+export function deleteAlbum(client: VylineClient, albumId: string, chatId: string) {
+  return albumClient(client).delete({ albumId, chatId });
+}
+
+export function shareAlbum(client: VylineClient, albumId: string, chatId: string) {
+  return albumClient(client).share({ albumId, chatId });
+}
+
+export function listAlbumPhotos(
+  client: VylineClient,
+  albumId: string,
+  query: {
+    chatId: string;
+    cursor?: string;
+    pageSize?: string;
+    orderBy?: string;
+    include?: string;
+    filterType?: string;
+    targetUser?: string;
+  },
+) {
+  return albumClient(client).photos({
+    chatId: query.chatId,
+    albumId,
+    ...(query.cursor !== undefined ? { cursor: query.cursor } : {}),
+    ...(query.pageSize !== undefined ? { pageSize: Number(query.pageSize) } : {}),
+    ...(query.orderBy !== undefined ? { orderBy: query.orderBy } : {}),
+    ...(query.include !== undefined ? { include: query.include } : {}),
+    ...(query.filterType !== undefined ? { filterType: query.filterType } : {}),
+    ...(query.targetUser !== undefined ? { targetUser: query.targetUser } : {}),
+  });
+}
+
+export function addAlbumPhotos(client: VylineClient, albumId: string, input: Parameters<AlbumClient["addPhotos"]>[0]) {
+  return albumClient(client).addPhotos({ ...input, albumId });
+}
+
+export function deleteAlbumPhotos(client: VylineClient, albumId: string, chatId: string, photoIds: string[]) {
+  return albumClient(client).deletePhotos({ albumId, chatId, photoIds });
+}
+
+export async function uploadAlbumMedia(
+  client: VylineClient,
+  albumId: string,
+  input: { chatId: string; data: Blob; oid?: string; contentType?: string },
+): Promise<{ oid: string }> {
+  const now = new Date();
+  const yy = String(now.getUTCFullYear()).slice(-2);
+  const mm = String(now.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(now.getUTCDate()).padStart(2, "0");
+  const hh = String(now.getUTCHours()).padStart(2, "0");
+  const oid = input.oid ?? `${crypto.randomUUID().replaceAll("-", "")}.${yy}${mm}${dd}${hh}`;
+  return await albumClient(client).upload({
+    albumId,
+    chatId: input.chatId,
+    oid,
+    data: input.data,
+  });
+}
+
+export function downloadAlbumMedia(
+  client: VylineClient,
+  albumId: string,
+  options: { chatId: string; oid: string; mediaType?: "image" | "video" },
+) {
+  return albumClient(client).download({ albumId, ...options });
 }

--- a/Vyline/backend/src/service/noteService.ts
+++ b/Vyline/backend/src/service/noteService.ts
@@ -108,15 +108,27 @@ export async function likeNote(
   });
 }
 
-export async function unlikeNote(client: VylineClient, homeId: string, postId: string): Promise<unknown> {
+export async function unlikeNote(
+  client: VylineClient,
+  homeId: string,
+  postId: string,
+): Promise<unknown> {
   return await client.base.timeline.unlikePost({ contentId: postId, homeId });
 }
 
-export async function getNoteLike(client: VylineClient, homeId: string, postId: string): Promise<unknown> {
+export async function getNoteLike(
+  client: VylineClient,
+  homeId: string,
+  postId: string,
+): Promise<unknown> {
   return await client.base.timeline.getLike({ contentId: postId, homeId });
 }
 
-export async function listNoteLikes(client: VylineClient, homeId: string, postId: string): Promise<unknown> {
+export async function listNoteLikes(
+  client: VylineClient,
+  homeId: string,
+  postId: string,
+): Promise<unknown> {
   return await client.base.timeline.listLikes({ contentId: postId, homeId });
 }
 

--- a/Vyline/backend/src/service/noteService.ts
+++ b/Vyline/backend/src/service/noteService.ts
@@ -10,21 +10,47 @@ import { childLogger } from "../logger.js";
 
 const log = childLogger("note");
 
+export type NoteContentInput = {
+  text?: string;
+  sharedPostId?: string;
+  stickerIds?: string[];
+  stickerPackageIds?: string[];
+  mediaObjectIds?: string[];
+  mediaObjectTypes?: string[];
+  textSizeMode?: "AUTO" | "NORMAL";
+  backgroundColor?: string;
+  textAnimation?: "NONE" | "SLIDE" | "ZOOM" | "BUZZ" | "BOUNCE" | "BLINK";
+  contents?: Record<string, unknown>;
+  postInfo?: Record<string, unknown>;
+};
+
 export async function listNotes(
   accountId: string,
   client: VylineClient,
   homeId: string,
 ): Promise<unknown> {
-  return await client.base.timeline.listPost({ homeId, sourceType: "TALKROOM" });
+  return await client.base.timeline.listPost({ homeId, sourceType: "GROUPHOME" });
+}
+
+export async function getGroupHomeUpdates(
+  client: VylineClient,
+  revision: number,
+): Promise<unknown> {
+  return await client.base.timeline.getGroupHomeUpdates(revision);
 }
 
 export async function createNote(
   accountId: string,
   client: VylineClient,
   homeId: string,
-  text: string,
+  input: NoteContentInput,
 ): Promise<unknown> {
-  const res = await client.base.timeline.createPost({ homeId, text, readPermissionType: "ALL" });
+  const res = await client.base.timeline.createPost({
+    homeId,
+    ...input,
+    readPermissionType: "ALL",
+    sourceType: "GROUPHOME",
+  });
   log.info({ accountId, homeId }, "note created");
   return res;
 }
@@ -54,16 +80,17 @@ export async function shareNoteToChat(
   client: VylineClient,
   homeId: string,
   postId: string,
-  chatMid: string,
 ): Promise<unknown> {
-  return await client.base.timeline.sharePost({ postId, chatMid, homeId });
+  const res = await client.base.timeline.sharePost({ postId, homeId });
+  log.info({ accountId, homeId, postId }, "note shared");
+  return res;
 }
 
 export async function updateNote(
   client: VylineClient,
   homeId: string,
   postId: string,
-  input: Parameters<VylineClient["base"]["timeline"]["updatePost"]>[0],
+  input: NoteContentInput,
 ): Promise<unknown> {
   return await client.base.timeline.updatePost({ ...input, homeId, postId });
 }
@@ -81,11 +108,44 @@ export async function likeNote(
   });
 }
 
+export async function unlikeNote(client: VylineClient, homeId: string, postId: string): Promise<unknown> {
+  return await client.base.timeline.unlikePost({ contentId: postId, homeId });
+}
+
+export async function getNoteLike(client: VylineClient, homeId: string, postId: string): Promise<unknown> {
+  return await client.base.timeline.getLike({ contentId: postId, homeId });
+}
+
+export async function listNoteLikes(client: VylineClient, homeId: string, postId: string): Promise<unknown> {
+  return await client.base.timeline.listLikes({ contentId: postId, homeId });
+}
+
 export async function commentNote(
   client: VylineClient,
   homeId: string,
   postId: string,
   commentText: string,
+  contentsList?: unknown[],
 ): Promise<unknown> {
-  return await client.base.timeline.createComment({ contentId: postId, homeId, commentText });
+  return await client.base.timeline.createComment({
+    contentId: postId,
+    homeId,
+    commentText,
+    ...(contentsList ? { contentsList } : {}),
+  });
+}
+
+export async function uploadNoteMedia(
+  client: VylineClient,
+  type: "image" | "video",
+  data: Blob,
+): Promise<{ objId: string; objHash: string }> {
+  return await client.base.timeline.uploadNoteMedia(type, data);
+}
+
+export async function uploadNoteCommentImage(
+  client: VylineClient,
+  data: Blob,
+): Promise<{ objId: string; objHash: string }> {
+  return await client.base.timeline.uploadNoteCommentImage(data);
 }

--- a/Vyline/backend/src/storage/tokenStore.ts
+++ b/Vyline/backend/src/storage/tokenStore.ts
@@ -139,7 +139,8 @@ export async function saveToken(
   const existing = tokens[accountId];
   const entry: TokenEntry = {
     authToken: token,
-    storageFile: meta?.storageFile ?? existing?.storageFile ?? join(DATA_DIR, `storage-${accountId}.json`),
+    storageFile:
+      meta?.storageFile ?? existing?.storageFile ?? join(DATA_DIR, `storage-${accountId}.json`),
     savedAt: new Date().toISOString(),
   };
   try {

--- a/Vyline/backend/src/storage/tokenStore.ts
+++ b/Vyline/backend/src/storage/tokenStore.ts
@@ -41,6 +41,8 @@ export interface TokenEntry {
   displayName?: string;
   picturePath?: string;
   statusMessage?: string;
+  /** セッション発行時のデバイス種別。復元時に別端末種別へ化けるのを防ぐ。 */
+  deviceMode?: string;
   premium?: {
     active: boolean;
     planType?: string | number;
@@ -63,10 +65,12 @@ async function persistTokens(tokens: TokenMap): Promise<void> {
 }
 
 export type SessionMeta = {
+  storageFile?: string;
   mid?: string;
   displayName?: string;
   picturePath?: string;
   statusMessage?: string;
+  deviceMode?: string;
   premium?: {
     active: boolean;
     planType?: string | number;
@@ -135,7 +139,7 @@ export async function saveToken(
   const existing = tokens[accountId];
   const entry: TokenEntry = {
     authToken: token,
-    storageFile: existing?.storageFile ?? join(DATA_DIR, `storage-${accountId}.json`),
+    storageFile: meta?.storageFile ?? existing?.storageFile ?? join(DATA_DIR, `storage-${accountId}.json`),
     savedAt: new Date().toISOString(),
   };
   try {
@@ -149,11 +153,13 @@ export async function saveToken(
   const displayName = meta?.displayName ?? existing?.displayName;
   const picturePath = meta?.picturePath ?? existing?.picturePath;
   const statusMessage = meta?.statusMessage ?? existing?.statusMessage;
+  const deviceMode = meta?.deviceMode ?? existing?.deviceMode;
   const premium = meta?.premium ?? existing?.premium;
   if (mid) entry.mid = mid;
   if (displayName) entry.displayName = displayName;
   if (picturePath) entry.picturePath = picturePath;
   if (statusMessage) entry.statusMessage = statusMessage;
+  if (deviceMode) entry.deviceMode = deviceMode;
   if (premium) entry.premium = premium;
   tokens[accountId] = entry;
 
@@ -169,6 +175,7 @@ export async function updateSessionMeta(accountId: string, meta: SessionMeta): P
   if (meta.displayName != null) existing.displayName = meta.displayName;
   if (meta.picturePath != null) existing.picturePath = meta.picturePath;
   if (meta.statusMessage != null) existing.statusMessage = meta.statusMessage;
+  if (meta.deviceMode != null) existing.deviceMode = meta.deviceMode;
   if (meta.premium != null) existing.premium = meta.premium;
   existing.savedAt = new Date().toISOString();
   tokens[accountId] = existing;
@@ -201,6 +208,7 @@ export async function listSavedSessions(): Promise<
 > {
   const tokens = await loadTokens();
   return Object.entries(tokens)
+    .filter(([accountId]) => !accountId.endsWith(":content"))
     .map(([accountId, entry]) => {
       const row: {
         accountId: string;


### PR DESCRIPTION
Adds full Note/Album BFF + desktop integration backed by the latest real iOS HAR and protocol PR #7.

Highlights:
- Note list/create/update/delete/share/like/unlike/comment/media surfaces
- Album create/list/preview/rename/share/upload/add/list/download/delete surfaces
- message-bubble integration for Note/Album notification content
- IOS / IOSIPAD device mode persistence without requiring a secondary content session
- OpenAPI coverage for the new BFF endpoints
- protocol dependency updated to `nezumi0627/vyline-api#7` head

Real-device validation:
- `grouphome/isnew` succeeded after matching current `x-lhm=GET` behavior
- approved test chat album lifecycle succeeded: create -> OBS upload -> add photo -> list -> download -> rename -> share -> delete photo -> delete album
- temporary test albums were cleaned up
- Note CRUD/share/like/comment flows were previously validated on the approved test chat

Checks:
- protocol/backend/desktop TypeScript checks passed
- Docker build/runtime smoke passed
- build and documentation checks passed
- security scan passed
- lint issues from the initial CI run were fixed and pushed

Known limitation:
- Note media OBS upload still requires a genuinely authorized current primary iOS/iPadOS session. A restored IOSIPAD credential previously returned HTTP 401, so Vyline does not spoof device authorization.