### PR TITLE
feat: Android版Lineのデータベースインポート対応

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,10 +43,11 @@ ENV NODE_ENV=production \
     VYLINE_DATA_DIR=/app/data \
     VYLINE_STORAGE_DIR=/app/storage
 LABEL org.opencontainers.image.title="Vyline" \
-      org.opencontainers.image.source="https://github.com/nezumi0627/Vyline" \
+      org.opencontainers.image.source="https://github.com/tqmane/vyline" \
       org.opencontainers.image.version="${VYLINE_VERSION}"
 RUN apt-get update \
   && apt-get upgrade -y \
+  && apt-get install -y --no-install-recommends gosu \
   && apt-get autoremove -y \
   && rm -rf /var/lib/apt/lists/*
 COPY --from=prod-deps /app/node_modules ./node_modules
@@ -55,10 +56,13 @@ COPY --from=build /app/Vyline/packages ./Vyline/packages
 COPY --from=build /app/openapi.yaml ./openapi.yaml
 COPY --from=build /app/Vyline/backend/src ./Vyline/backend/src
 COPY --from=build /app/Vyline/apps/desktop/dist ./Vyline/apps/desktop/dist
-RUN mkdir -p /app/data /app/storage && chown -R bun:bun /app/data /app/storage
-USER bun
+COPY docker-entrypoint.sh /usr/local/bin/vyline-entrypoint
+RUN mkdir -p /app/data /app/storage \
+  && chown -R bun:bun /app/data /app/storage \
+  && chmod 0755 /usr/local/bin/vyline-entrypoint
 EXPOSE 3000
 VOLUME ["/app/data", "/app/storage"]
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
   CMD bun -e 'fetch("http://127.0.0.1:"+(process.env.PORT||3000)+"/healthz").then(function(r){process.exit(r.ok?0:1)},function(){process.exit(1)})'
+ENTRYPOINT ["/usr/local/bin/vyline-entrypoint"]
 CMD ["bun", "Vyline/backend/src/index.ts"]

--- a/Vyline/apps/desktop/src/api/client.ts
+++ b/Vyline/apps/desktop/src/api/client.ts
@@ -115,7 +115,11 @@ async function request<T>(
   }
 }
 
-async function uploadFile<T>(path: string, file: File): Promise<T> {
+async function uploadBinary<T>(
+  path: string,
+  body: Blob,
+  extraHeaders?: HeadersInit,
+): Promise<T> {
   let res: Response;
   const sessionToken =
     typeof localStorage !== "undefined" ? localStorage.getItem("vyline:subdevice-session") : null;
@@ -125,11 +129,11 @@ async function uploadFile<T>(path: string, file: File): Promise<T> {
       method: "POST",
       headers: {
         "Content-Type": "application/octet-stream",
-        "X-Vyline-Backup-Name": encodeURIComponent(file.name || "naver_line"),
         ...(sessionToken ? { Authorization: `Bearer ${sessionToken}` } : {}),
         ...(installationId ? { "X-Vyline-Installation-Id": installationId } : {}),
+        ...(extraHeaders ?? {}),
       },
-      body: file,
+      body,
     });
   } catch (err) {
     if (isBackendDown(err)) throw new Error("BACKEND_DOWN");
@@ -137,6 +141,11 @@ async function uploadFile<T>(path: string, file: File): Promise<T> {
   }
 
   const text = await res.text();
+  if (res.status === 413) {
+    throw new Error(
+      "リバースプロキシがアップロードchunkを拒否しました（HTTP 413）。Nginx の client_max_body_size が 512 KiB 未満になっていないか確認してください。",
+    );
+  }
   if (!text.trim()) {
     throw new Error(
       res.ok
@@ -149,6 +158,65 @@ async function uploadFile<T>(path: string, file: File): Promise<T> {
   } catch {
     throw new Error(`サーバー応答の解析に失敗しました: ${text.slice(0, 120)}`);
   }
+}
+
+async function uploadAndroidBackupChunked(
+  accountId: string,
+  file: File,
+  includeMedia: boolean,
+  onProgress?: (uploadedBytes: number, totalBytes: number) => void,
+): Promise<{ ok: boolean; sessionId?: string; error?: string }> {
+  const basePath = `/line/${accountId}/restore/android-backup/chunked`;
+  const init = await request<{
+    ok: boolean;
+    uploadId?: string;
+    chunkSize?: number;
+    error?: string;
+  }>("POST", basePath, {
+    sourceName: file.name || "naver_line",
+    includeMedia,
+    expectedBytes: file.size,
+  });
+  if (!init.ok || !init.uploadId) {
+    throw new Error(init.error ?? "Androidバックアップの分割アップロードを開始できませんでした");
+  }
+
+  const chunkSize = Math.min(768 * 1024, Math.max(64 * 1024, Number(init.chunkSize ?? 512 * 1024)));
+  let index = 0;
+  for (let offset = 0; offset < file.size; offset += chunkSize, index += 1) {
+    const end = Math.min(file.size, offset + chunkSize);
+    const chunk = file.slice(offset, end);
+    let lastError: unknown = null;
+    let uploaded = false;
+    for (let attempt = 1; attempt <= 3 && !uploaded; attempt += 1) {
+      try {
+        const response = await uploadBinary<{
+          ok: boolean;
+          receivedBytes?: number;
+          expectedBytes?: number;
+          error?: string;
+        }>(`${basePath}/${encodeURIComponent(init.uploadId)}/chunks/${index}`, chunk);
+        if (!response.ok) {
+          throw new Error(response.error ?? `chunk ${index} の送信に失敗しました`);
+        }
+        onProgress?.(response.receivedBytes ?? end, file.size);
+        uploaded = true;
+      } catch (error) {
+        lastError = error;
+        if (attempt < 3) {
+          await new Promise((resolve) => window.setTimeout(resolve, attempt * 250));
+        }
+      }
+    }
+    if (!uploaded) {
+      throw lastError instanceof Error ? lastError : new Error(`chunk ${index} の送信に失敗しました`);
+    }
+  }
+
+  return request<{ ok: boolean; sessionId?: string; error?: string }>(
+    "POST",
+    `${basePath}/${encodeURIComponent(init.uploadId)}/complete`,
+  );
 }
 
 // ─── api ──────────────────────────────────────
@@ -921,11 +989,12 @@ export const api = {
       }>("GET", `/line/${accountId}/restore/ios-backup/${encodeURIComponent(sessionId)}`),
 
     /** Android naver_line DB / LEINs ZIP から履歴復元を開始 */
-    startAndroidBackupRestore: (accountId: string, file: File, includeMedia = false) =>
-      uploadFile<{ ok: boolean; sessionId?: string; error?: string }>(
-        `/line/${accountId}/restore/android-backup?includeMedia=${includeMedia ? "1" : "0"}`,
-        file,
-      ),
+    startAndroidBackupRestore: (
+      accountId: string,
+      file: File,
+      includeMedia = false,
+      onProgress?: (uploadedBytes: number, totalBytes: number) => void,
+    ) => uploadAndroidBackupChunked(accountId, file, includeMedia, onProgress),
 
     /** Android DB 復元セッションのステータス取得 */
     getAndroidBackupSession: (accountId: string, sessionId: string) =>

--- a/Vyline/apps/desktop/src/api/client.ts
+++ b/Vyline/apps/desktop/src/api/client.ts
@@ -115,6 +115,42 @@ async function request<T>(
   }
 }
 
+async function uploadFile<T>(path: string, file: File): Promise<T> {
+  let res: Response;
+  const sessionToken =
+    typeof localStorage !== "undefined" ? localStorage.getItem("vyline:subdevice-session") : null;
+  const installationId = getSubdeviceInstallationId();
+  try {
+    res = await fetch(`${BASE}${path}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/octet-stream",
+        "X-Vyline-Backup-Name": encodeURIComponent(file.name || "naver_line"),
+        ...(sessionToken ? { Authorization: `Bearer ${sessionToken}` } : {}),
+        ...(installationId ? { "X-Vyline-Installation-Id": installationId } : {}),
+      },
+      body: file,
+    });
+  } catch (err) {
+    if (isBackendDown(err)) throw new Error("BACKEND_DOWN");
+    throw new Error(`backend に接続できません（:3001 が起動しているか確認）: ${String(err)}`);
+  }
+
+  const text = await res.text();
+  if (!text.trim()) {
+    throw new Error(
+      res.ok
+        ? "サーバーが空の応答を返しました"
+        : `サーバーエラー HTTP ${res.status}（backend のログを確認）`,
+    );
+  }
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    throw new Error(`サーバー応答の解析に失敗しました: ${text.slice(0, 120)}`);
+  }
+}
+
 // ─── api ──────────────────────────────────────
 
 export const api = {
@@ -883,6 +919,57 @@ export const api = {
         } | null;
         error?: string;
       }>("GET", `/line/${accountId}/restore/ios-backup/${encodeURIComponent(sessionId)}`),
+
+    /** Android naver_line DB / LEINs ZIP から履歴復元を開始 */
+    startAndroidBackupRestore: (accountId: string, file: File, includeMedia = false) =>
+      uploadFile<{ ok: boolean; sessionId?: string; error?: string }>(
+        `/line/${accountId}/restore/android-backup?includeMedia=${includeMedia ? "1" : "0"}`,
+        file,
+      ),
+
+    /** Android DB 復元セッションのステータス取得 */
+    getAndroidBackupSession: (accountId: string, sessionId: string) =>
+      request<{
+        ok: boolean;
+        session?: {
+          id: string;
+          accountId: string;
+          sourceName: string;
+          includeMedia: boolean;
+          status: "pending" | "running" | "completed" | "failed";
+          progress: {
+            stage: string;
+            current: number;
+            total: number;
+            message: string;
+            file?: string;
+          } | null;
+          result: {
+            sourceName: string;
+            sourceKind: "sqlite" | "zip";
+            databaseVersion: number;
+            restoredAt: string;
+            parsed: {
+              chats: number;
+              totalMessages: number;
+              reactions: number;
+              unsupportedReactions: number;
+            };
+            restoredChatMids: string[];
+            merged: {
+              importedChats: number;
+              skippedChats: number;
+              importedMessages: number;
+              skippedMessages: number;
+            };
+            media: { restored: number; skipped: number };
+          } | null;
+          error: string | null;
+          startedAt: number;
+          completedAt: number | null;
+        } | null;
+        error?: string;
+      }>("GET", `/line/${accountId}/restore/android-backup/${encodeURIComponent(sessionId)}`),
 
     /** VylineBackup: チャット一覧 + メッセージ件数（選択 UI 用） */
     backupChats: (accountId: string) =>

--- a/Vyline/apps/desktop/src/components/android-backup-panel.tsx
+++ b/Vyline/apps/desktop/src/components/android-backup-panel.tsx
@@ -20,11 +20,13 @@ export function AndroidBackupPanel({ accountId }: { accountId: string | null }) 
   const [session, setSession] = useState<Session | null>(null);
   const [message, setMessage] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [uploadProgress, setUploadProgress] = useState<{ current: number; total: number } | null>(null);
 
   useEffect(() => {
     setFile(null);
     setSession(null);
     setMessage(null);
+    setUploadProgress(null);
   }, [accountId]);
 
   useEffect(() => {
@@ -62,11 +64,18 @@ export function AndroidBackupPanel({ accountId }: { accountId: string | null }) 
     setLoading(true);
     setMessage(null);
     setSession(null);
+    setUploadProgress({ current: 0, total: file.size });
     try {
-      const response = await api.line.startAndroidBackupRestore(accountId, file, includeMedia);
+      const response = await api.line.startAndroidBackupRestore(
+        accountId,
+        file,
+        includeMedia,
+        (current, total) => setUploadProgress({ current, total }),
+      );
       if (!response.ok || !response.sessionId) {
         throw new Error(response.error ?? "Android DBの復元を開始できませんでした");
       }
+      setUploadProgress(null);
       setSession({
         id: response.sessionId,
         accountId,
@@ -88,6 +97,7 @@ export function AndroidBackupPanel({ accountId }: { accountId: string | null }) 
       setMessage(error instanceof Error ? error.message : "Android DBの復元を開始できませんでした");
     } finally {
       setLoading(false);
+      setUploadProgress(null);
     }
   };
 
@@ -122,6 +132,7 @@ export function AndroidBackupPanel({ accountId }: { accountId: string | null }) 
               setFile(event.target.files?.[0] ?? null);
               setSession(null);
               setMessage(null);
+              setUploadProgress(null);
             }}
           />
         </label>
@@ -164,9 +175,43 @@ export function AndroidBackupPanel({ accountId }: { accountId: string | null }) 
           className="w-full rounded-lg px-3 py-2 text-xs font-semibold text-[var(--vy-accent-contrast)] disabled:opacity-50"
           style={{ background: "var(--vy-accent)" }}
         >
-          {loading ? "アップロード中…" : busy ? "復元中…" : "Android DBから復元"}
+          {loading && uploadProgress?.total
+            ? `アップロード中… ${Math.min(100, Math.round((uploadProgress.current / uploadProgress.total) * 100))}%`
+            : loading
+              ? "アップロード中…"
+              : busy
+                ? "復元中…"
+                : "Android DBから復元"}
         </button>
       </div>
+
+      {loading && uploadProgress && (
+        <div className="mt-3 space-y-1.5" role="status" aria-live="polite">
+          <div className="flex items-center justify-between gap-3 text-xs text-[var(--vy-text-dim)]">
+            <span>リバースプロキシ互換の分割アップロード</span>
+            <span className="shrink-0 font-mono">
+              {uploadProgress.total > 0
+                ? `${Math.min(100, Math.round((uploadProgress.current / uploadProgress.total) * 100))}%`
+                : "0%"}
+            </span>
+          </div>
+          <div
+            className="h-1.5 overflow-hidden rounded-full bg-[var(--vy-surface-2)]"
+            role="progressbar"
+            aria-label="Android DBアップロードの進捗"
+            aria-valuemin={0}
+            aria-valuemax={Math.max(1, uploadProgress.total)}
+            aria-valuenow={Math.min(uploadProgress.current, Math.max(1, uploadProgress.total))}
+          >
+            <div
+              className="h-full rounded-full bg-[var(--vy-accent)] transition-[width] duration-300"
+              style={{
+                width: `${uploadProgress.total > 0 ? Math.min(100, (uploadProgress.current / uploadProgress.total) * 100) : 0}%`,
+              }}
+            />
+          </div>
+        </div>
+      )}
 
       {session?.progress && (
         <div className="mt-3 space-y-1.5" role="status" aria-live="polite">

--- a/Vyline/apps/desktop/src/components/android-backup-panel.tsx
+++ b/Vyline/apps/desktop/src/components/android-backup-panel.tsx
@@ -1,0 +1,235 @@
+import { useEffect, useState } from "react";
+import { api } from "@/api/client";
+import { IconBlock, IconCheck, IconHardDrive, IconShield } from "@/components/icons";
+import { markRestoredChatMids } from "@/utils/dismissedChats";
+
+type Session = NonNullable<
+  Awaited<ReturnType<typeof api.line.getAndroidBackupSession>>["session"]
+>;
+
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  const index = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  return `${(bytes / 1024 ** index).toFixed(index === 0 ? 0 : 1)} ${units[index]}`;
+}
+
+export function AndroidBackupPanel({ accountId }: { accountId: string | null }) {
+  const [file, setFile] = useState<File | null>(null);
+  const [includeMedia, setIncludeMedia] = useState(false);
+  const [session, setSession] = useState<Session | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    setFile(null);
+    setSession(null);
+    setMessage(null);
+  }, [accountId]);
+
+  useEffect(() => {
+    if (
+      !session?.id ||
+      !accountId ||
+      (session.status !== "pending" && session.status !== "running")
+    ) {
+      return;
+    }
+    const timer = window.setInterval(async () => {
+      try {
+        const response = await api.line.getAndroidBackupSession(accountId, session.id);
+        if (response.session) setSession(response.session);
+      } catch (error) {
+        setMessage(error instanceof Error ? error.message : "復元状態の取得に失敗しました");
+      }
+    }, 1000);
+    return () => window.clearInterval(timer);
+  }, [accountId, session?.id, session?.status]);
+
+  useEffect(() => {
+    if (session?.status !== "completed" || !accountId) return;
+    const chatMids = session.result?.restoredChatMids ?? [];
+    markRestoredChatMids(accountId, chatMids);
+    window.dispatchEvent(
+      new CustomEvent("vyline:android-backup-restored", {
+        detail: { accountId, chatMids },
+      }),
+    );
+  }, [accountId, session?.status]);
+
+  const start = async () => {
+    if (!accountId || !file || loading) return;
+    setLoading(true);
+    setMessage(null);
+    setSession(null);
+    try {
+      const response = await api.line.startAndroidBackupRestore(accountId, file, includeMedia);
+      if (!response.ok || !response.sessionId) {
+        throw new Error(response.error ?? "Android DBの復元を開始できませんでした");
+      }
+      setSession({
+        id: response.sessionId,
+        accountId,
+        sourceName: file.name || "naver_line",
+        includeMedia,
+        status: "pending",
+        progress: {
+          stage: "starting",
+          current: 0,
+          total: 1,
+          message: "Android DBの解析を開始しています",
+        },
+        result: null,
+        error: null,
+        startedAt: Date.now(),
+        completedAt: null,
+      });
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "Android DBの復元を開始できませんでした");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const busy =
+    loading || session?.status === "pending" || session?.status === "running";
+
+  return (
+    <section className="mt-6 rounded-2xl border border-[var(--vy-border)] bg-[var(--vy-surface)] p-4">
+      <div className="flex items-start gap-3">
+        <IconHardDrive size={20} className="mt-0.5 shrink-0 text-[var(--vy-accent)]" />
+        <div className="min-w-0 flex-1">
+          <h3 className="font-semibold">Android LINE DB から復元</h3>
+          <p className="mt-1 text-xs leading-relaxed text-[var(--vy-text-dim)]">
+            Android から取得した <span className="font-mono">naver_line</span> SQLite DB、または
+            LEINs 一括バックアップ ZIP を読み込み、トーク履歴を現在の Vyline
+            アカウントへ統合します。既存履歴と元ファイルは変更しません。
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-4 space-y-3 rounded-xl border border-[var(--vy-border)] bg-[var(--vy-surface-2)] p-3">
+        <label className="block cursor-pointer rounded-lg border border-dashed border-[var(--vy-border)] bg-[var(--vy-surface)] p-3 transition hover:border-[var(--vy-accent)]">
+          <span className="block text-xs font-medium">DB / バックアップZIPを選択</span>
+          <span className="mt-1 block text-[0.65rem] text-[var(--vy-text-dim)]">
+            拡張子なしの naver_line、.db、SQLite、.zip に対応
+          </span>
+          <input
+            type="file"
+            className="mt-2 block w-full text-xs text-[var(--vy-text-dim)] file:mr-3 file:rounded-md file:border-0 file:bg-[var(--vy-accent)] file:px-3 file:py-1.5 file:text-xs file:font-semibold file:text-[var(--vy-accent-contrast)]"
+            disabled={busy || !accountId}
+            onChange={(event) => {
+              setFile(event.target.files?.[0] ?? null);
+              setSession(null);
+              setMessage(null);
+            }}
+          />
+        </label>
+
+        {file && (
+          <div className="flex items-center justify-between gap-3 rounded-lg bg-[var(--vy-surface)] px-3 py-2 text-xs">
+            <span className="min-w-0 truncate font-mono">{file.name || "naver_line"}</span>
+            <span className="shrink-0 text-[var(--vy-text-dim)]">{formatBytes(file.size)}</span>
+          </div>
+        )}
+
+        <label className="flex items-start gap-2 text-xs text-[var(--vy-text-dim)]">
+          <input
+            type="checkbox"
+            checked={includeMedia}
+            disabled={busy}
+            onChange={(event) => setIncludeMedia(event.target.checked)}
+            className="mt-0.5 h-4 w-4 accent-[var(--vy-accent)]"
+          />
+          <span>
+            ZIP 内の保存済み画像・動画・音声・ファイルも復元する
+            <span className="mt-0.5 block text-[0.65rem] opacity-80">
+              生のDBだけを選んだ場合は無視されます。ZIPが大きい場合は容量を多く使用します。
+            </span>
+          </span>
+        </label>
+
+        <div className="flex items-start gap-2 rounded-lg border border-[var(--vy-border)] bg-[var(--vy-surface)] px-3 py-2 text-[0.65rem] leading-relaxed text-[var(--vy-text-dim)]">
+          <IconShield size={14} className="mt-0.5 shrink-0" />
+          <span>
+            選択中の Vyline アカウントと、DBを取得したLINEアカウントが同じことを確認してください。
+            メッセージIDが一致する既存履歴は重複追加しません。
+          </span>
+        </div>
+
+        <button
+          type="button"
+          onClick={() => void start()}
+          disabled={!accountId || !file || busy}
+          className="w-full rounded-lg px-3 py-2 text-xs font-semibold text-[var(--vy-accent-contrast)] disabled:opacity-50"
+          style={{ background: "var(--vy-accent)" }}
+        >
+          {loading ? "アップロード中…" : busy ? "復元中…" : "Android DBから復元"}
+        </button>
+      </div>
+
+      {session?.progress && (
+        <div className="mt-3 space-y-1.5" role="status" aria-live="polite">
+          <div className="flex items-center justify-between gap-3 text-xs text-[var(--vy-text-dim)]">
+            <span className="min-w-0 truncate">
+              {session.progress.message}
+              {session.progress.file ? ` · ${session.progress.file}` : ""}
+            </span>
+            <span className="shrink-0 font-mono">
+              {session.progress.total > 0
+                ? `${Math.min(100, Math.round((session.progress.current / session.progress.total) * 100))}%`
+                : "0%"}
+            </span>
+          </div>
+          <div
+            className="h-1.5 overflow-hidden rounded-full bg-[var(--vy-surface-2)]"
+            role="progressbar"
+            aria-label="Android DB復元の進捗"
+            aria-valuemin={0}
+            aria-valuemax={Math.max(1, session.progress.total)}
+            aria-valuenow={Math.min(session.progress.current, Math.max(1, session.progress.total))}
+          >
+            <div
+              className="h-full rounded-full bg-[var(--vy-accent)] transition-[width] duration-300"
+              style={{
+                width: `${session.progress.total > 0 ? Math.min(100, (session.progress.current / session.progress.total) * 100) : 0}%`,
+              }}
+            />
+          </div>
+        </div>
+      )}
+
+      {session?.status === "completed" && session.result && (
+        <div className="mt-3 rounded-lg border border-emerald-500/30 bg-emerald-500/5 p-3 text-xs">
+          <p className="flex items-center gap-2 text-emerald-400" role="status">
+            <IconCheck size={14} />
+            復元完了：{session.result.parsed.chats} チャット /{" "}
+            {session.result.parsed.totalMessages.toLocaleString()} メッセージ
+          </p>
+          <p className="mt-1 text-[0.65rem] leading-relaxed text-[var(--vy-text-dim)]">
+            DB v{session.result.databaseVersion} · 新規メッセージ {session.result.merged.importedMessages.toLocaleString()}
+            件 · 重複 {session.result.merged.skippedMessages.toLocaleString()} 件 · リアクション {session.result.parsed.reactions.toLocaleString()} 件
+            {session.result.media.restored > 0
+              ? ` · メディア ${session.result.media.restored.toLocaleString()} 件`
+              : ""}
+            {session.result.parsed.unsupportedReactions > 0
+              ? ` · 表示未対応カスタムリアクション ${session.result.parsed.unsupportedReactions.toLocaleString()} 件（データ保持）`
+              : ""}
+          </p>
+        </div>
+      )}
+
+      {session?.status === "failed" && (
+        <p className="mt-3 flex items-center gap-2 text-xs text-red-400" role="alert">
+          <IconBlock size={14} />
+          {session.error ?? "Android DBの復元に失敗しました"}
+        </p>
+      )}
+      {message && (
+        <p className="mt-3 text-xs text-red-400" role="alert">
+          {message}
+        </p>
+      )}
+    </section>
+  );
+}

--- a/Vyline/apps/desktop/src/components/chat-area.tsx
+++ b/Vyline/apps/desktop/src/components/chat-area.tsx
@@ -1,4 +1,13 @@
-import { memo, useEffect, useMemo, useRef, useState, useCallback, type UIEvent } from "react";
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type UIEvent,
+} from "react";
 import { useStore, displayName, type Message } from "@/lib/store";
 import { cn } from "@/lib/utils";
 import { api } from "@/api/client";
@@ -207,43 +216,78 @@ function ChatAreaBase() {
     scrollToBottom,
   } = useVirtualList<MsgRow>({ rows, estimateHeight: estimateMsgHeight });
 
-  // 先頭に居続けているときは、ページ追加後も次のローカル履歴を連続して取得する。
-  useEffect(() => {
-    const onOlderLoaded = (event: Event) => {
-      const chatMid = (event as CustomEvent<{ chatMid?: string }>).detail?.chatMid;
-      if (chatMid !== activeChatId) return;
-      const container = containerRef.current;
-      if (!container || container.scrollTop > 160) return;
-      window.requestAnimationFrame(() => {
-        window.dispatchEvent(
-          new CustomEvent("vyline:load-older-messages", { detail: { chatMid: activeChatId } }),
-        );
-      });
-    };
-    window.addEventListener("vyline:older-messages-loaded", onOlderLoaded);
-    return () => window.removeEventListener("vyline:older-messages-loaded", onOlderLoaded);
-  }, [activeChatId, containerRef]);
+  const olderBoundaryArmedRef = useRef(true);
+  const lastUserScrollIntentAtRef = useRef(0);
+  const prependAnchorRef = useRef<{
+    chatMid: string;
+    messageCount: number;
+    oldestMessageId: string | null;
+    scrollHeight: number;
+    scrollTop: number;
+  } | null>(null);
+
+  const requestOlderMessages = useCallback(() => {
+    if (!activeChatId || olderState.loading || !olderState.hasMore) return;
+    const container = containerRef.current;
+    if (container) {
+      prependAnchorRef.current = {
+        chatMid: activeChatId,
+        messageCount: chatMessages.length,
+        oldestMessageId: chatMessages[0]?.id ?? null,
+        scrollHeight: container.scrollHeight,
+        scrollTop: container.scrollTop,
+      };
+    }
+    window.dispatchEvent(
+      new CustomEvent("vyline:load-older-messages", { detail: { chatMid: activeChatId } }),
+    );
+  }, [activeChatId, chatMessages.length, containerRef, olderState]);
 
   const handleMessageScroll = useCallback(
     (event: UIEvent<HTMLDivElement>) => {
       onScroll(event);
-      if (event.currentTarget.scrollTop <= 160 && activeChatId) {
-        window.dispatchEvent(
-          new CustomEvent("vyline:load-older-messages", { detail: { chatMid: activeChatId } }),
-        );
+      const top = event.currentTarget.scrollTop;
+      if (top > 240) {
+        olderBoundaryArmedRef.current = true;
+        return;
+      }
+      const userDriven = performance.now() - lastUserScrollIntentAtRef.current < 1_500;
+      if (
+        top <= 80 &&
+        userDriven &&
+        olderBoundaryArmedRef.current &&
+        olderState.hasMore &&
+        !olderState.loading
+      ) {
+        // wheel / touch / scrollbar 操作で実際に上端へ到達した時だけ1ページ。
+        // 初期レイアウトやプログラムによる scrollTop 変更では取得しない。
+        olderBoundaryArmedRef.current = false;
+        requestOlderMessages();
       }
     },
-    [activeChatId, onScroll],
+    [olderState.hasMore, olderState.loading, onScroll, requestOlderMessages],
   );
 
-  const requestOlderMessages = useCallback(() => {
-    if (!activeChatId || olderState.loading || !olderState.hasMore) return;
-    window.dispatchEvent(
-      new CustomEvent("vyline:load-older-messages", { detail: { chatMid: activeChatId } }),
-    );
-  }, [activeChatId, olderState]);
+  // prepend 後も、読み込み前に見ていた位置を維持する。
+  useLayoutEffect(() => {
+    const anchor = prependAnchorRef.current;
+    if (!anchor || anchor.chatMid !== activeChatId) return;
+    if (chatMessages.length <= anchor.messageCount) return;
+    if ((chatMessages[0]?.id ?? null) === anchor.oldestMessageId) return;
+
+    const frame = requestAnimationFrame(() => {
+      const container = containerRef.current;
+      if (!container) return;
+      const addedHeight = Math.max(0, container.scrollHeight - anchor.scrollHeight);
+      container.scrollTop = anchor.scrollTop + addedHeight;
+      prependAnchorRef.current = null;
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [activeChatId, chatMessages.length, containerRef]);
 
   useEffect(() => {
+    olderBoundaryArmedRef.current = true;
+    prependAnchorRef.current = null;
     setOlderState({ hasMore: true, loading: false });
     const onOlderState = (event: Event) => {
       const detail = (
@@ -254,7 +298,11 @@ function ChatAreaBase() {
         }>
       ).detail;
       if (detail?.chatMid !== activeChatId) return;
-      setOlderState({ hasMore: detail.hasMore ?? false, loading: detail.loading ?? false });
+      const next = { hasMore: detail.hasMore ?? false, loading: detail.loading ?? false };
+      if (!next.loading && !next.hasMore && prependAnchorRef.current?.chatMid === activeChatId) {
+        prependAnchorRef.current = null;
+      }
+      setOlderState(next);
     };
     window.addEventListener("vyline:older-messages-state", onOlderState);
     return () => window.removeEventListener("vyline:older-messages-state", onOlderState);
@@ -557,6 +605,15 @@ function ChatAreaBase() {
         <div
           ref={containerRef}
           onScroll={handleMessageScroll}
+          onWheel={() => {
+            lastUserScrollIntentAtRef.current = performance.now();
+          }}
+          onTouchStart={() => {
+            lastUserScrollIntentAtRef.current = performance.now();
+          }}
+          onPointerDown={() => {
+            lastUserScrollIntentAtRef.current = performance.now();
+          }}
           onContextMenu={(e) => {
             e.preventDefault();
             setPanel({ x: e.clientX, y: e.clientY });

--- a/Vyline/apps/desktop/src/components/settings-sections.tsx
+++ b/Vyline/apps/desktop/src/components/settings-sections.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils";
 import { BetaSection } from "@/components/beta-consent";
 import { AgentIBetaPanel } from "@/components/agent-i-beta-panel";
 import { IosBackupBetaPanel } from "@/components/ios-backup-beta-panel";
+import { AndroidBackupPanel } from "@/components/android-backup-panel";
 import { QRCodeSVG } from "qrcode.react";
 
 function formatRelativeTime(ts: number): string {
@@ -1492,6 +1493,7 @@ function AdvancedSection() {
         </p>
       )}
       <div className="mt-4">
+        <AndroidBackupPanel accountId={accountId} />
         <IosBackupBetaPanel accountId={accountId} />
       </div>
     </Section>

--- a/Vyline/apps/desktop/src/components/sidebar.tsx
+++ b/Vyline/apps/desktop/src/components/sidebar.tsx
@@ -164,12 +164,16 @@ function SidebarBase() {
     let list = chats;
     if (tab === "friend") list = chats.filter((c) => c.type === "friend" && !c.hidden && !c.left);
     else if (tab === "group")
-      list = chats.filter((c) => c.type === "group" && !c.hidden && !c.left);
+      list = chats.filter(
+        (c) => c.type === "group" && !c.hidden && (!c.left || c.restoredHistory),
+      );
     else if (tab === "hidden") list = chats.filter((c) => c.hidden);
     else if (tab === "official") list = chats.filter((c) => c.isOfficial && !c.hidden && !c.left);
     else
       list = chats.filter(
-        (c) => !c.hidden && (!c.left || (c.members != null && c.members.length > 0)),
+        (c) =>
+          !c.hidden &&
+          (!c.left || c.restoredHistory || (c.members != null && c.members.length > 0)),
       );
 
     if (query.trim()) {

--- a/Vyline/apps/desktop/src/hooks/useLineData.ts
+++ b/Vyline/apps/desktop/src/hooks/useLineData.ts
@@ -361,7 +361,7 @@ export function useLineData({ accountId }: UseLineDataOptions) {
     }
   }, [accountId, applyChatsToContactCache]);
 
-  // iOS復元完了後は、ネットワーク同期で上書きせず、書き込み済みのローカルDBを即表示する。
+  // 外部バックアップ復元完了後は、ネットワーク同期で上書きせず、書き込み済みのローカルDBを即表示する。
   useEffect(() => {
     if (!accountId || typeof window === "undefined") return;
     const onRestore = (event: Event) => {
@@ -389,7 +389,11 @@ export function useLineData({ accountId }: UseLineDataOptions) {
       })();
     };
     window.addEventListener("vyline:ios-backup-restored", onRestore);
-    return () => window.removeEventListener("vyline:ios-backup-restored", onRestore);
+    window.addEventListener("vyline:android-backup-restored", onRestore);
+    return () => {
+      window.removeEventListener("vyline:ios-backup-restored", onRestore);
+      window.removeEventListener("vyline:android-backup-restored", onRestore);
+    };
   }, [accountId, loadBootstrap, resolveMessageAuthors]);
 
   // accountId 変更時だけフルリセット（loadChats 再生成で回さない）

--- a/Vyline/apps/desktop/src/hooks/useLineData.ts
+++ b/Vyline/apps/desktop/src/hooks/useLineData.ts
@@ -2,8 +2,9 @@
  * hooks/useLineData.ts
  *
  * Desktop 準拠 local-first:
- * 1. bootstrap（ディスクキャッシュ）で即時表示
- * 2. バックグラウンドで RPC 同期
+ * 1. bootstrap / chatdb で即時表示
+ * 2. チャットごとの履歴ウィンドウを保持し、古い履歴は必要時だけ1ページ取得
+ * 3. 新着同期は push / delta 側に任せ、履歴の暗黙 prefetch は行わない
  *
  * 注意: accountId 変更時だけフルリセット。loadChats の identity 変更で
  * useEffect が回り chats=[] になるループは禁止。
@@ -19,12 +20,19 @@ import {
   vylineClientToContactMap,
 } from "../lib/vyline-cache.js";
 import { resolveChatToOpen, useStore } from "../lib/store.js";
+import {
+  HISTORY_PAGE_SIZE,
+  MAX_LOCAL_HISTORY_LIMIT,
+  mergeHistoryMessages,
+  readHistoryDepths,
+  rememberHistoryDepth,
+  trimHistoryWindows,
+  type ChatHistoryWindow,
+} from "../lib/chatHistoryWindow.js";
 
 interface UseLineDataOptions {
   accountId: string | null;
 }
-
-const PAGE_SIZE = 100;
 
 export function useLineData({ accountId }: UseLineDataOptions) {
   const [profile, setProfile] = useState<LineProfile | null>(null);
@@ -49,6 +57,8 @@ export function useLineData({ accountId }: UseLineDataOptions) {
     bootstrap: false,
   });
   const bootstrapMessages = useRef<Map<string, Message[]>>(new Map());
+  const historyWindows = useRef<Map<string, ChatHistoryWindow>>(new Map());
+  const historyDepths = useRef<Map<string, number>>(new Map());
   const messagesRef = useRef(messages);
   messagesRef.current = messages;
   const selectedChatMidRef = useRef(selectedChatMid);
@@ -201,59 +211,104 @@ export function useLineData({ accountId }: UseLineDataOptions) {
     [prefetchContacts],
   );
 
+  const commitHistoryWindow = useCallback(
+    (chatMid: string, list: Message[], hasMore: boolean) => {
+      if (!accountId) return;
+      const nextWindow: ChatHistoryWindow = {
+        messages: list,
+        hasMore,
+        touchedAt: Date.now(),
+      };
+      historyWindows.current.set(chatMid, nextWindow);
+      rememberHistoryDepth(accountId, historyDepths.current, chatMid, list.length);
+      trimHistoryWindows(historyWindows.current, chatMid);
+
+      if (selectedChatMidRef.current === chatMid) {
+        setMessages(list);
+        setHasMoreMessages(hasMore);
+        setFromLocalCache(true);
+        resolveMessageAuthors(list);
+      }
+    },
+    [accountId, resolveMessageAuthors],
+  );
+
   const loadMessages = useCallback(
-    async (chatMid: string, limit = PAGE_SIZE, opts?: { force?: boolean }) => {
+    async (chatMid: string, limit = HISTORY_PAGE_SIZE, opts?: { force?: boolean }) => {
       if (!accountId || !chatMid) return;
       const gen = ++messagesGen.current;
+      fetchContact(chatMid);
 
-      const boot = bootstrapMessages.current.get(chatMid);
-      if (boot && boot.length > 0 && !opts?.force) {
-        fetchContact(chatMid);
-        const asc = [...boot].reverse();
-        setMessages(asc);
-        setHasMoreMessages(boot.length >= limit);
+      const cachedWindow = historyWindows.current.get(chatMid);
+      if (cachedWindow && !opts?.force) {
+        cachedWindow.touchedAt = Date.now();
+        setMessages(cachedWindow.messages);
+        setHasMoreMessages(cachedWindow.hasMore);
         setFromLocalCache(true);
-        resolveMessageAuthors(asc);
-      } else if (!opts?.force) {
-        // chatdb ローカルを先に描画（ネットワーク待ちを避ける）
+        setLoadingMessages(false);
+        resolveMessageAuthors(cachedWindow.messages);
+
+        // 再入室時は表示を待たせずキャッシュを出し、その後に最新1ページだけローカルDBから統合する。
+        // 3,000件読んだ履歴を3,000件再取得することも、ネットワーク先読みすることもない。
         try {
-          const local = await api.line.messages(accountId, chatMid, limit, { local: true });
-          if (gen === messagesGen.current && selectedChatMidRef.current === chatMid) {
-            if (local.ok && local.messages && local.messages.length > 0) {
-              fetchContact(chatMid);
-              const asc = [...local.messages].reverse();
-              setMessages(asc);
-              setHasMoreMessages(local.hasMore ?? local.messages.length >= limit);
-              setFromLocalCache(true);
-              resolveMessageAuthors(asc);
-            } else {
-              setLoadingMessages(true);
-            }
+          const local = await api.line.messages(accountId, chatMid, HISTORY_PAGE_SIZE, { local: true });
+          if (gen !== messagesGen.current || selectedChatMidRef.current !== chatMid) return;
+          if (local.ok && local.messages?.length) {
+            const latestAsc = [...local.messages].reverse();
+            const merged = mergeHistoryMessages(cachedWindow.messages, latestAsc);
+            commitHistoryWindow(chatMid, merged, cachedWindow.hasMore);
           }
         } catch {
-          setLoadingMessages(true);
+          /* ローカル差分更新は任意。既存ウィンドウをそのまま表示する。 */
         }
+        return;
+      }
+
+      const rememberedDepth = historyDepths.current.get(chatMid) ?? 0;
+      const localLimit = Math.min(
+        MAX_LOCAL_HISTORY_LIMIT,
+        Math.max(limit, rememberedDepth || HISTORY_PAGE_SIZE),
+      );
+
+      const boot = bootstrapMessages.current.get(chatMid);
+      if (boot?.length && !opts?.force) {
+        const bootAsc = [...boot].reverse();
+        setMessages(bootAsc);
+        setHasMoreMessages(true);
+        setFromLocalCache(true);
+        resolveMessageAuthors(bootAsc);
       } else {
         setLoadingMessages(true);
       }
 
       try {
-        fetchContact(chatMid);
-        const res = await api.line.messages(accountId, chatMid, limit, opts);
-        if (gen !== messagesGen.current) return;
-        if (selectedChatMidRef.current !== chatMid) return;
+        if (!opts?.force) {
+          const local = await api.line.messages(accountId, chatMid, localLimit, { local: true });
+          if (gen !== messagesGen.current || selectedChatMidRef.current !== chatMid) return;
+          if (local.ok && local.messages?.length) {
+            const asc = [...local.messages].reverse();
+            commitHistoryWindow(
+              chatMid,
+              asc,
+              local.hasMore ?? local.messages.length >= localLimit,
+            );
+            return;
+          }
+        }
+
+        // ローカルに1件も無い新規チャットだけ、ユーザーが開いたタイミングで1ページ取得する。
+        // これは明示的な foreground fetch で、連続先読みはしない。
+        const res = await api.line.messages(accountId, chatMid, limit, { force: true });
+        if (gen !== messagesGen.current || selectedChatMidRef.current !== chatMid) return;
         if (res.ok && res.messages) {
           const asc = [...res.messages].reverse();
-          setMessages(asc);
-          setHasMoreMessages(res.hasMore ?? res.messages.length >= limit);
-          if (res.fromCache) setFromLocalCache(true);
-          resolveMessageAuthors(asc);
+          commitHistoryWindow(chatMid, asc, res.hasMore ?? res.messages.length >= limit);
         }
       } finally {
         if (gen === messagesGen.current) setLoadingMessages(false);
       }
     },
-    [accountId, resolveMessageAuthors, fetchContact],
+    [accountId, commitHistoryWindow, fetchContact, resolveMessageAuthors],
   );
 
   const loadOlderMessages = useCallback(
@@ -268,48 +323,39 @@ export function useLineData({ accountId }: UseLineDataOptions) {
       if (!oldest) return;
 
       const gen = messagesGen.current;
-      let shouldContinue = false;
       olderInFlight.current = true;
       setLoadingOlder(true);
       try {
-        const res = await api.line.messages(accountId, chatMid, PAGE_SIZE, {
+        const res = await api.line.messages(accountId, chatMid, HISTORY_PAGE_SIZE, {
           beforeMessageId: oldest.id,
           beforeDeliveredTime: oldest.createdTime,
           local: true,
         });
-        if (gen !== messagesGen.current) return;
-        if (selectedChatMidRef.current !== chatMid) return;
+        if (gen !== messagesGen.current || selectedChatMidRef.current !== chatMid) return;
         if (!res.ok || !res.messages) {
-          setHasMoreMessages(false);
+          commitHistoryWindow(chatMid, current, false);
           return;
         }
+
         const olderAsc = [...res.messages].reverse();
-        const existing = new Set(messagesRef.current.map((m) => m.id));
-        const fresh = olderAsc.filter((m) => !existing.has(m.id));
-        if (fresh.length === 0) {
-          setHasMoreMessages(false);
+        const merged = mergeHistoryMessages(current, olderAsc);
+        const added = merged.length - current.length;
+        if (added <= 0) {
+          commitHistoryWindow(chatMid, current, false);
           return;
         }
-        setMessages((prev) => [...fresh, ...prev]);
-        shouldContinue = res.hasMore ?? res.messages.length >= PAGE_SIZE;
-        setHasMoreMessages(shouldContinue);
-        resolveMessageAuthors(fresh);
+
+        const hasMore = res.hasMore ?? res.messages.length >= HISTORY_PAGE_SIZE;
+        commitHistoryWindow(chatMid, merged, hasMore);
       } finally {
         olderInFlight.current = false;
         if (gen === messagesGen.current) setLoadingOlder(false);
       }
-      if (shouldContinue && gen === messagesGen.current && selectedChatMidRef.current === chatMid) {
-        window.requestAnimationFrame(() => {
-          window.dispatchEvent(
-            new CustomEvent("vyline:older-messages-loaded", { detail: { chatMid } }),
-          );
-        });
-      }
     },
-    [accountId, hasMoreMessages, resolveMessageAuthors],
+    [accountId, commitHistoryWindow, hasMoreMessages],
   );
 
-  // ChatArea の仮想スクロールが先頭に到達したら、古い履歴を追加取得する。
+  // ChatArea が明示的に1ページ要求した時だけ、古いローカル履歴を追加取得する。
   useEffect(() => {
     if (typeof window === "undefined") return;
     const onLoadOlder = (event: Event) => {
@@ -369,6 +415,7 @@ export function useLineData({ accountId }: UseLineDataOptions) {
       if (restoredAccountId !== accountId) return;
       const restoredChatMids =
         (event as CustomEvent<{ chatMids?: string[] }>).detail?.chatMids ?? [];
+      for (const chatMid of restoredChatMids) historyWindows.current.delete(chatMid);
       const restoreTarget = restoredChatMids[0];
       if (restoreTarget) {
         setSelectedChatMid(restoreTarget);
@@ -377,15 +424,7 @@ export function useLineData({ accountId }: UseLineDataOptions) {
       void (async () => {
         await loadBootstrap();
         const chatMid = restoreTarget ?? selectedChatMidRef.current;
-        if (!chatMid) return;
-        const res = await api.line.messages(accountId, chatMid, PAGE_SIZE, { local: true });
-        if (res.ok && res.messages) {
-          const messages = [...res.messages].reverse();
-          setMessages(messages);
-          setHasMoreMessages(res.hasMore ?? res.messages.length >= PAGE_SIZE);
-          setFromLocalCache(true);
-          resolveMessageAuthors(messages);
-        }
+        if (chatMid) await loadMessages(chatMid);
       })();
     };
     window.addEventListener("vyline:ios-backup-restored", onRestore);
@@ -394,7 +433,7 @@ export function useLineData({ accountId }: UseLineDataOptions) {
       window.removeEventListener("vyline:ios-backup-restored", onRestore);
       window.removeEventListener("vyline:android-backup-restored", onRestore);
     };
-  }, [accountId, loadBootstrap, resolveMessageAuthors]);
+  }, [accountId, loadBootstrap, loadMessages]);
 
   // accountId 変更時だけフルリセット（loadChats 再生成で回さない）
   useEffect(() => {
@@ -407,6 +446,8 @@ export function useLineData({ accountId }: UseLineDataOptions) {
     setFromLocalCache(false);
     contactFetching.current.clear();
     bootstrapMessages.current.clear();
+    historyWindows.current.clear();
+    historyDepths.current = accountId ? readHistoryDepths(accountId) : new Map();
     if (!accountId) {
       setContactCache(new Map());
       return;
@@ -442,23 +483,6 @@ export function useLineData({ accountId }: UseLineDataOptions) {
       await loadChats({ refresh: true, light: true });
       if (accountIdRef.current !== accountId) return;
 
-      // 初回インデックス: 過去メッセージ等を chatdb に先読み（1アカウント1回）
-      const indexKey = `vyline:indexed:${accountId}`;
-      const needIndex = typeof localStorage !== "undefined" && !localStorage.getItem(indexKey);
-      if (needIndex) {
-        useStore.getState().setIndexing({
-          active: true,
-          label: "初回インデックス中… 過去のメッセージをキャッシュしています",
-        });
-        try {
-          const idx = await api.line.runIndex(accountId);
-          if (idx.ok) localStorage.setItem(indexKey, "1");
-        } catch {
-          /* バックエンド warm でも走っているので失敗は無視 */
-        } finally {
-          useStore.getState().setIndexing(null);
-        }
-      }
 
       window.setTimeout(() => {
         if (accountIdRef.current === accountId) void loadChats({ light: true });
@@ -469,8 +493,6 @@ export function useLineData({ accountId }: UseLineDataOptions) {
 
   useEffect(() => {
     if (!selectedChatMid) return;
-    messagesGen.current += 1;
-    setHasMoreMessages(true);
     void loadMessages(selectedChatMid);
   }, [selectedChatMid, loadMessages]);
 

--- a/Vyline/apps/desktop/src/lib/chatHistoryWindow.test.ts
+++ b/Vyline/apps/desktop/src/lib/chatHistoryWindow.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "bun:test";
+import type { Message } from "../types/index.js";
+import {
+  mergeHistoryMessages,
+  trimHistoryWindows,
+  type ChatHistoryWindow,
+} from "./chatHistoryWindow.js";
+
+function message(id: string, createdTime: number, text = id): Message {
+  return {
+    id,
+    from: "u-peer",
+    to: "u-me",
+    text,
+    contentType: "NONE",
+    createdTime,
+    isMyMessage: false,
+    contentMetadata: null,
+  };
+}
+
+describe("chat history window", () => {
+  it("merges pages without duplicates and keeps oldest-first order", () => {
+    const merged = mergeHistoryMessages(
+      [message("20", 20), message("30", 30)],
+      [message("10", 10), message("20", 20, "updated")],
+    );
+
+    expect(merged.map((item) => item.id)).toEqual(["10", "20", "30"]);
+    expect(merged[1]?.text).toBe("updated");
+  });
+
+  it("evicts least-recent inactive windows but never the active chat", () => {
+    const windows = new Map<string, ChatHistoryWindow>([
+      ["old", { messages: [message("1", 1), message("2", 2)], hasMore: true, touchedAt: 1 }],
+      ["active", { messages: [message("3", 3), message("4", 4)], hasMore: true, touchedAt: 2 }],
+      ["new", { messages: [message("5", 5), message("6", 6)], hasMore: true, touchedAt: 3 }],
+    ]);
+
+    trimHistoryWindows(windows, "active", 4);
+
+    expect(windows.has("active")).toBe(true);
+    expect(windows.has("old")).toBe(false);
+    expect(windows.has("new")).toBe(true);
+  });
+});

--- a/Vyline/apps/desktop/src/lib/chatHistoryWindow.ts
+++ b/Vyline/apps/desktop/src/lib/chatHistoryWindow.ts
@@ -1,0 +1,105 @@
+import type { Message } from "../types/index.js";
+
+export const HISTORY_PAGE_SIZE = 100;
+export const MAX_LOCAL_HISTORY_LIMIT = 10_000;
+export const HISTORY_CACHE_MESSAGE_BUDGET = 20_000;
+
+export type ChatHistoryWindow = {
+  messages: Message[];
+  hasMore: boolean;
+  touchedAt: number;
+};
+
+function compareMessageIds(left: string, right: string): number {
+  if (left === right) return 0;
+  try {
+    const a = BigInt(left);
+    const b = BigInt(right);
+    return a < b ? -1 : 1;
+  } catch {
+    return left.localeCompare(right);
+  }
+}
+
+export function compareHistoryMessagesOldestFirst(left: Message, right: Message): number {
+  const byTime = left.createdTime - right.createdTime;
+  return byTime || compareMessageIds(left.id, right.id);
+}
+
+/**
+ * 履歴ウィンドウを ID で統合する。incoming を優先し、時系列は oldest-first に揃える。
+ * 新着の差分マージと過去ページの prepend の両方で同じ処理を使う。
+ */
+export function mergeHistoryMessages(existing: Message[], incoming: Message[]): Message[] {
+  const byId = new Map<string, Message>();
+  for (const message of existing) byId.set(message.id, message);
+  for (const message of incoming) byId.set(message.id, message);
+  return [...byId.values()].sort(compareHistoryMessagesOldestFirst);
+}
+
+function depthStorageKey(accountId: string): string {
+  return `vyline:history-depth:${accountId}`;
+}
+
+export function readHistoryDepths(accountId: string): Map<string, number> {
+  if (typeof localStorage === "undefined") return new Map();
+  try {
+    const raw = localStorage.getItem(depthStorageKey(accountId));
+    if (!raw) return new Map();
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const entries = Object.entries(parsed)
+      .map(([chatMid, value]) => [chatMid, Number(value)] as const)
+      .filter(([, value]) => Number.isFinite(value) && value > 0)
+      .map(([chatMid, value]) => [chatMid, Math.min(MAX_LOCAL_HISTORY_LIMIT, Math.floor(value))] as const);
+    return new Map(entries);
+  } catch {
+    return new Map();
+  }
+}
+
+export function rememberHistoryDepth(
+  accountId: string,
+  depths: Map<string, number>,
+  chatMid: string,
+  count: number,
+): void {
+  const nextCount = Math.min(MAX_LOCAL_HISTORY_LIMIT, Math.max(0, Math.floor(count)));
+  const previous = depths.get(chatMid) ?? 0;
+  if (nextCount <= previous) return;
+  depths.set(chatMid, nextCount);
+  if (typeof localStorage === "undefined") return;
+  try {
+    const compact = Object.fromEntries(
+      [...depths.entries()]
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 64),
+    );
+    localStorage.setItem(depthStorageKey(accountId), JSON.stringify(compact));
+  } catch {
+    /* persisted depth metadata is optional */
+  }
+}
+
+/**
+ * 複数チャットの履歴を無制限にメモリ常駐させないための LRU trim。
+ * depth は別保存なので、evict 後も再入室時はローカルDBから一発で同じ深さまで戻せる。
+ */
+export function trimHistoryWindows(
+  windows: Map<string, ChatHistoryWindow>,
+  activeChatMid: string,
+  budget = HISTORY_CACHE_MESSAGE_BUDGET,
+): void {
+  let total = 0;
+  for (const window of windows.values()) total += window.messages.length;
+  if (total <= budget) return;
+
+  const candidates = [...windows.entries()]
+    .filter(([chatMid]) => chatMid !== activeChatMid)
+    .sort((a, b) => a[1].touchedAt - b[1].touchedAt);
+
+  for (const [chatMid, window] of candidates) {
+    if (total <= budget) break;
+    windows.delete(chatMid);
+    total -= window.messages.length;
+  }
+}

--- a/Vyline/apps/desktop/src/lib/mappers.ts
+++ b/Vyline/apps/desktop/src/lib/mappers.ts
@@ -93,6 +93,7 @@ export function mapChat(
     backgroundUrl: c.backgroundUrl,
     isSelf: c.isSelf,
     left,
+    restoredHistory: c.restoredHistory,
     unread: c.unreadCount ?? 0,
     hidden,
     lastMessagePreview: c.lastMessagePreview,

--- a/Vyline/apps/desktop/src/lib/store-types.ts
+++ b/Vyline/apps/desktop/src/lib/store-types.ts
@@ -173,6 +173,8 @@ export type Chat = {
   muted?: boolean;
   /** 退出・キック済みグループ */
   left?: boolean;
+  /** 外部バックアップから復元された履歴を持つ */
+  restoredHistory?: boolean;
   unread: number;
   /** 一覧用プレビュー（API） */
   lastMessagePreview?: string;

--- a/Vyline/apps/desktop/src/lib/store.ts
+++ b/Vyline/apps/desktop/src/lib/store.ts
@@ -71,7 +71,6 @@ const lastDeltaPollAt = new Map<string, number>();
 /** messageId → リアクションのキャッシュ（高速読み込み用） */
 const messageReactionCache = new Map<string, MessageReaction[]>();
 /** chatId → 進行中のギャップ backfill（重複抑止） */
-const backfillInflight = new Map<string, Promise<void>>();
 /** mid → プロフィール取得済み（重複 API 抑止） */
 const contactFetched = new Set<string>();
 /** このセッションでユーザーが明示的に開いた chatId（自動既読ガード） */
@@ -491,7 +490,6 @@ type State = {
   /** 楽観リアクション更新（UNDO は自分の全リアクション除去） */
   setMessageReaction: (messageId: string, reaction: "UNDO" | string, myMid: string) => void;
   fetchMessageHistory: (chatId: string, messageId: string) => Promise<Message["history"]>;
-  backfillChat: (chatId: string) => Promise<void>;
   pollMessagesDelta: (chatId: string) => Promise<void>;
   pollIncoming: () => Promise<void>;
   loadAnnouncements: (chatId: string) => Promise<void>;
@@ -568,7 +566,6 @@ export const useStore = create<State>()(
           readReceiptSent.clear();
           readReceiptInflight.clear();
           myMessageIdsByChat.clear();
-          backfillInflight.clear();
           lastDeltaPollAt.clear();
           sessionOpenedChats.clear();
           eventPollCursor.delete(String(id));
@@ -899,10 +896,14 @@ export const useStore = create<State>()(
                 : c;
             }),
           messages: (() => {
-            if (mappedMessages.length === 0 && st.messages.length > 0) return st.messages;
-            const pending = st.messages.filter(
-              (m) => m.id.startsWith("pending_") || m.status === "sending" || m.status === "failed",
-            );
+            if (!chatId) return [];
+
+            // hydrate は「現在のチャットの最新スナップショットを重ねる」だけにする。
+            // 既に表示済みの古い履歴を捨てると、送受信や contact 解決のたびに
+            // 数千件の履歴ウィンドウが初期ページへ巻き戻るため、同一チャット分は保持する。
+            const existingChat = st.messages.filter((m) => m.chatId === chatId);
+            if (mappedMessages.length === 0) return existingChat;
+
             mappedMessages.forEach((m) => {
               if (m.id) {
                 if (m.reactions?.length) {
@@ -912,12 +913,16 @@ export const useStore = create<State>()(
                 }
               }
             });
-            if (pending.length === 0) {
-              return mappedMessages;
-            }
-            const ids = new Set(mappedMessages.map((m) => m.id));
-            const keep = pending.filter((p) => !ids.has(p.id));
-            return [...mappedMessages, ...keep];
+
+            const merged = new Map<string, Message>();
+            for (const m of existingChat) merged.set(m.id, m);
+            // API / local DB 側の値を新しい正本として上書きする。
+            for (const m of mappedMessages) merged.set(m.id, m);
+
+            return [...merged.values()].sort((a, b) => {
+              if (a.createdAt !== b.createdAt) return a.createdAt - b.createdAt;
+              return a.id.localeCompare(b.id);
+            });
           })(),
           activeChatId: st.activeChatId ?? chatId,
           customOrder: st.customOrder.length ? st.customOrder : mappedChats.map((c) => c.id),
@@ -2009,23 +2014,8 @@ export const useStore = create<State>()(
                     : base;
                 }),
             }));
-            // ギャップ回復: 既知だが欠落のある chat を最新ページで修復
-            // （getMessageBoxes の lastMessageTime が store の最新より新しい）
-            const activeChatId = get().activeChatId;
-            const msgs = get().messages;
-            const candidates = res.chats
-              .filter((c) => {
-                const newest = msgs
-                  .filter((m) => m.chatId === c.mid)
-                  .reduce((t, m) => Math.max(t, m.createdAt), 0);
-                return newest > 0 && newest < (c.lastMessageTime ?? 0);
-              })
-              .sort((a, b) => (b.mid === activeChatId ? 1 : 0) - (a.mid === activeChatId ? 1 : 0));
-            for (const c of candidates.slice(0, 3)) {
-              void get()
-                .backfillChat(c.mid)
-                .catch(() => undefined);
-            }
+            // チャット一覧更新ではメッセージ履歴を触らない。
+            // 新着は push / delta、古い履歴はユーザー操作時のページングだけが担当する。
           }
         } catch {
           /* silent */
@@ -2169,12 +2159,27 @@ export const useStore = create<State>()(
                 }
                 return false;
               });
+              // refresh は最新50件を「置換」するのではなく、現在保持している履歴へ重ねる。
+              // これにより送信・既読更新・手動 refresh 後も読み込み済みの古い履歴を維持する。
               const mergedMap = new Map<string, Message>();
+              for (const m of existingChat) {
+                if (
+                  m.id.startsWith("pending_") ||
+                  m.status === "sending" ||
+                  m.status === "failed"
+                ) {
+                  continue;
+                }
+                mergedMap.set(m.id, m);
+              }
               for (const m of mapped) mergedMap.set(m.id, m);
               for (const m of keep) {
                 if (!mergedMap.has(m.id)) mergedMap.set(m.id, m);
               }
-              const forChat = [...mergedMap.values()].sort((a, b) => a.createdAt - b.createdAt);
+              const forChat = [...mergedMap.values()].sort((a, b) => {
+                if (a.createdAt !== b.createdAt) return a.createdAt - b.createdAt;
+                return a.id.localeCompare(b.id);
+              });
               return {
                 messages: [...st.messages.filter((m) => m.chatId !== chatId), ...forChat],
                 chats: st.chats.map((c) =>
@@ -2635,31 +2640,6 @@ export const useStore = create<State>()(
           if (msgs.every((m, i) => m === st.messages[i])) return st;
           return { messages: msgs };
         });
-      },
-
-      backfillChat: async (chatId) => {
-        const accountId = get().accountId;
-        if (!accountId || !chatId) return;
-        const chatKey = accountChatKey(accountId, chatId);
-        const inflight = backfillInflight.get(chatKey);
-        if (inflight) return inflight;
-
-        let task!: Promise<void>;
-        task = (async () => {
-          try {
-            const res = await api.line.messages(accountId, chatId, 50, { force: true });
-            if (res.ok && res.messages?.length) {
-              get().mergeIncomingMessages(chatId, res.messages, { silent: true });
-            }
-          } catch {
-            /* silent */
-          }
-        })();
-        backfillInflight.set(chatKey, task);
-        void task.finally(() => {
-          if (backfillInflight.get(chatKey) === task) backfillInflight.delete(chatKey);
-        });
-        return task;
       },
 
       pollMessagesDelta: async (chatId) => {

--- a/Vyline/backend/src/api/line.ts
+++ b/Vyline/backend/src/api/line.ts
@@ -403,12 +403,15 @@ lineRouter.get("/:accountId/messages/:chatMid", async (c) => {
   const accountId = c.req.param("accountId");
   const chatMid = c.req.param("chatMid");
   const limitParam = Number(c.req.query("limit") ?? "30");
-  const limit = Math.min(Math.max(1, limitParam), 100);
+  const localOnly = c.req.query("local") === "1";
+  // ネットワーク RPC は従来通り最大100件。ローカル chatdb の再入室復元だけは、
+  // 前回ユーザーが見た深度を1回で戻せるよう上限を広げる。
+  const limitMax = localOnly ? 10_000 : 100;
+  const limit = Math.min(Math.max(1, limitParam), limitMax);
   const beforeMessageId = c.req.query("beforeMessageId") || undefined;
   const beforeDeliveredTimeRaw = c.req.query("beforeDeliveredTime");
   const beforeDeliveredTime = beforeDeliveredTimeRaw ? Number(beforeDeliveredTimeRaw) : undefined;
   const force = c.req.query("force") === "1";
-  const localOnly = c.req.query("local") === "1";
 
   try {
     const fetchOpts: {
@@ -423,11 +426,14 @@ lineRouter.get("/:accountId/messages/:chatMid", async (c) => {
     }
     if (force) fetchOpts.force = true;
     if (localOnly) fetchOpts.localOnly = true;
-    const messages = await fetchMessages(accountId, chatMid, limit, fetchOpts);
+    const fetchLimit = localOnly ? limit + 1 : limit;
+    const fetched = await fetchMessages(accountId, chatMid, fetchLimit, fetchOpts);
+    const hasMore = localOnly ? fetched.length > limit : fetched.length >= limit;
+    const messages = localOnly && fetched.length > limit ? fetched.slice(0, limit) : fetched;
     return c.json({
       ok: true,
       messages,
-      hasMore: messages.length >= limit,
+      hasMore,
       fromCache: localOnly || (!force && !beforeMessageId),
     });
   } catch (err) {

--- a/Vyline/backend/src/api/line.ts
+++ b/Vyline/backend/src/api/line.ts
@@ -1987,6 +1987,39 @@ lineRouter.get("/:accountId/restore/ios-backup/:sessionId", async (c) => {
     : c.json({ ok: false, error: "復元セッションが見つかりません" }, 404);
 });
 
+// ─── Android: naver_line DB / LEINs バックアップ復元 ───
+
+lineRouter.post("/:accountId/restore/android-backup", async (c) => {
+  const accountId = c.req.param("accountId");
+  if (!c.req.raw.body) {
+    return c.json({ ok: false, error: "Androidバックアップファイルが必要です" }, 400);
+  }
+  try {
+    const sourceName = c.req.header("X-Vyline-Backup-Name") ?? "naver_line";
+    const includeMedia = c.req.query("includeMedia") === "1";
+    const { startAndroidBackupRestore } = await import(
+      "../service/androidBackupService.js"
+    );
+    const session = await startAndroidBackupRestore(
+      accountId,
+      sourceName,
+      c.req.raw,
+      includeMedia,
+    );
+    return c.json({ ok: true, sessionId: session.id });
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+lineRouter.get("/:accountId/restore/android-backup/:sessionId", async (c) => {
+  const { getAndroidBackupSession } = await import("../service/androidBackupService.js");
+  const session = getAndroidBackupSession(c.req.param("accountId"), c.req.param("sessionId"));
+  return session
+    ? c.json({ ok: true, session })
+    : c.json({ ok: false, error: "復元セッションが見つかりません" }, 404);
+});
+
 // ─── VylineBackup: スナップショット作成 / 一覧 / 復元 ───
 
 lineRouter.get("/:accountId/backup/chats", async (c) => {

--- a/Vyline/backend/src/api/line.ts
+++ b/Vyline/backend/src/api/line.ts
@@ -2012,6 +2012,63 @@ lineRouter.post("/:accountId/restore/android-backup", async (c) => {
   }
 });
 
+lineRouter.post("/:accountId/restore/android-backup/chunked", async (c) => {
+  const accountId = c.req.param("accountId");
+  try {
+    const body = await c.req.json<{
+      sourceName?: string;
+      includeMedia?: boolean;
+      expectedBytes?: number;
+    }>();
+    const { createAndroidBackupChunkUpload } = await import(
+      "../service/androidBackupService.js"
+    );
+    const upload = await createAndroidBackupChunkUpload(
+      accountId,
+      body.sourceName ?? "naver_line",
+      body.includeMedia === true,
+      Number(body.expectedBytes ?? 0),
+    );
+    return c.json({ ok: true, ...upload });
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+lineRouter.post("/:accountId/restore/android-backup/chunked/:uploadId/chunks/:index", async (c) => {
+  const accountId = c.req.param("accountId");
+  if (!c.req.raw.body) {
+    return c.json({ ok: false, error: "chunkデータが必要です" }, 400);
+  }
+  try {
+    const { appendAndroidBackupChunk } = await import(
+      "../service/androidBackupService.js"
+    );
+    const result = await appendAndroidBackupChunk(
+      accountId,
+      c.req.param("uploadId"),
+      Number(c.req.param("index")),
+      c.req.raw,
+    );
+    return c.json({ ok: true, ...result });
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+lineRouter.post("/:accountId/restore/android-backup/chunked/:uploadId/complete", async (c) => {
+  const accountId = c.req.param("accountId");
+  try {
+    const { completeAndroidBackupChunkUpload } = await import(
+      "../service/androidBackupService.js"
+    );
+    const session = await completeAndroidBackupChunkUpload(accountId, c.req.param("uploadId"));
+    return c.json({ ok: true, sessionId: session.id });
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
 lineRouter.get("/:accountId/restore/android-backup/:sessionId", async (c) => {
   const { getAndroidBackupSession } = await import("../service/androidBackupService.js");
   const session = getAndroidBackupSession(c.req.param("accountId"), c.req.param("sessionId"));

--- a/Vyline/backend/src/index.ts
+++ b/Vyline/backend/src/index.ts
@@ -32,6 +32,11 @@ import { handoffRouter } from "./api/handoff.js";
 import { diagnosticsRouter } from "./api/diagnostics.js";
 
 const PORT = Number(process.env.PORT ?? 3001);
+const MAX_REQUEST_BODY_BYTES = Number(
+  process.env.VYLINE_MAX_REQUEST_BODY_BYTES ??
+    process.env.VYLINE_ANDROID_BACKUP_MAX_BYTES ??
+    2 * 1024 * 1024 * 1024,
+);
 const LAN_ACCESS = process.env.VYLINE_LAN_ACCESS === "true";
 const HOST = LAN_ACCESS ? "0.0.0.0" : (process.env.VYLINE_HOST ?? "127.0.0.1");
 const CORS_ORIGIN = process.env.VYLINE_CORS_ORIGIN ?? "http://localhost:5173";
@@ -336,6 +341,8 @@ async function getCallWsHandlers(): Promise<CallWsHandlers> {
 export default {
   port: PORT,
   hostname: HOST,
+  /** AndroidバックアップZIPは数百MBになるため、ストリーム受信前のBun上限も合わせる。 */
+  maxRequestBodySize: MAX_REQUEST_BODY_BYTES,
   /** 既読取得など LINE RPC が 10s を超えることがある */
   idleTimeout: 120,
   async fetch(req: Request, server: Bun.Server<CallWsData>) {

--- a/Vyline/backend/src/service/androidBackupService.test.ts
+++ b/Vyline/backend/src/service/androidBackupService.test.ts
@@ -143,6 +143,7 @@ describe("Android LINE backup import", () => {
       name: "Test group",
       kind: "group",
       hasMessages: true,
+      restoredHistory: true,
     });
     expect(parsed.records.messages["c-group"]?.["581758080913244212"]).toMatchObject({
       from: "u-me",

--- a/Vyline/backend/src/service/androidBackupService.test.ts
+++ b/Vyline/backend/src/service/androidBackupService.test.ts
@@ -1,0 +1,188 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  androidContentType,
+  parseAndroidDatabase,
+  parseAndroidParameter,
+} from "./androidBackupService.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map((path) => rm(path, { recursive: true, force: true })),
+  );
+});
+
+describe("Android LINE backup import", () => {
+  test("parses tab-separated LINE contentMetadata without dropping Android-only fields", () => {
+    expect(
+      parseAndroidParameter(
+        'STKPKGID\t123\tSTKID\t456\tmessage_relation_type_code\treply\tmessage_relation_server_message_id\t999',
+      ),
+    ).toEqual({
+      STKPKGID: "123",
+      STKID: "456",
+      message_relation_type_code: "reply",
+      message_relation_server_message_id: "999",
+    });
+  });
+
+  test("maps Android attachment and unsent types to Vyline content types", () => {
+    expect(androidContentType(1, 0)).toBe("NONE");
+    expect(androidContentType(1, 1)).toBe("IMAGE");
+    expect(androidContentType(5, 7)).toBe("STICKER");
+    expect(androidContentType(13, 18)).toBe("CHATEVENT");
+    expect(androidContentType(27, 0)).toBe("UNSENT");
+  });
+
+  test("parses a naver_line SQLite DB and preserves 64-bit reaction message IDs", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "vyline-android-test-"));
+    tempDirs.push(dir);
+    const path = join(dir, "naver_line");
+    const db = new Database(path, { create: true, safeIntegers: true, strict: true });
+    try {
+      db.exec(`
+        PRAGMA user_version = 164;
+        CREATE TABLE chat (
+          chat_id TEXT PRIMARY KEY,
+          chat_name TEXT,
+          message_count INTEGER,
+          read_message_count INTEGER,
+          type INTEGER
+        );
+        CREATE TABLE chat_history (
+          id INTEGER PRIMARY KEY,
+          server_id TEXT,
+          type INTEGER,
+          chat_id TEXT,
+          from_mid TEXT,
+          content TEXT,
+          created_time TEXT,
+          read_count INTEGER,
+          attachement_type INTEGER,
+          parameter TEXT
+        );
+        CREATE TABLE reactions (
+          server_message_id INTEGER,
+          member_id TEXT,
+          chat_id TEXT,
+          reaction_time_millis INTEGER,
+          reaction_type TEXT,
+          custom_reaction TEXT
+        );
+      `);
+      db.query(
+        "INSERT INTO chat VALUES (?, ?, ?, ?, ?)",
+      ).run("c-group", "Test group", 2, 2, 3);
+      db.query(
+        "INSERT INTO chat_history VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+      ).run(
+        10,
+        "581758080913244212",
+        1,
+        "c-group",
+        null,
+        "mine",
+        "1787977000000",
+        1,
+        0,
+        "",
+      );
+      db.query(
+        "INSERT INTO chat_history VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+      ).run(
+        11,
+        "581758080913244213",
+        1,
+        "c-group",
+        "u-peer",
+        null,
+        "1787977001000",
+        0,
+        1,
+        "message_relation_type_code\treply\tmessage_relation_server_message_id\t581758080913244212",
+      );
+      db.query(
+        "INSERT INTO chat_history VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+      ).run(
+        12,
+        "581758080913244213",
+        1,
+        "c-group",
+        "u-peer",
+        "取り消しされたメッセージです",
+        "1787977001000",
+        0,
+        0,
+        "LEINsUnsend",
+      );
+      db.query(
+        "INSERT INTO reactions VALUES (?, ?, ?, ?, ?, ?)",
+      ).run(581758080913244213n, "u-reactor", "c-group", 1787977002000, "love", "");
+      db.query(
+        "INSERT INTO reactions VALUES (?, ?, ?, ?, ?, ?)",
+      ).run(
+        581758080913244213n,
+        "u-paid-reactor",
+        "c-group",
+        1787977003000,
+        "",
+        '{"paidReactionType":{"productId":"test","emojiId":"001"}}',
+      );
+    } finally {
+      db.close();
+    }
+
+    const parsed = parseAndroidDatabase(path, "u-me");
+    expect(parsed.databaseVersion).toBe(164);
+    expect(parsed.records.chats["c-group"]).toMatchObject({
+      name: "Test group",
+      kind: "group",
+      hasMessages: true,
+    });
+    expect(parsed.records.messages["c-group"]?.["581758080913244212"]).toMatchObject({
+      from: "u-me",
+      to: "c-group",
+      text: "mine",
+      contentType: "NONE",
+      isMyMessage: true,
+    });
+    expect(parsed.records.messages["c-group"]?.["581758080913244213"]).toMatchObject({
+      from: "u-peer",
+      to: "u-me",
+      text: null,
+      contentType: "UNSENT",
+      messageState: "revoked-by-other",
+      relatedMessageId: "581758080913244212",
+      revokedSnapshot: {
+        contentType: "IMAGE",
+        relatedMessageId: "581758080913244212",
+      },
+      reactions: [{ fromMid: "u-reactor", type: 3, atMillis: 1787977002000 }],
+    });
+    expect(parsed.mediaRefs).toEqual([
+      {
+        chatMid: "c-group",
+        localId: "11",
+        messageId: "581758080913244213",
+        contentType: "IMAGE",
+      },
+    ]);
+    const customReactions = JSON.parse(
+      parsed.records.messages["c-group"]?.["581758080913244213"]?.contentMetadata
+        ?.ANDROID_CUSTOM_REACTIONS ?? "[]",
+    ) as Array<{ fromMid: string; customReaction: string }>;
+    expect(customReactions).toEqual([
+      expect.objectContaining({
+        fromMid: "u-paid-reactor",
+        customReaction: '{"paidReactionType":{"productId":"test","emojiId":"001"}}',
+      }),
+    ]);
+    expect(parsed.reactions).toBe(1);
+    expect(parsed.unsupportedReactions).toBe(1);
+  });
+});

--- a/Vyline/backend/src/service/androidBackupService.test.ts
+++ b/Vyline/backend/src/service/androidBackupService.test.ts
@@ -154,7 +154,8 @@ describe("Android LINE backup import", () => {
     });
     expect(parsed.records.messages["c-group"]?.["581758080913244213"]).toMatchObject({
       from: "u-peer",
-      to: "u-me",
+      // Received group messages must still target the group chat MID.
+      to: "c-group",
       text: null,
       contentType: "UNSENT",
       messageState: "revoked-by-other",

--- a/Vyline/backend/src/service/androidBackupService.ts
+++ b/Vyline/backend/src/service/androidBackupService.ts
@@ -680,7 +680,13 @@ export function parseAndroidDatabase(dbPath: string, selfMid: string): ParsedAnd
         id: messageId,
         chatMid,
         from,
-        to: isMyMessage ? chatMid : selfMid,
+        // LINE group/room messages target the chat MID even when received.
+        // Using selfMid here makes the desktop-side chat filter drop every
+        // restored message sent by another group member.
+        to:
+          isMyMessage || chatMid.startsWith("c") || chatMid.startsWith("r")
+            ? chatMid
+            : selfMid,
         text: unsent ? null : asNullableString(row.content),
         contentType: unsent ? "UNSENT" : contentType,
         createdTime: Number.isFinite(createdTime) ? createdTime : 0,

--- a/Vyline/backend/src/service/androidBackupService.ts
+++ b/Vyline/backend/src/service/androidBackupService.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync } from "node:fs";
-import { mkdtemp, open, readFile, rm, stat } from "node:fs/promises";
+import { appendFile, mkdtemp, open, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { Database } from "bun:sqlite";
@@ -21,6 +21,13 @@ const log = childLogger("android-backup");
 
 const MAX_UPLOAD_BYTES = Number(
   process.env.VYLINE_ANDROID_BACKUP_MAX_BYTES ?? 2 * 1024 * 1024 * 1024,
+);
+const CHUNK_UPLOAD_BYTES = Math.min(
+  768 * 1024,
+  Math.max(64 * 1024, Number(process.env.VYLINE_ANDROID_BACKUP_CHUNK_BYTES ?? 512 * 1024)),
+);
+const CHUNK_UPLOAD_TTL_MS = Number(
+  process.env.VYLINE_ANDROID_BACKUP_CHUNK_TTL_MS ?? 60 * 60 * 1000,
 );
 const MAX_EXTRACT_BYTES = Number(
   process.env.VYLINE_ANDROID_BACKUP_MAX_EXTRACT_BYTES ?? 4 * 1024 * 1024 * 1024,
@@ -94,6 +101,72 @@ interface ExtractedAndroidZip {
 
 const sessions = new Map<string, AndroidBackupSession>();
 
+interface AndroidBackupChunkUpload {
+  id: string;
+  accountId: string;
+  sourceName: string;
+  includeMedia: boolean;
+  expectedBytes: number;
+  receivedBytes: number;
+  nextIndex: number;
+  workDir: string;
+  sourcePath: string;
+  updatedAt: number;
+}
+
+const chunkUploads = new Map<string, AndroidBackupChunkUpload>();
+
+async function pruneStaleChunkUploads(): Promise<void> {
+  const threshold = Date.now() - CHUNK_UPLOAD_TTL_MS;
+  const stale = [...chunkUploads.values()].filter((upload) => upload.updatedAt < threshold);
+  for (const upload of stale) {
+    chunkUploads.delete(upload.id);
+    await rm(upload.workDir, { recursive: true, force: true }).catch(() => undefined);
+  }
+}
+
+function createRestoreSession(
+  accountId: string,
+  sourceName: string,
+  includeMedia: boolean,
+  totalBytes: number,
+): AndroidBackupSession {
+  const id = `android-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  return {
+    id,
+    accountId,
+    sourceName: sanitizeDisplayName(sourceName),
+    includeMedia,
+    status: "pending",
+    progress: {
+      stage: "upload",
+      current: 0,
+      total: totalBytes > 0 ? totalBytes : 1,
+      message: "Androidバックアップを受信しています",
+    },
+    result: null,
+    error: null,
+    startedAt: Date.now(),
+    completedAt: null,
+  };
+}
+
+function queueRestore(
+  session: AndroidBackupSession,
+  sourcePath: string,
+  workDir: string,
+): AndroidBackupSession {
+  session.progress = {
+    stage: "queued",
+    current: 1,
+    total: 1,
+    message: "復元処理を開始しています",
+  };
+  sessions.set(session.id, session);
+  void runRestore(session, sourcePath, workDir);
+  return session;
+}
+
 export async function startAndroidBackupRestore(
   accountId: string,
   sourceName: string,
@@ -106,26 +179,9 @@ export async function startAndroidBackupRestore(
     throw new Error(`Androidバックアップが大きすぎます（上限 ${formatBytes(MAX_UPLOAD_BYTES)}）`);
   }
 
-  const id = `android-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-  const session: AndroidBackupSession = {
-    id,
-    accountId,
-    sourceName: sanitizeDisplayName(sourceName),
-    includeMedia,
-    status: "pending",
-    progress: {
-      stage: "upload",
-      current: 0,
-      total: contentLength > 0 ? contentLength : 1,
-      message: "Androidバックアップを受信しています",
-    },
-    result: null,
-    error: null,
-    startedAt: Date.now(),
-    completedAt: null,
-  };
+  const session = createRestoreSession(accountId, sourceName, includeMedia, contentLength);
 
-  const workDir = await mkdtemp(join(tmpdir(), `vyline-android-${id}-`));
+  const workDir = await mkdtemp(join(tmpdir(), `vyline-android-${session.id}-`));
   const sourcePath = join(workDir, "source.bin");
   try {
     const written = await Bun.write(sourcePath, request);
@@ -133,19 +189,129 @@ export async function startAndroidBackupRestore(
     if (written > MAX_UPLOAD_BYTES) {
       throw new Error(`Androidバックアップが大きすぎます（上限 ${formatBytes(MAX_UPLOAD_BYTES)}）`);
     }
-    session.progress = {
-      stage: "queued",
-      current: 1,
-      total: 1,
-      message: "復元処理を開始しています",
-    };
-    sessions.set(id, session);
-    void runRestore(session, sourcePath, workDir);
-    return session;
+    return queueRestore(session, sourcePath, workDir);
   } catch (error) {
     await rm(workDir, { recursive: true, force: true }).catch(() => undefined);
     throw error;
   }
+}
+
+/**
+ * Reverse proxy の body size 制限を避けるための分割アップロードを開始する。
+ * chunk 自体は 1 MiB を十分下回るため、Nginx の既定 client_max_body_size=1m でも通る。
+ */
+export async function createAndroidBackupChunkUpload(
+  accountId: string,
+  sourceName: string,
+  includeMedia: boolean,
+  expectedBytes: number,
+): Promise<{ uploadId: string; chunkSize: number }> {
+  if (!accountId) throw new Error("accountId が必要です");
+  if (!Number.isFinite(expectedBytes) || expectedBytes <= 0) {
+    throw new Error("Androidバックアップのファイルサイズが不正です");
+  }
+  if (expectedBytes > MAX_UPLOAD_BYTES) {
+    throw new Error(`Androidバックアップが大きすぎます（上限 ${formatBytes(MAX_UPLOAD_BYTES)}）`);
+  }
+
+  await pruneStaleChunkUploads();
+  const id = `android-upload-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const workDir = await mkdtemp(join(tmpdir(), `vyline-${id}-`));
+  const sourcePath = join(workDir, "source.bin");
+  await writeFile(sourcePath, new Uint8Array());
+  chunkUploads.set(id, {
+    id,
+    accountId,
+    sourceName: sanitizeDisplayName(sourceName),
+    includeMedia,
+    expectedBytes,
+    receivedBytes: 0,
+    nextIndex: 0,
+    workDir,
+    sourcePath,
+    updatedAt: Date.now(),
+  });
+  return { uploadId: id, chunkSize: CHUNK_UPLOAD_BYTES };
+}
+
+export async function appendAndroidBackupChunk(
+  accountId: string,
+  uploadId: string,
+  index: number,
+  request: Request,
+): Promise<{ receivedBytes: number; expectedBytes: number; nextIndex: number }> {
+  const upload = chunkUploads.get(uploadId);
+  if (!upload || upload.accountId !== accountId) {
+    throw new Error("Androidバックアップのアップロードセッションが見つかりません");
+  }
+  if (!Number.isInteger(index) || index < 0) throw new Error("chunk index が不正です");
+
+  // 応答だけ失われて同じchunkが再送された場合は二重追記せず成功扱いにする。
+  if (index < upload.nextIndex) {
+    upload.updatedAt = Date.now();
+    return {
+      receivedBytes: upload.receivedBytes,
+      expectedBytes: upload.expectedBytes,
+      nextIndex: upload.nextIndex,
+    };
+  }
+  if (index !== upload.nextIndex) {
+    throw new Error(`chunk順序が不正です（expected=${upload.nextIndex}, received=${index}）`);
+  }
+
+  const declared = Number(request.headers.get("content-length") ?? 0);
+  if (Number.isFinite(declared) && declared > CHUNK_UPLOAD_BYTES) {
+    throw new Error(`chunkが大きすぎます（上限 ${formatBytes(CHUNK_UPLOAD_BYTES)}）`);
+  }
+  const bytes = new Uint8Array(await request.arrayBuffer());
+  if (bytes.byteLength <= 0) throw new Error("空のchunkは受け付けられません");
+  if (bytes.byteLength > CHUNK_UPLOAD_BYTES) {
+    throw new Error(`chunkが大きすぎます（上限 ${formatBytes(CHUNK_UPLOAD_BYTES)}）`);
+  }
+  if (upload.receivedBytes + bytes.byteLength > upload.expectedBytes) {
+    throw new Error("アップロードサイズが宣言されたファイルサイズを超えました");
+  }
+
+  await appendFile(upload.sourcePath, bytes);
+  upload.receivedBytes += bytes.byteLength;
+  upload.nextIndex += 1;
+  upload.updatedAt = Date.now();
+  return {
+    receivedBytes: upload.receivedBytes,
+    expectedBytes: upload.expectedBytes,
+    nextIndex: upload.nextIndex,
+  };
+}
+
+export async function completeAndroidBackupChunkUpload(
+  accountId: string,
+  uploadId: string,
+): Promise<AndroidBackupSession> {
+  const upload = chunkUploads.get(uploadId);
+  if (!upload || upload.accountId !== accountId) {
+    throw new Error("Androidバックアップのアップロードセッションが見つかりません");
+  }
+  if (upload.receivedBytes !== upload.expectedBytes) {
+    throw new Error(
+      `アップロードが未完了です（${formatBytes(upload.receivedBytes)} / ${formatBytes(upload.expectedBytes)}）`,
+    );
+  }
+
+  chunkUploads.delete(uploadId);
+  const actualBytes = (await stat(upload.sourcePath)).size;
+  if (actualBytes !== upload.expectedBytes) {
+    await rm(upload.workDir, { recursive: true, force: true }).catch(() => undefined);
+    throw new Error(
+      `アップロード済みファイルサイズが一致しません（${formatBytes(actualBytes)} / ${formatBytes(upload.expectedBytes)}）`,
+    );
+  }
+  const session = createRestoreSession(
+    upload.accountId,
+    upload.sourceName,
+    upload.includeMedia,
+    actualBytes,
+  );
+  return queueRestore(session, upload.sourcePath, upload.workDir);
 }
 
 export function getAndroidBackupSession(

--- a/Vyline/backend/src/service/androidBackupService.ts
+++ b/Vyline/backend/src/service/androidBackupService.ts
@@ -1,0 +1,975 @@
+import { existsSync, mkdirSync } from "node:fs";
+import { mkdtemp, open, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import { Database } from "bun:sqlite";
+import { Unzip, UnzipInflate } from "fflate";
+import type { MessageContentMeta, MessageReaction, MessageSnapshot } from "@vyline/types";
+import { childLogger } from "../logger.js";
+import { getClient } from "../line/clientManager.js";
+import {
+  flushAccountChatDb,
+  mergeImportedChatDb,
+  type ChatDbRecords,
+  type StoredChat,
+  type StoredMessage,
+} from "../storage/chatStore.js";
+import { writeMediaStorage } from "../storage/mediaStorage.js";
+import { getToken } from "../storage/tokenStore.js";
+
+const log = childLogger("android-backup");
+
+const MAX_UPLOAD_BYTES = Number(
+  process.env.VYLINE_ANDROID_BACKUP_MAX_BYTES ?? 2 * 1024 * 1024 * 1024,
+);
+const MAX_EXTRACT_BYTES = Number(
+  process.env.VYLINE_ANDROID_BACKUP_MAX_EXTRACT_BYTES ?? 4 * 1024 * 1024 * 1024,
+);
+const SQLITE_MAGIC = "SQLite format 3\u0000";
+const MEDIA_CONTENT_TYPES = new Set(["IMAGE", "VIDEO", "AUDIO", "FILE"]);
+const UNSENT_HISTORY_TYPES = new Set([27, 28, 38]);
+
+export interface AndroidBackupProgress {
+  stage: string;
+  current: number;
+  total: number;
+  message: string;
+  file?: string;
+}
+
+export interface AndroidBackupSession {
+  id: string;
+  accountId: string;
+  sourceName: string;
+  includeMedia: boolean;
+  status: "pending" | "running" | "completed" | "failed";
+  progress: AndroidBackupProgress | null;
+  result: {
+    sourceName: string;
+    sourceKind: "sqlite" | "zip";
+    databaseVersion: number;
+    restoredAt: string;
+    parsed: {
+      chats: number;
+      totalMessages: number;
+      reactions: number;
+      unsupportedReactions: number;
+    };
+    restoredChatMids: string[];
+    merged: {
+      importedChats: number;
+      skippedChats: number;
+      importedMessages: number;
+      skippedMessages: number;
+    };
+    media: { restored: number; skipped: number };
+  } | null;
+  error: string | null;
+  startedAt: number;
+  completedAt: number | null;
+}
+
+type SqlValue = string | number | bigint | Uint8Array | null;
+type AndroidRow = Record<string, SqlValue>;
+
+interface AndroidMediaRef {
+  chatMid: string;
+  localId: string;
+  messageId: string;
+  contentType: string;
+}
+
+export interface ParsedAndroidDatabase {
+  records: ChatDbRecords;
+  mediaRefs: AndroidMediaRef[];
+  databaseVersion: number;
+  reactions: number;
+  unsupportedReactions: number;
+}
+
+interface ExtractedAndroidZip {
+  databasePath: string;
+  mediaRoot: string | null;
+}
+
+const sessions = new Map<string, AndroidBackupSession>();
+
+export async function startAndroidBackupRestore(
+  accountId: string,
+  sourceName: string,
+  request: Request,
+  includeMedia: boolean,
+): Promise<AndroidBackupSession> {
+  if (!accountId) throw new Error("accountId が必要です");
+  const contentLength = Number(request.headers.get("content-length") ?? 0);
+  if (Number.isFinite(contentLength) && contentLength > MAX_UPLOAD_BYTES) {
+    throw new Error(`Androidバックアップが大きすぎます（上限 ${formatBytes(MAX_UPLOAD_BYTES)}）`);
+  }
+
+  const id = `android-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const session: AndroidBackupSession = {
+    id,
+    accountId,
+    sourceName: sanitizeDisplayName(sourceName),
+    includeMedia,
+    status: "pending",
+    progress: {
+      stage: "upload",
+      current: 0,
+      total: contentLength > 0 ? contentLength : 1,
+      message: "Androidバックアップを受信しています",
+    },
+    result: null,
+    error: null,
+    startedAt: Date.now(),
+    completedAt: null,
+  };
+
+  const workDir = await mkdtemp(join(tmpdir(), `vyline-android-${id}-`));
+  const sourcePath = join(workDir, "source.bin");
+  try {
+    const written = await Bun.write(sourcePath, request);
+    if (written <= 0) throw new Error("アップロードされたファイルが空です");
+    if (written > MAX_UPLOAD_BYTES) {
+      throw new Error(`Androidバックアップが大きすぎます（上限 ${formatBytes(MAX_UPLOAD_BYTES)}）`);
+    }
+    session.progress = {
+      stage: "queued",
+      current: 1,
+      total: 1,
+      message: "復元処理を開始しています",
+    };
+    sessions.set(id, session);
+    void runRestore(session, sourcePath, workDir);
+    return session;
+  } catch (error) {
+    await rm(workDir, { recursive: true, force: true }).catch(() => undefined);
+    throw error;
+  }
+}
+
+export function getAndroidBackupSession(
+  accountId: string,
+  id: string,
+): AndroidBackupSession | null {
+  const session = sessions.get(id);
+  return session?.accountId === accountId ? session : null;
+}
+
+async function runRestore(
+  session: AndroidBackupSession,
+  sourcePath: string,
+  workDir: string,
+): Promise<void> {
+  session.status = "running";
+  try {
+    const sourceKind = await detectBackupKind(sourcePath);
+    let databasePath = sourcePath;
+    let mediaRoot: string | null = null;
+
+    if (sourceKind === "zip") {
+      session.progress = {
+        stage: "extract",
+        current: 0,
+        total: (await stat(sourcePath)).size,
+        message: session.includeMedia
+          ? "DBとAndroidの保存済みメディアを展開しています"
+          : "AndroidバックアップからDBを取り出しています",
+      };
+      const extracted = await extractAndroidZip(
+        sourcePath,
+        join(workDir, "extracted"),
+        session.includeMedia,
+        (current, total, file) => {
+          session.progress = {
+            stage: "extract",
+            current,
+            total,
+            message: session.includeMedia
+              ? "DBとAndroidの保存済みメディアを展開しています"
+              : "AndroidバックアップからDBを取り出しています",
+            ...(file ? { file } : {}),
+          };
+        },
+      );
+      databasePath = extracted.databasePath;
+      mediaRoot = extracted.mediaRoot;
+    }
+
+    session.progress = {
+      stage: "parse",
+      current: 0,
+      total: 1,
+      message: "naver_line DBを解析しています",
+    };
+    const token = await getToken(session.accountId);
+    const selfMid =
+      token?.mid?.trim() || String(getClient(session.accountId)?.base.profile?.mid ?? "").trim();
+    if (!selfMid) {
+      throw new Error("復元先LINEアカウントのMIDを確認できません。再ログインしてから実行してください");
+    }
+    const parsed = parseAndroidDatabase(databasePath, selfMid);
+
+    session.progress = {
+      stage: "merge",
+      current: 0,
+      total: 1,
+      message: "Androidのトーク履歴をVylineへ統合しています",
+    };
+    const merged = await mergeImportedChatDb(session.accountId, parsed.records);
+
+    let media = { restored: 0, skipped: 0 };
+    if (session.includeMedia && mediaRoot) {
+      session.progress = {
+        stage: "media",
+        current: 0,
+        total: parsed.mediaRefs.length,
+        message: "Androidの保存済みメディアを紐付けています",
+      };
+      media = await restoreAndroidMedia(
+        session.accountId,
+        mediaRoot,
+        parsed.mediaRefs,
+        (current, total) => {
+          session.progress = {
+            stage: "media",
+            current,
+            total,
+            message: "Androidの保存済みメディアを紐付けています",
+          };
+        },
+      );
+    }
+
+    session.progress = {
+      stage: "save",
+      current: 1,
+      total: 1,
+      message: "復元結果を保存しています",
+    };
+    await flushAccountChatDb(session.accountId);
+
+    const totalMessages = Object.values(parsed.records.messages).reduce(
+      (sum, messages) => sum + Object.keys(messages).length,
+      0,
+    );
+    session.result = {
+      sourceName: session.sourceName,
+      sourceKind,
+      databaseVersion: parsed.databaseVersion,
+      restoredAt: new Date().toISOString(),
+      parsed: {
+        chats: Object.keys(parsed.records.chats).length,
+        totalMessages,
+        reactions: parsed.reactions,
+        unsupportedReactions: parsed.unsupportedReactions,
+      },
+      restoredChatMids: Object.values(parsed.records.chats)
+        .filter((chat) => chat.hasMessages)
+        .sort((a, b) => (b.lastMessageTime ?? 0) - (a.lastMessageTime ?? 0))
+        .map((chat) => chat.mid),
+      merged,
+      media,
+    };
+    session.status = "completed";
+    session.completedAt = Date.now();
+  } catch (error) {
+    session.status = "failed";
+    session.error =
+      error instanceof Error ? error.message : "Androidバックアップの復元に失敗しました";
+    session.completedAt = Date.now();
+    log.warn(
+      { accountId: session.accountId, sourceName: session.sourceName, error },
+      "Android backup restore failed",
+    );
+  } finally {
+    await rm(workDir, { recursive: true, force: true }).catch(() => undefined);
+  }
+}
+
+async function detectBackupKind(path: string): Promise<"sqlite" | "zip"> {
+  const handle = await open(path, "r");
+  try {
+    const buffer = Buffer.alloc(16);
+    const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+    const header = buffer.subarray(0, bytesRead);
+    if (header.toString("latin1") === SQLITE_MAGIC) return "sqlite";
+    if (header.length >= 4 && header[0] === 0x50 && header[1] === 0x4b) return "zip";
+    throw new Error("SQLiteの naver_line DB または対応バックアップZIPを選択してください");
+  } finally {
+    await handle.close();
+  }
+}
+
+async function extractAndroidZip(
+  sourcePath: string,
+  outputDir: string,
+  includeMedia: boolean,
+  onProgress?: (current: number, total: number, file?: string) => void,
+): Promise<ExtractedAndroidZip> {
+  mkdirSync(outputDir, { recursive: true });
+  const total = (await stat(sourcePath)).size;
+  let current = 0;
+  let extractedBytes = 0;
+  let extractionError: Error | null = null;
+  const databaseCandidates: Array<{ path: string; rank: number }> = [];
+  const endTasks: Promise<unknown>[] = [];
+  let dbIndex = 0;
+  let extractedMedia = false;
+
+  const unzipper = new Unzip((file) => {
+    if (extractionError) return;
+    const name = file.name.replace(/\\/g, "/").replace(/^\/+/, "");
+    const dbRank = androidDatabaseCandidateRank(name);
+    const media = includeMedia ? parseAndroidMediaEntry(name) : null;
+    if (dbRank === null && !media) return;
+
+    const declaredSize = Number(file.originalSize ?? 0);
+    if (
+      Number.isFinite(declaredSize) &&
+      declaredSize > 0 &&
+      extractedBytes + declaredSize > MAX_EXTRACT_BYTES
+    ) {
+      extractionError = new Error(
+        `Androidバックアップの展開サイズが上限 ${formatBytes(MAX_EXTRACT_BYTES)} を超えます`,
+      );
+      return;
+    }
+
+    const target = media
+      ? join(outputDir, "media", media.chatMid, media.fileName)
+      : join(outputDir, `database-${dbIndex++}.sqlite`);
+    mkdirSync(dirname(target), { recursive: true });
+    const writer = Bun.file(target).writer({ highWaterMark: 1024 * 1024 });
+    let writtenForFile = 0;
+    file.ondata = (error, chunk, final) => {
+      if (error) {
+        extractionError = error instanceof Error ? error : new Error(String(error));
+        try {
+          file.terminate();
+        } catch {
+          // ignore
+        }
+        return;
+      }
+      try {
+        writtenForFile += chunk.byteLength;
+        extractedBytes += chunk.byteLength;
+        if (extractedBytes > MAX_EXTRACT_BYTES) {
+          extractionError = new Error(
+            `Androidバックアップの展開サイズが上限 ${formatBytes(MAX_EXTRACT_BYTES)} を超えます`,
+          );
+          file.terminate();
+          return;
+        }
+        if (chunk.byteLength > 0) writer.write(chunk);
+        if (final) {
+          endTasks.push(Promise.resolve(writer.end()));
+          if (media) {
+            extractedMedia = extractedMedia || writtenForFile > 0;
+          } else {
+            databaseCandidates.push({ path: target, rank: dbRank ?? 99 });
+          }
+        }
+      } catch (writeError) {
+        extractionError =
+          writeError instanceof Error ? writeError : new Error(String(writeError));
+        try {
+          file.terminate();
+        } catch {
+          // ignore
+        }
+      }
+    };
+    onProgress?.(current, total, basename(name));
+    file.start();
+  });
+  unzipper.register(UnzipInflate);
+
+  for await (const chunk of Bun.file(sourcePath).stream()) {
+    const bytes = chunk instanceof Uint8Array ? chunk : new Uint8Array(chunk);
+    current += bytes.byteLength;
+    unzipper.push(bytes, false);
+    if (extractionError) throw extractionError;
+    onProgress?.(Math.min(current, total), total);
+  }
+  unzipper.push(new Uint8Array(), true);
+  if (extractionError) throw extractionError;
+  await Promise.all(endTasks);
+
+  const database = databaseCandidates.sort((a, b) => a.rank - b.rank)[0];
+  if (!database || !existsSync(database.path)) {
+    throw new Error("ZIP内に naver_line DB が見つかりませんでした");
+  }
+  return {
+    databasePath: database.path,
+    mediaRoot: includeMedia && extractedMedia ? join(outputDir, "media") : null,
+  };
+}
+
+function androidDatabaseCandidateRank(name: string): number | null {
+  const lower = name.toLowerCase();
+  if (/(^|\/)database\/naver_line(?:\.db)?$/.test(lower)) return 0;
+  if (/(^|\/)naver_line(?:\.db)?$/.test(lower)) return 1;
+  if (/(^|\/)chats\/naver_line_backup_[^/]+\.db$/.test(lower)) return 2;
+  return null;
+}
+
+function parseAndroidMediaEntry(
+  name: string,
+): { chatMid: string; fileName: string } | null {
+  const match = name.match(
+    /(?:^|\/)chats\/([a-z0-9_-]{4,128})\/messages\/(\d+)(\.original|\.thumb)?$/i,
+  );
+  if (!match) return null;
+  return { chatMid: match[1], fileName: `${match[2]}${match[3] ?? ""}` };
+}
+
+export function parseAndroidDatabase(dbPath: string, selfMid: string): ParsedAndroidDatabase {
+  const db = new Database(dbPath, { readonly: true, safeIntegers: true, strict: true });
+  try {
+    const tables = new Set(
+      (db.query("SELECT name FROM sqlite_master WHERE type = 'table'").all() as AndroidRow[])
+        .map((row) => asString(row.name))
+        .filter(Boolean),
+    );
+    if (!tables.has("chat_history")) {
+      throw new Error("chat_history テーブルがないため、LINE Androidの naver_line DB として読めません");
+    }
+
+    const databaseVersion = Number(
+      (db.query("PRAGMA user_version").get() as AndroidRow | null)?.user_version ?? 0,
+    );
+    const chatRows = tables.has("chat")
+      ? (db.query("SELECT * FROM chat").all() as AndroidRow[])
+      : [];
+    const historyRows = db.query("SELECT * FROM chat_history").all() as AndroidRow[];
+    const groupRows = tables.has("groups")
+      ? (db.query("SELECT * FROM groups").all() as AndroidRow[])
+      : [];
+    const contactRows = tables.has("contacts")
+      ? (db.query("SELECT * FROM contacts").all() as AndroidRow[])
+      : [];
+    const reactionRows = tables.has("reactions")
+      ? (db.query("SELECT * FROM reactions").all() as AndroidRow[])
+      : [];
+
+    const groupNames = new Map<string, string>();
+    for (const row of groupRows) {
+      const mid = firstString(row, ["id", "mid", "m_id"]);
+      const name = firstString(row, ["name", "group_name", "display_name"]);
+      if (mid && name) groupNames.set(mid, name);
+    }
+
+    const contactNames = new Map<string, string>();
+    for (const row of contactRows) {
+      const mid = firstString(row, ["m_id", "mid", "id"]);
+      const name = firstString(row, ["custom_name", "name", "display_name", "contact_name"]);
+      if (mid && name) contactNames.set(mid, name);
+    }
+
+    const {
+      byMessage: reactionsByMessage,
+      unsupportedByMessage,
+      restored,
+      unsupported,
+    } = parseAndroidReactions(reactionRows);
+    const savedAt = new Date().toISOString();
+    const messages: Record<string, Record<string, StoredMessage>> = {};
+    const mediaRefsByMessage = new Map<string, AndroidMediaRef>();
+
+    for (const row of historyRows) {
+      const chatMid = asString(row.chat_id);
+      const localId = asString(row.id);
+      if (!chatMid || !localId) continue;
+      const rawServerId = asString(row.server_id);
+      const messageId = rawServerId && rawServerId !== "0" ? rawServerId : `android-local-${localId}`;
+      const rawFrom = asString(row.from_mid);
+      const isMyMessage = !rawFrom || rawFrom === selfMid;
+      const from = isMyMessage ? selfMid : rawFrom;
+      const historyType = asNumber(row.type);
+      const attachmentType = asNumber(row.attachement_type);
+      const rawParameter = asNullableString(row.parameter);
+      const parsedMetadata = parseAndroidParameter(rawParameter);
+      const unsupportedReactionPayloads = unsupportedByMessage.get(messageId);
+      const contentMetadata: MessageContentMeta | null =
+        parsedMetadata || unsupportedReactionPayloads?.length
+          ? {
+              ...(parsedMetadata ?? {}),
+              ...(unsupportedReactionPayloads?.length
+                ? { ANDROID_CUSTOM_REACTIONS: JSON.stringify(unsupportedReactionPayloads) }
+                : {}),
+            }
+          : null;
+      const contentType = androidContentType(historyType, attachmentType);
+      const relationType = String(contentMetadata?.message_relation_type_code ?? "").toLowerCase();
+      const relationId = String(contentMetadata?.message_relation_server_message_id ?? "").trim();
+      const createdTime = asNumber(row.created_time);
+      const readCount = asNumber(row.read_count);
+      const reactions = reactionsByMessage.get(messageId);
+      const unsent = isAndroidUnsentRow(historyType, rawParameter);
+      const stickerOption = String(contentMetadata?.STKOPT ?? "").toUpperCase();
+
+      const message: StoredMessage = {
+        id: messageId,
+        chatMid,
+        from,
+        to: isMyMessage ? chatMid : selfMid,
+        text: unsent ? null : asNullableString(row.content),
+        contentType: unsent ? "UNSENT" : contentType,
+        createdTime: Number.isFinite(createdTime) ? createdTime : 0,
+        isMyMessage,
+        ...(contentMetadata ? { contentMetadata } : {}),
+        ...(readCount > 0 ? { readCount } : {}),
+        ...(relationType === "reply" && relationId ? { relatedMessageId: relationId } : {}),
+        ...(stickerOption.includes("A") ? { stickerAnimated: true } : {}),
+        ...(reactions?.length ? { reactions } : {}),
+        ...(unsent
+          ? { messageState: isMyMessage ? "revoked-by-self" : "revoked-by-other" }
+          : {}),
+        savedAt,
+      };
+      const byChat = (messages[chatMid] ??= {});
+      byChat[messageId] = mergeAndroidDuplicateMessage(byChat[messageId], message);
+
+      if (MEDIA_CONTENT_TYPES.has(contentType)) {
+        mediaRefsByMessage.set(`${chatMid}:${messageId}`, {
+          chatMid,
+          localId,
+          messageId,
+          contentType,
+        });
+      }
+    }
+
+    const chatRowsByMid = new Map<string, AndroidRow>();
+    for (const row of chatRows) {
+      const chatMid = asString(row.chat_id);
+      if (chatMid) chatRowsByMid.set(chatMid, row);
+    }
+
+    const chats: Record<string, StoredChat> = {};
+    const allChatMids = new Set([...chatRowsByMid.keys(), ...Object.keys(messages)]);
+    for (const chatMid of allChatMids) {
+      const row = chatRowsByMid.get(chatMid);
+      const byChat = Object.values(messages[chatMid] ?? {}).sort(
+        (a, b) => a.createdTime - b.createdTime || compareId(a.id, b.id),
+      );
+      const latest = byChat.at(-1);
+      const declaredName = row ? asString(row.chat_name) : "";
+      const name = declaredName || groupNames.get(chatMid) || contactNames.get(chatMid) || chatMid;
+      const messageCount = row ? asNumber(row.message_count) : byChat.length;
+      const readMessageCount = row ? asNumber(row.read_message_count) : messageCount;
+      const unreadCount = Math.max(0, messageCount - readMessageCount);
+      chats[chatMid] = {
+        mid: chatMid,
+        name,
+        kind: androidChatKind(chatMid, row ? asNumber(row.type) : 0),
+        hasMessages: byChat.length > 0,
+        ...(latest
+          ? {
+              lastMessageTime: latest.createdTime,
+              lastMessageId: latest.id,
+              lastMessagePreview: previewForStoredMessage(latest),
+            }
+          : {}),
+        ...(unreadCount > 0 ? { unreadCount } : {}),
+        updatedAt: savedAt,
+      };
+    }
+
+    return {
+      records: { chats, messages },
+      mediaRefs: [...mediaRefsByMessage.values()],
+      databaseVersion,
+      reactions: restored,
+      unsupportedReactions: unsupported,
+    };
+  } finally {
+    db.close();
+  }
+}
+
+function isAndroidUnsentRow(historyType: number, rawParameter: string | null): boolean {
+  if (UNSENT_HISTORY_TYPES.has(historyType)) return true;
+  const marker = rawParameter?.trim().toLowerCase() ?? "";
+  return marker === "limesunsend" || marker === "leinsunsend";
+}
+
+function isStoredUnsent(message: StoredMessage): boolean {
+  return (
+    message.contentType === "UNSENT" ||
+    message.messageState === "revoked-by-self" ||
+    message.messageState === "revoked-by-other"
+  );
+}
+
+function snapshotFromAndroidMessage(message: StoredMessage): MessageSnapshot {
+  const {
+    chatMid: _chatMid,
+    savedAt: _savedAt,
+    history: _history,
+    revokedSnapshot: _revokedSnapshot,
+    ...snapshot
+  } = message;
+  return snapshot;
+}
+
+function mergeAndroidDuplicateMessage(
+  previous: StoredMessage | undefined,
+  incoming: StoredMessage,
+): StoredMessage {
+  if (!previous) return incoming;
+  const previousUnsent = isStoredUnsent(previous);
+  const incomingUnsent = isStoredUnsent(incoming);
+
+  if (incomingUnsent && !previousUnsent) {
+    return {
+      ...previous,
+      contentType: "UNSENT",
+      text: null,
+      messageState: previous.isMyMessage ? "revoked-by-self" : "revoked-by-other",
+      revokedSnapshot: previous.revokedSnapshot ?? snapshotFromAndroidMessage(previous),
+      history: [
+        ...(previous.history ?? []),
+        {
+          state: previous.messageState ?? "normal",
+          text: previous.text,
+          contentType: previous.contentType,
+          updatedTime: incoming.createdTime || previous.createdTime,
+        },
+      ],
+      ...(incoming.reactions?.length ? { reactions: incoming.reactions } : {}),
+      savedAt: incoming.savedAt,
+    };
+  }
+
+  if (previousUnsent && !incomingUnsent) {
+    return {
+      ...previous,
+      revokedSnapshot: previous.revokedSnapshot ?? snapshotFromAndroidMessage(incoming),
+      history: previous.history?.length
+        ? previous.history
+        : [
+            {
+              state: incoming.messageState ?? "normal",
+              text: incoming.text,
+              contentType: incoming.contentType,
+              updatedTime: previous.createdTime || incoming.createdTime,
+            },
+          ],
+      ...(incoming.reactions?.length ? { reactions: incoming.reactions } : {}),
+    };
+  }
+
+  if (previousUnsent && incomingUnsent) {
+    return {
+      ...previous,
+      ...(incoming.reactions?.length ? { reactions: incoming.reactions } : {}),
+    };
+  }
+
+  return androidMessageRichness(incoming) > androidMessageRichness(previous) ? incoming : previous;
+}
+
+function androidMessageRichness(message: StoredMessage): number {
+  let score = 0;
+  if (message.contentType !== "NONE" && !message.contentType.startsWith("ANDROID_")) score += 4;
+  if (message.text?.trim()) score += 2;
+  if (message.contentMetadata && Object.keys(message.contentMetadata).length > 0) score += 2;
+  if (message.relatedMessageId) score += 1;
+  if (message.reactions?.length) score += 1;
+  return score;
+}
+
+export function parseAndroidParameter(value: string | null): MessageContentMeta | null {
+  if (!value) return null;
+  const parts = value.split("\t");
+  const output: MessageContentMeta = {};
+  for (let i = 0; i + 1 < parts.length; i += 2) {
+    const key = parts[i]?.trim();
+    if (!key) continue;
+    output[key] = parts[i + 1] ?? "";
+  }
+  if (parts.length % 2 === 1 && parts.at(-1)?.trim()) {
+    output.ANDROID_PARAMETER_EXTRA = parts.at(-1) ?? "";
+  }
+  return Object.keys(output).length > 0 ? output : null;
+}
+
+export function androidContentType(historyType: number, attachmentType: number): string {
+  if (UNSENT_HISTORY_TYPES.has(historyType)) return "UNSENT";
+  switch (attachmentType) {
+    case 0:
+      return historyType === 1 ? "NONE" : historyType > 1 ? `ANDROID_${historyType}` : "NONE";
+    case 1:
+      return "IMAGE";
+    case 2:
+      return "VIDEO";
+    case 3:
+      return "AUDIO";
+    case 6:
+      return "CALL";
+    case 7:
+      return "STICKER";
+    case 13:
+      return "CONTACT";
+    case 14:
+      return "FILE";
+    case 15:
+      return "LOCATION";
+    case 16:
+      return "POSTNOTIFICATION";
+    case 17:
+      return "RICH";
+    case 18:
+      return "CHATEVENT";
+    case 22:
+      return "FLEX";
+    default:
+      return String(attachmentType);
+  }
+}
+
+function parseAndroidReactions(rows: AndroidRow[]): {
+  byMessage: Map<string, MessageReaction[]>;
+  unsupportedByMessage: Map<
+    string,
+    Array<{ fromMid: string; atMillis: number; reactionType: string; customReaction: string }>
+  >;
+  restored: number;
+  unsupported: number;
+} {
+  const byMessage = new Map<string, MessageReaction[]>();
+  const unsupportedByMessage = new Map<
+    string,
+    Array<{ fromMid: string; atMillis: number; reactionType: string; customReaction: string }>
+  >();
+  let restored = 0;
+  let unsupported = 0;
+  for (const row of rows) {
+    const messageId = asString(row.server_message_id);
+    const fromMid = asString(row.member_id);
+    const reactionType = asString(row.reaction_type);
+    const customReaction = asString(row.custom_reaction);
+    const type = androidReactionType(reactionType);
+    if (!messageId || !fromMid || !type) {
+      if (reactionType || customReaction) {
+        unsupported++;
+        if (messageId) {
+          const list = unsupportedByMessage.get(messageId) ?? [];
+          list.push({
+            fromMid,
+            atMillis: asNumber(row.reaction_time_millis),
+            reactionType,
+            customReaction,
+          });
+          unsupportedByMessage.set(messageId, list);
+        }
+      }
+      continue;
+    }
+    const reaction: MessageReaction = {
+      fromMid,
+      atMillis: asNumber(row.reaction_time_millis),
+      type,
+    };
+    const list = byMessage.get(messageId) ?? [];
+    list.push(reaction);
+    byMessage.set(messageId, list);
+    restored++;
+  }
+  return { byMessage, unsupportedByMessage, restored, unsupported };
+}
+
+function androidReactionType(value: string): number | null {
+  switch (value.trim().toLowerCase()) {
+    case "nice":
+      return 2;
+    case "love":
+      return 3;
+    case "fun":
+      return 4;
+    case "amazing":
+      return 5;
+    case "sad":
+      return 6;
+    case "omg":
+      return 7;
+    default:
+      return null;
+  }
+}
+
+async function restoreAndroidMedia(
+  accountId: string,
+  mediaRoot: string,
+  refs: AndroidMediaRef[],
+  onProgress?: (current: number, total: number) => void,
+): Promise<{ restored: number; skipped: number }> {
+  let restored = 0;
+  let skipped = 0;
+  let current = 0;
+  onProgress?.(0, refs.length);
+  for (const ref of refs) {
+    const candidates = [
+      join(mediaRoot, ref.chatMid, `${ref.localId}.original`),
+      join(mediaRoot, ref.chatMid, ref.localId),
+      ...(ref.contentType === "IMAGE"
+        ? [join(mediaRoot, ref.chatMid, `${ref.localId}.thumb`)]
+        : []),
+    ];
+    const path = candidates.find((candidate) => existsSync(candidate));
+    if (!path) {
+      skipped++;
+      current++;
+      onProgress?.(current, refs.length);
+      continue;
+    }
+    try {
+      const bytes = new Uint8Array(await readFile(path));
+      await writeMediaStorage(
+        accountId,
+        ref.chatMid,
+        ref.messageId,
+        bytes,
+        sniffMediaMime(bytes, ref.contentType),
+      );
+      restored++;
+    } catch {
+      skipped++;
+    }
+    current++;
+    onProgress?.(current, refs.length);
+  }
+  return { restored, skipped };
+}
+
+function sniffMediaMime(bytes: Uint8Array, kind: string): string {
+  if (bytes.length >= 8 && bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4e) {
+    return "image/png";
+  }
+  if (bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) {
+    return "image/jpeg";
+  }
+  if (bytes.length >= 6) {
+    const head = Buffer.from(bytes.subarray(0, 6)).toString("ascii");
+    if (head === "GIF87a" || head === "GIF89a") return "image/gif";
+  }
+  if (
+    bytes.length >= 12 &&
+    Buffer.from(bytes.subarray(0, 4)).toString("ascii") === "RIFF" &&
+    Buffer.from(bytes.subarray(8, 12)).toString("ascii") === "WEBP"
+  ) {
+    return "image/webp";
+  }
+  if (
+    bytes.length >= 12 &&
+    Buffer.from(bytes.subarray(4, 8)).toString("ascii") === "ftyp"
+  ) {
+    return kind === "AUDIO" ? "audio/mp4" : "video/mp4";
+  }
+  if (bytes.length >= 3 && Buffer.from(bytes.subarray(0, 3)).toString("ascii") === "ID3") {
+    return "audio/mpeg";
+  }
+  if (bytes.length >= 2 && bytes[0] === 0xff && (bytes[1] & 0xe0) === 0xe0) {
+    return "audio/mpeg";
+  }
+  if (bytes.length >= 5 && Buffer.from(bytes.subarray(0, 5)).toString("ascii") === "%PDF-") {
+    return "application/pdf";
+  }
+  if (kind === "IMAGE") return "image/jpeg";
+  if (kind === "VIDEO") return "video/mp4";
+  if (kind === "AUDIO") return "audio/mp4";
+  return "application/octet-stream";
+}
+
+function androidChatKind(chatMid: string, type: number): StoredChat["kind"] {
+  if (chatMid.startsWith("u") || type === 1) return "direct";
+  if (chatMid.startsWith("c") || chatMid.startsWith("r") || type === 2 || type === 3) {
+    return "group";
+  }
+  return "unknown";
+}
+
+function previewForStoredMessage(message: StoredMessage): string {
+  const text = message.text?.trim();
+  if (text) return text.slice(0, 120);
+  switch (message.contentType) {
+    case "IMAGE":
+      return "画像";
+    case "VIDEO":
+      return "動画";
+    case "AUDIO":
+      return "音声";
+    case "FILE":
+      return "ファイル";
+    case "STICKER":
+      return "スタンプ";
+    case "UNSENT":
+      return "送信を取り消したメッセージ";
+    case "CHATEVENT":
+      return "チャットイベント";
+    case "CALL":
+      return "通話";
+    default:
+      return message.contentType || "メッセージ";
+  }
+}
+
+function compareId(left: string, right: string): number {
+  try {
+    const a = BigInt(left);
+    const b = BigInt(right);
+    return a === b ? 0 : a < b ? -1 : 1;
+  } catch {
+    return left.localeCompare(right);
+  }
+}
+
+function firstString(row: AndroidRow, keys: string[]): string {
+  for (const key of keys) {
+    const value = asString(row[key]);
+    if (value) return value;
+  }
+  return "";
+}
+
+function asString(value: SqlValue | undefined): string {
+  if (value === null || value === undefined) return "";
+  if (value instanceof Uint8Array) return "";
+  return String(value);
+}
+
+function asNullableString(value: SqlValue | undefined): string | null {
+  if (value === null || value === undefined || value instanceof Uint8Array) return null;
+  return String(value);
+}
+
+function asNumber(value: SqlValue | undefined): number {
+  if (typeof value === "number") return Number.isFinite(value) ? value : 0;
+  if (typeof value === "bigint") return Number(value);
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+}
+
+function sanitizeDisplayName(value: string): string {
+  const decoded = (() => {
+    try {
+      return decodeURIComponent(value);
+    } catch {
+      return value;
+    }
+  })();
+  return basename(decoded.replace(/\\/g, "/")).slice(0, 180) || "naver_line";
+}
+
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  const index = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  return `${(bytes / 1024 ** index).toFixed(index === 0 ? 0 : 1)} ${units[index]}`;
+}

--- a/Vyline/backend/src/service/androidBackupService.ts
+++ b/Vyline/backend/src/service/androidBackupService.ts
@@ -732,6 +732,7 @@ export function parseAndroidDatabase(dbPath: string, selfMid: string): ParsedAnd
         name,
         kind: androidChatKind(chatMid, row ? asNumber(row.type) : 0),
         hasMessages: byChat.length > 0,
+        restoredHistory: true,
         ...(latest
           ? {
               lastMessageTime: latest.createdTime,

--- a/Vyline/backend/src/service/iosBackupService.test.ts
+++ b/Vyline/backend/src/service/iosBackupService.test.ts
@@ -50,4 +50,49 @@ describe("historyToChatDb", () => {
       isMyMessage: false,
     });
   });
+
+  test("keeps received group messages addressed to the group chat", () => {
+    const result = historyToChatDb(
+      {
+        account: "u-me",
+        exportedAt: "2026-08-24T00:00:00.000Z",
+        chats: [
+          {
+            chatMid: "c-group",
+            kind: "group",
+            name: "Group",
+            count: 1,
+            firstIso: null,
+            lastIso: null,
+            file: "c-group.jsonl",
+          },
+        ],
+        messages: new Map([
+          [
+            "c-group",
+            [
+              {
+                id: 99,
+                ts: 1_755_984_000_000,
+                iso: null,
+                contentType: 0,
+                sendStatus: 0,
+                fromMid: "u-peer",
+                fromName: "Peer",
+                text: "group hello",
+                contentMetadata: null,
+              },
+            ],
+          ],
+        ]),
+      },
+      "u-account-fallback",
+    );
+
+    expect(result.messages["c-group"]?.["99"]).toMatchObject({
+      from: "u-peer",
+      to: "c-group",
+      isMyMessage: false,
+    });
+  });
 });

--- a/Vyline/backend/src/service/iosBackupService.ts
+++ b/Vyline/backend/src/service/iosBackupService.ts
@@ -376,7 +376,10 @@ function mapMessage(
     id: String(message.id),
     chatMid,
     from,
-    to: isMyMessage ? chatMid : myMid,
+    // Group/room recipients are the chat MID for both sent and received messages.
+    // Keeping received restores pointed at myMid causes them to be filtered out in the UI.
+    to:
+      isMyMessage || chatMid.startsWith("c") || chatMid.startsWith("r") ? chatMid : myMid,
     text: message.text,
     contentType: iosContentType(message.contentType),
     createdTime: Number.isFinite(message.ts) ? message.ts : 0,

--- a/Vyline/backend/src/service/lineService.ts
+++ b/Vyline/backend/src/service/lineService.ts
@@ -2584,6 +2584,7 @@ function chatFromMessageBox(
       statusMessage?: string;
     }
   >,
+  joinedChatsKnown = true,
 ): Chat {
   const mid = String(box.id);
   const meta = boxMeta(box);
@@ -2591,7 +2592,8 @@ function chatFromMessageBox(
 
   if (kind === "group" || kind === "room") {
     const group = groupByMid.get(mid);
-    const left = !group; // messageBox にあるが joined に無い = 退出・キック済み
+    // joinedChats の取得自体が失敗した場合は「退出済み」と誤判定しない。
+    const left = joinedChatsKnown ? !group : false;
     const raw = group?.raw ?? {};
     const ps = String(raw.pictureStatus ?? raw.picturePath ?? "");
     const chat: Chat = {
@@ -2730,11 +2732,13 @@ async function fetchChatsCore(
 
 async function fetchChatsInner(accountId: string, opts?: { light?: boolean }): Promise<Chat[]> {
   const client = requireClient(accountId);
+  let joinedChatsFetchFailed = false;
 
   const [messageBoxes, joinedChats, users] = await Promise.all([
     fetchMessageBoxesCached(accountId, client, { forChats: true }),
     client.fetchJoinedChats().catch((err) => {
-      log.warn({ accountId, err }, "fetchJoinedChats failed — skipping groups");
+      joinedChatsFetchFailed = true;
+      log.warn({ accountId, err }, "fetchJoinedChats failed — preserving cached groups");
       return [] as Awaited<ReturnType<VylineClient["fetchJoinedChats"]>>;
     }),
     client.fetchUsers().catch((err) => {
@@ -2827,7 +2831,7 @@ async function fetchChatsInner(accountId: string, opts?: { light?: boolean }): P
 
   // Desktop 準拠: getMessageBoxes の返却順 = 最新メッセージ順（再ソートしない）
   for (const box of messageBoxes) {
-    const chat = chatFromMessageBox(box, groupByMid, userByMid);
+    const chat = chatFromMessageBox(box, groupByMid, userByMid, !joinedChatsFetchFailed);
     seen.add(chat.mid);
     result.push(chat);
   }
@@ -3010,17 +3014,56 @@ async function fetchChatsInner(accountId: string, opts?: { light?: boolean }): P
     void vylinePutGroup(accountId, put);
   }
 
+  // 通常RPCに現れない復元済みチャットも一覧から消さない。
+  // upsertChats は復元名・種別・最新履歴を保持するため、ここでディスク順を正本にして
+  // live-only の left / official / profile 情報だけ重ねる。
+  const storedChats = await getStoredChats(accountId);
+  const liveByMid = new Map(result.map((chat) => [chat.mid, chat]));
+  const mergedResult = storedChats.map((stored) => {
+    const live = liveByMid.get(stored.mid);
+    if (!live) return stored;
+    const storedTime = stored.lastMessageTime ?? 0;
+    const liveTime = live.lastMessageTime ?? 0;
+    const useStoredLast = storedTime > liveTime;
+    const liveNameIsFallback =
+      !live.name || live.name === live.mid || live.name === "(No Name)";
+    return {
+      ...stored,
+      ...live,
+      name: liveNameIsFallback && stored.name ? stored.name : live.name,
+      kind: live.kind === "unknown" ? stored.kind : live.kind,
+      hasMessages: stored.hasMessages || live.hasMessages,
+      lastMessageTime: Math.max(storedTime, liveTime),
+      ...(useStoredLast && stored.lastMessageId
+        ? { lastMessageId: stored.lastMessageId }
+        : live.lastMessageId
+          ? { lastMessageId: live.lastMessageId }
+          : stored.lastMessageId
+            ? { lastMessageId: stored.lastMessageId }
+            : {}),
+      ...(useStoredLast && stored.lastMessagePreview
+        ? { lastMessagePreview: stored.lastMessagePreview }
+        : live.lastMessagePreview
+          ? { lastMessagePreview: live.lastMessagePreview }
+          : stored.lastMessagePreview
+            ? { lastMessagePreview: stored.lastMessagePreview }
+            : {}),
+      ...(stored.restoredHistory || live.restoredHistory ? { restoredHistory: true } : {}),
+    };
+  });
+
   log.debug(
     {
       accountId,
-      count: result.length,
+      count: mergedResult.length,
       activeBoxes: messageBoxes.length,
       friends: users.length,
       groups: joinedChats.length,
+      restoredOnly: mergedResult.filter((chat) => !liveByMid.has(chat.mid)).length,
     },
-    "chats fetched (desktop messageBox order)",
+    "chats fetched (desktop messageBox order + restored history)",
   );
-  return result;
+  return mergedResult;
 }
 
 /** 復号済み Thrift メッセージ → API Message */

--- a/Vyline/backend/src/service/lineService.ts
+++ b/Vyline/backend/src/service/lineService.ts
@@ -72,7 +72,6 @@ import {
   getStoredMessages,
   getBootstrapPayload,
   getCacheMeta,
-  messageSyncAgeMs,
   upsertChats,
   upsertMessages,
   markStoredMessagesReadThrough,
@@ -738,7 +737,6 @@ const readRangeBgAt = new Map<string, number>();
 type ChatsCacheEntry = { at: number; chats: Chat[] };
 const chatsCache = new Map<string, ChatsCacheEntry>();
 const CHATS_CACHE_MS = Number(process.env.VYLINE_CHATS_CACHE_MS ?? 60_000);
-const MESSAGE_LOCAL_STALE_MS = Number(process.env.VYLINE_MESSAGE_LOCAL_STALE_MS ?? 90_000);
 
 type MessageBoxesCacheEntry = {
   at: number;
@@ -2638,13 +2636,9 @@ export async function fetchBootstrap(accountId: string): Promise<BootstrapPayloa
 }
 
 export async function warmLineCache(accountId: string): Promise<void> {
+  // セッション/プロフィール等の軽量キャッシュだけを温める。
+  // メッセージ履歴の一括インデックスは暗黙実行しない。
   await warmAccountCache(accountId);
-  // 初回インデックス（裏）— 履歴・プロフィールを chatdb / VylineCache へ
-  // runAccountIndex 内の fetchChats が必要な RPC を同じキューに入れるため、
-  // ここで外側まで enqueue すると初回起動時に自己待機になる。
-  void runAccountIndex(accountId, { topChats: 16, messagesPerChat: 30 }).catch((err) => {
-    log.debug({ accountId, err }, "background account index failed");
-  });
 }
 
 export async function fetchChats(
@@ -3546,24 +3540,8 @@ export async function fetchMessages(
   if (!opts?.force && !isPagination && !isSpecial) {
     const local = await getStoredMessages(accountId, chatMid, limit);
     if (local.length > 0) {
-      const meta = await getCacheMeta(accountId);
-      const age = messageSyncAgeMs(meta, chatMid);
-      if (age == null || age > MESSAGE_LOCAL_STALE_MS) {
-        void enqueueTalkRpcBackground(accountId, () =>
-          fetchMessagesInner(accountId, chatMid, limit, { ...opts, lite: true }).catch((err) => {
-            log.debug(
-              {
-                accountId,
-                chatMid,
-                err: err instanceof Error ? err.message : String(err),
-              },
-              "background message sync failed",
-            );
-          }),
-        );
-      }
-      const cacheDict = await readRangeStorage.load(accountId);
-      const cached = cacheDict[chatMid]?.ranges ?? [];
+      // local-first は本当に local-only にする。表示要求に便乗した履歴RPCは発火させない。
+      // 新着は push / delta、明示同期は force 経路が担当する。
       return local;
     }
   }

--- a/Vyline/backend/src/storage/chatStore.iosRestore.test.ts
+++ b/Vyline/backend/src/storage/chatStore.iosRestore.test.ts
@@ -70,6 +70,32 @@ describe("mergeChatDbRecords", () => {
     expect(target.messages["u-chat"]?.["2"]?.text).toBe("imported");
   });
 
+
+  test("repairs a cached c* chat to group and keeps restored-history visibility", () => {
+    const existing = chat("c-group", "c-group", 500);
+    existing.kind = "direct";
+    const imported = chat("c-group", "Restored group", 400);
+    imported.kind = "group";
+    imported.restoredHistory = true;
+    const target: ChatDbRecords = {
+      chats: { "c-group": existing },
+      messages: { "c-group": { "1": message("1", "c-group", "local") } },
+    };
+
+    mergeChatDbRecords(target, {
+      chats: { "c-group": imported },
+      messages: { "c-group": { "2": message("2", "c-group", "restored") } },
+    });
+
+    expect(target.chats["c-group"]).toMatchObject({
+      name: "Restored group",
+      kind: "group",
+      restoredHistory: true,
+      hasMessages: true,
+    });
+    expect(target.messages["c-group"]?.["2"]?.text).toBe("restored");
+  });
+
   test("is idempotent when the same backup is merged twice", () => {
     const target: ChatDbRecords = { chats: {}, messages: {} };
     const incoming = {

--- a/Vyline/backend/src/storage/chatStore.iosRestore.test.ts
+++ b/Vyline/backend/src/storage/chatStore.iosRestore.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   compareMessagesNewestFirst,
   mergeChatDbRecords,
+  rebuildChatDbRecords,
   type ChatDbRecords,
   type StoredChat,
   type StoredMessage,
@@ -70,6 +71,25 @@ describe("mergeChatDbRecords", () => {
     expect(target.messages["u-chat"]?.["2"]?.text).toBe("imported");
   });
 
+
+  test("repairs legacy restored group recipients and preserves restored-history flag", () => {
+    const restoredGroup = chat("c-group", "Restored group", 100);
+    restoredGroup.kind = "group";
+    restoredGroup.restoredHistory = true;
+    const received = message("1", "c-group", "from peer");
+    received.from = "u-peer";
+    received.to = "u-me"; // legacy restore bug
+    received.isMyMessage = false;
+    const target: ChatDbRecords = {
+      chats: { "c-group": restoredGroup },
+      messages: { "c-group": { "1": received } },
+    };
+
+    rebuildChatDbRecords(target);
+
+    expect(target.messages["c-group"]?.["1"]?.to).toBe("c-group");
+    expect(target.chats["c-group"]?.restoredHistory).toBe(true);
+  });
 
   test("repairs a cached c* chat to group and keeps restored-history visibility", () => {
     const existing = chat("c-group", "c-group", 500);

--- a/Vyline/backend/src/storage/chatStore.ts
+++ b/Vyline/backend/src/storage/chatStore.ts
@@ -18,6 +18,7 @@ import type {
 } from "@vyline/types";
 import { childLogger } from "../logger.js";
 import { accountFile, readAccountJson } from "./accountDirs.js";
+import { writeTextAtomic } from "./safeFile.js";
 
 const log = childLogger("chatStore");
 const _dir = dirname(fileURLToPath(import.meta.url));
@@ -139,7 +140,9 @@ function previewForMessage(message: StoredMessage): string {
 
 const memory = new Map<string, ChatDb>();
 const dirty = new Set<string>();
+const dirtyVersion = new Map<string, number>();
 const saveTimers = new Map<string, ReturnType<typeof setTimeout>>();
+const flushInFlight = new Map<string, Promise<void>>();
 
 function dbPath(accountId: string): string {
   return accountFile(accountId, "chatdb.json");
@@ -210,12 +213,16 @@ function snapshotFromStoredMessage(stored: StoredMessage): MessageSnapshot {
 
 function scheduleSave(accountId: string): void {
   dirty.add(accountId);
+  dirtyVersion.set(accountId, (dirtyVersion.get(accountId) ?? 0) + 1);
   const prev = saveTimers.get(accountId);
   if (prev) clearTimeout(prev);
   saveTimers.set(
     accountId,
     setTimeout(() => {
-      void flushDb(accountId);
+      saveTimers.delete(accountId);
+      // Background saves are best-effort, but failures remain dirty so an
+      // explicit restore/rebuild flush can retry and surface the error.
+      void flushDb(accountId).catch(() => undefined);
     }, SAVE_DEBOUNCE_MS),
   );
 }
@@ -235,15 +242,46 @@ export function mergeStoredReadState(
 }
 
 async function flushDb(accountId: string): Promise<void> {
+  const existingFlush = flushInFlight.get(accountId);
+  if (existingFlush) return existingFlush;
   if (!dirty.has(accountId)) return;
-  dirty.delete(accountId);
-  const db = memory.get(accountId);
-  if (!db) return;
-  await ensureDataDir();
+
+  const run = (async () => {
+    while (dirty.has(accountId)) {
+      const db = memory.get(accountId);
+      if (!db) {
+        dirty.delete(accountId);
+        return;
+      }
+
+      await ensureDataDir();
+      const version = dirtyVersion.get(accountId) ?? 0;
+      // Serialize before the asynchronous write starts so mutations that occur
+      // during I/O can be detected by dirtyVersion and written in a second pass.
+      const serialized = JSON.stringify(db);
+      try {
+        await writeTextAtomic(dbPath(accountId), serialized);
+      } catch (err) {
+        // Never convert a failed restore into a successful in-memory-only one.
+        // Keep the DB dirty and let explicit flush callers observe the error.
+        dirty.add(accountId);
+        log.warn({ accountId, err }, "failed to save chat db");
+        throw err;
+      }
+
+      if ((dirtyVersion.get(accountId) ?? 0) === version) {
+        dirty.delete(accountId);
+      }
+      // If another mutation happened while writing, dirty remains set and the
+      // loop atomically writes the newer snapshot before resolving.
+    }
+  })();
+
+  flushInFlight.set(accountId, run);
   try {
-    await writeFile(dbPath(accountId), JSON.stringify(db), "utf-8");
-  } catch (err) {
-    log.warn({ accountId, err }, "failed to save chat db");
+    await run;
+  } finally {
+    if (flushInFlight.get(accountId) === run) flushInFlight.delete(accountId);
   }
 }
 
@@ -826,7 +864,9 @@ export async function mergeImportedChatDb(
   for (const [chatMid, messages] of Object.entries(db.messages)) {
     applyLocalReadWatermark(messages, db.meta.localReadUpTo?.[chatMid]?.messageId);
   }
-  if (result.importedChats > 0 || result.importedMessages > 0) scheduleSave(accountId);
+  // mergeChatDbRecords can normalize/repair records even when every incoming
+  // message ID already exists, so every restore attempt must become durable.
+  scheduleSave(accountId);
   return result;
 }
 

--- a/Vyline/backend/src/storage/chatStore.ts
+++ b/Vyline/backend/src/storage/chatStore.ts
@@ -531,10 +531,17 @@ function storedChatToChat(stored: StoredChat): Chat {
 }
 
 function storedMessageToMessage(stored: StoredMessage): Message {
+  // Older Android/iOS restores stored received group messages with to=self MID.
+  // Normalize on read so already-imported histories become visible immediately
+  // after upgrading, without requiring users to delete or re-import chatdb.
+  const to =
+    stored.chatMid.startsWith("c") || stored.chatMid.startsWith("r")
+      ? stored.chatMid
+      : stored.to;
   const msg: Message = {
     id: stored.id,
     from: stored.from,
-    to: stored.to,
+    to,
     text: stored.text,
     contentType: stored.contentType,
     createdTime: stored.createdTime,
@@ -779,7 +786,13 @@ export function rebuildChatDbRecords(target: ChatDbRecords): { chats: number; me
   let messages = 0;
   const allMids = new Set([...Object.keys(target.chats), ...Object.keys(target.messages)]);
   for (const chatMid of allMids) {
-    const ordered = Object.values(target.messages[chatMid] ?? {}).sort(compareMessagesOldestFirst);
+    const byChat = target.messages[chatMid] ?? {};
+    // Repair legacy restore records in-place as well. LINE group/room messages
+    // always target the chat MID, regardless of who sent them.
+    if (chatMid.startsWith("c") || chatMid.startsWith("r")) {
+      for (const message of Object.values(byChat)) message.to = chatMid;
+    }
+    const ordered = Object.values(byChat).sort(compareMessagesOldestFirst);
     target.messages[chatMid] = Object.fromEntries(ordered.map((message) => [message.id, message]));
     messages += ordered.length;
     const latest = ordered.at(-1);
@@ -796,6 +809,7 @@ export function rebuildChatDbRecords(target: ChatDbRecords): { chats: number; me
       ...(existing?.thumbnailUrl ? { thumbnailUrl: existing.thumbnailUrl } : {}),
       ...(existing?.unreadCount != null ? { unreadCount: existing.unreadCount } : {}),
       ...(existing?.isOfficial != null ? { isOfficial: existing.isOfficial } : {}),
+      ...(existing?.restoredHistory ? { restoredHistory: true } : {}),
       updatedAt: existing?.updatedAt ?? latest.savedAt,
     };
   }

--- a/Vyline/backend/src/storage/chatStore.ts
+++ b/Vyline/backend/src/storage/chatStore.ts
@@ -38,6 +38,8 @@ export interface StoredChat {
   thumbnailUrl?: string;
   unreadCount?: number;
   isOfficial?: boolean;
+  /** 外部バックアップから復元された履歴を持つ。退出済みグループも履歴として表示するために使う。 */
+  restoredHistory?: boolean;
   updatedAt: string;
 }
 
@@ -258,7 +260,42 @@ export async function upsertChats(
 ): Promise<void> {
   const db = await getDb(accountId);
   for (const chat of chats) {
-    db.chats[chat.mid] = chat;
+    const existing = db.chats[chat.mid];
+    if (!existing) {
+      db.chats[chat.mid] = chat;
+      continue;
+    }
+
+    const incomingTime = chat.lastMessageTime ?? 0;
+    const existingTime = existing.lastMessageTime ?? 0;
+    const keepExistingLast = existingTime > incomingTime;
+    const incomingNameIsFallback =
+      !chat.name || chat.name === chat.mid || chat.name === "(No Name)";
+    const incomingKindIsFallback = chat.kind === "unknown";
+
+    db.chats[chat.mid] = {
+      ...existing,
+      ...chat,
+      name: incomingNameIsFallback && existing.name ? existing.name : chat.name,
+      kind: incomingKindIsFallback ? existing.kind : chat.kind,
+      hasMessages: existing.hasMessages || chat.hasMessages,
+      lastMessageTime: Math.max(existingTime, incomingTime),
+      ...(keepExistingLast && existing.lastMessageId
+        ? { lastMessageId: existing.lastMessageId }
+        : chat.lastMessageId
+          ? { lastMessageId: chat.lastMessageId }
+          : existing.lastMessageId
+            ? { lastMessageId: existing.lastMessageId }
+            : {}),
+      ...(keepExistingLast && existing.lastMessagePreview
+        ? { lastMessagePreview: existing.lastMessagePreview }
+        : chat.lastMessagePreview
+          ? { lastMessagePreview: chat.lastMessagePreview }
+          : existing.lastMessagePreview
+            ? { lastMessagePreview: existing.lastMessagePreview }
+            : {}),
+      ...(existing.restoredHistory || chat.restoredHistory ? { restoredHistory: true } : {}),
+    };
   }
   if (meta?.boxOrder) db.meta.boxOrder = meta.boxOrder;
   if (meta?.lastOpRevision != null) db.meta.lastOpRevision = meta.lastOpRevision;
@@ -489,6 +526,7 @@ function storedChatToChat(stored: StoredChat): Chat {
   if (stored.lastMessagePreview) chat.lastMessagePreview = stored.lastMessagePreview;
   if (stored.unreadCount != null) chat.unreadCount = stored.unreadCount;
   if (stored.isOfficial) chat.isOfficial = true;
+  if (stored.restoredHistory) chat.restoredHistory = true;
   return chat;
 }
 
@@ -675,9 +713,15 @@ export function mergeChatDbRecords(
 
     skippedChats++;
     const incomingIsNewer = (incomingChat.lastMessageTime ?? 0) > (existing.lastMessageTime ?? 0);
+    const incomingKindShouldWin =
+      incomingChat.kind !== "unknown" &&
+      (existing.kind === "unknown" ||
+        ((mid.startsWith("c") || mid.startsWith("r")) && incomingChat.kind === "group"));
     target.chats[mid] = {
       ...existing,
+      kind: incomingKindShouldWin ? incomingChat.kind : existing.kind,
       hasMessages: existing.hasMessages || incomingChat.hasMessages,
+      ...(existing.restoredHistory || incomingChat.restoredHistory ? { restoredHistory: true } : {}),
       lastMessageTime: Math.max(existing.lastMessageTime ?? 0, incomingChat.lastMessageTime ?? 0),
       ...(incomingIsNewer && incomingChat.lastMessageId
         ? { lastMessageId: incomingChat.lastMessageId }

--- a/Vyline/backend/src/storage/safeFile.ts
+++ b/Vyline/backend/src/storage/safeFile.ts
@@ -9,17 +9,25 @@ export function safePathComponent(value: string, fallback = "unknown"): string {
   return normalized || fallback;
 }
 
-export async function writeJsonAtomic(path: string, value: unknown): Promise<void> {
+export async function writeTextAtomic(
+  path: string,
+  content: string,
+  mode = 0o600,
+): Promise<void> {
   await mkdir(dirname(path), { recursive: true });
   const temp = join(
     dirname(path),
     `.${safePathComponent(path.split(/[\\/]/).pop() ?? "data")}.${process.pid}.${Date.now()}.tmp`,
   );
   try {
-    await writeFile(temp, `${JSON.stringify(value, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+    await writeFile(temp, content, { encoding: "utf8", mode });
     await rename(temp, path);
   } catch (error) {
     await unlink(temp).catch(() => undefined);
     throw error;
   }
+}
+
+export async function writeJsonAtomic(path: string, value: unknown): Promise<void> {
+  await writeTextAtomic(path, `${JSON.stringify(value, null, 2)}\n`);
 }

--- a/Vyline/backend/src/storage/vylineStorageInfo.ts
+++ b/Vyline/backend/src/storage/vylineStorageInfo.ts
@@ -5,7 +5,7 @@
  */
 
 import { existsSync } from "node:fs";
-import { mkdir, readdir, stat } from "node:fs/promises";
+import { mkdir, readdir, stat, statfs } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { childLogger } from "../logger.js";
@@ -75,9 +75,31 @@ function extractDriveLetter(path: string): string {
 }
 
 async function getDiskInfo(
-  driveLetter: string,
+  targetPath: string,
 ): Promise<{ totalBytes: number; freeBytes: number; usedBytes: number } | null> {
+  // statfs works for Linux containers as well as ordinary local filesystems and
+  // reports the capacity of the filesystem backing the bind mount.
   try {
+    const fs = await statfs(targetPath);
+    const blockSize = Number(fs.bsize);
+    const totalBytes = Number(fs.blocks) * blockSize;
+    const freeBytes = Number(fs.bavail) * blockSize;
+    if (Number.isFinite(totalBytes) && Number.isFinite(freeBytes) && totalBytes > 0) {
+      return {
+        totalBytes,
+        freeBytes: Math.max(0, freeBytes),
+        usedBytes: Math.max(0, totalBytes - freeBytes),
+      };
+    }
+  } catch (err) {
+    log.debug({ err, targetPath }, "statfs failed");
+  }
+
+  // Older Windows/Bun combinations may not expose a useful statfs result.
+  // Keep the previous PowerShell fallback there only.
+  if (process.platform !== "win32") return null;
+  try {
+    const driveLetter = extractDriveLetter(targetPath);
     if (!driveLetter) return null;
     const name = driveLetter.replace(":", "");
     const ps = `[pscustomobject]@{ Total = (Get-PSDrive ${name}).Used + (Get-PSDrive ${name}).Free; Free = (Get-PSDrive ${name}).Free; Used = (Get-PSDrive ${name}).Used } | ConvertTo-Json`;
@@ -85,11 +107,7 @@ async function getDiskInfo(
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [code, stdout, stderr] = await Promise.all([
-      proc.exited,
-      streamToText(proc.stdout),
-      streamToText(proc.stderr),
-    ]);
+    const [code, stdout] = await Promise.all([proc.exited, streamToText(proc.stdout)]);
     if (typeof code === "number" && code === 0 && stdout.trim()) {
       const data = JSON.parse(stdout.trim());
       if (data && typeof data.Total === "number") {
@@ -117,7 +135,7 @@ export async function getVylineStorageInfo() {
   const cacheSize = cdnCacheSize + iconCacheSize;
   const savedMediaSize = imagesSize + videosSize + audioSize + filesSize;
   const vylineTotal = cacheSize + savedMediaSize;
-  const disk = await getDiskInfo(driveLetter);
+  const disk = await getDiskInfo(VYLINE_STORAGE_DIR);
 
   return {
     ok: true,

--- a/Vyline/packages/types/src/index.ts
+++ b/Vyline/packages/types/src/index.ts
@@ -90,6 +90,8 @@ export interface Chat {
   left?: boolean;
   /** 公式アカウント（userType=BOT） */
   isOfficial?: boolean;
+  /** 外部バックアップから復元された履歴を持つ */
+  restoredHistory?: boolean;
   /** ステータスメッセージ（直接トーク相手） */
   statusMessage?: string;
   /** プロフィール背景 URL */

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -eu
+
+DATA_DIR="${VYLINE_DATA_DIR:-/app/data}"
+STORAGE_DIR="${VYLINE_STORAGE_DIR:-/app/storage}"
+
+mkdir -p "$DATA_DIR" "$STORAGE_DIR"
+
+if [ "$(id -u)" = "0" ]; then
+  # Docker bind mounts keep the host-side ownership and therefore hide the
+  # ownership prepared in the image.  Vyline runs as the unprivileged `bun`
+  # user, so a root-owned ./data bind mount otherwise makes restores appear to
+  # work in memory while chatdb/settings silently fail to persist.
+  chown -R bun:bun "$DATA_DIR" "$STORAGE_DIR"
+
+  if ! gosu bun test -w "$DATA_DIR"; then
+    echo "[vyline] VYLINE_DATA_DIR is not writable by bun: $DATA_DIR" >&2
+    exit 1
+  fi
+  if ! gosu bun test -w "$STORAGE_DIR"; then
+    echo "[vyline] VYLINE_STORAGE_DIR is not writable by bun: $STORAGE_DIR" >&2
+    exit 1
+  fi
+
+  exec gosu bun "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
## Summary
Android版LineのnaverdbおよびLEINsの一括backup zipからのデータインポートに対応
from = u-peer, to   = u-meを無視していた実装を修正

## Changes

- c... / r... の復元チャットを確実に group として補正
- 既存キャッシュで誤って direct/unknown になっていても修復
- 通常LINE同期に出てこない復元済みグループを一覧から消さない
- fetchJoinedChats が一時的に失敗しただけで、全グループを「退出済み」と誤判定して非表示にしていた問題を修正
- 実際に退出済みのグループでも、復元履歴がある場合は「すべて」「グループ」タブに表示
- 通常同期でAndroidバックアップ由来のグループ名・最新履歴情報を潰さない
- restoredHistory を永続化して、以後の同期でも復元チャットを保持

## Test Plan

<!-- テスト項目 -->

- [ ] from = u-peer, to   = u-meがiOSのデータベースにあるか確認してください。

## Screenshots

<!-- UI変更がある場合 -->

<img width="960" height="440" alt="image" src="https://github.com/user-attachments/assets/8aedfffc-3bb0-4198-b012-f01a977afce9" />
