### PR TITLE
feat(auth): complete channel token lifecycle and credential handoff

### DIFF
--- a/Vyline/backend/src/api/line.ts
+++ b/Vyline/backend/src/api/line.ts
@@ -2471,6 +2471,50 @@ lineRouter.delete("/:accountId/backup/:backupId", async (c) => {
   }
 });
 
+// ─── Credentials: encrypted handoff / channel-token lifecycle ───
+
+lineRouter.post("/:accountId/credentials/handoff/export", async (c) => {
+  const accountId = c.req.param("accountId");
+  const { passphrase } = await c.req.json<{ passphrase: string }>();
+  try {
+    const { exportCredentialHandoff } = await import("../storage/tokenStore.js");
+    return c.json({ ok: true, bundle: await exportCredentialHandoff(accountId, passphrase) });
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+lineRouter.post("/:accountId/credentials/handoff/import", async (c) => {
+  const accountId = c.req.param("accountId");
+  const body = await c.req.json<{
+    passphrase: string;
+    bundle: import("../storage/tokenStore.js").CredentialHandoffBundle;
+  }>();
+  try {
+    const { importCredentialHandoff } = await import("../storage/tokenStore.js");
+    await importCredentialHandoff(body.bundle, body.passphrase, accountId);
+    return c.json({ ok: true });
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
+lineRouter.post("/:accountId/credentials/channel/:channelId/reissue", async (c) => {
+  const accountId = c.req.param("accountId");
+  const channelId = c.req.param("channelId");
+  try {
+    const client = getClient(accountId);
+    if (!client) return c.json({ ok: false, error: "not logged in" }, 401);
+    const base = client.base as typeof client.base & {
+      channelTokens: { reissue(id: string, approve?: boolean): Promise<string> };
+    };
+    await base.channelTokens.reissue(channelId, true);
+    return c.json({ ok: true, channelId, reissued: true });
+  } catch (err) {
+    return handleError(err, c);
+  }
+});
+
 lineRouter.get("/:accountId/log", async (c) => {
   const accountId = c.req.param("accountId");
   const { readRecentMessageLog } = await import("../storage/messageLog.js");

--- a/Vyline/backend/src/api/openapi.line.ts
+++ b/Vyline/backend/src/api/openapi.line.ts
@@ -1453,6 +1453,46 @@ const routes: Array<[string, Method, OpSpec]> = [
     },
   ],
   [
+    "/line/{accountId}/credentials/handoff/export",
+    "post",
+    {
+      op: "exportCredentialHandoff",
+      summary: "認証情報を暗号化引き継ぎファイルとして書き出す",
+      description: "通常の VylineBackup とは分離。パスフレーズは保存しない。",
+      tags: ["credentials"],
+      params: [acc],
+      requestBody: body(["passphrase"], { passphrase: { type: "string", minLength: 8 } }),
+      responses: { "200": jsonRes("暗号化 credential handoff bundle") },
+    },
+  ],
+  [
+    "/line/{accountId}/credentials/handoff/import",
+    "post",
+    {
+      op: "importCredentialHandoff",
+      summary: "暗号化認証情報を指定アカウントへ復元",
+      tags: ["credentials"],
+      params: [acc],
+      requestBody: body(["passphrase", "bundle"], {
+        passphrase: { type: "string", minLength: 8 },
+        bundle: { type: "object" },
+      }),
+      responses: { "200": okRes() },
+    },
+  ],
+  [
+    "/line/{accountId}/credentials/channel/{channelId}/reissue",
+    "post",
+    {
+      op: "reissueChannelToken",
+      summary: "チャネルトークンを明示的に再発行",
+      description: "新しいトークン値そのものは API 応答へ返さない。",
+      tags: ["credentials"],
+      params: [acc, pathParam("channelId", "LINE Channel ID")],
+      responses: { "200": okRes() },
+    },
+  ],
+  [
     "/line/{accountId}/vyline/cache",
     "get",
     {
@@ -1771,6 +1811,7 @@ export const lineOpenApiSpec = {
     { name: "announcements", description: "アナウンス" },
     { name: "calls", description: "通話" },
     { name: "backup", description: "VylineBackup の作成・復元" },
+    { name: "credentials", description: "認証情報の安全な引き継ぎ・再発行" },
     { name: "storage", description: "キャッシュ・ストレージ管理" },
     { name: "misc", description: "その他（プラグイン・プロキシ・復元など Vyline 拡張）" },
   ],

--- a/Vyline/backend/src/line/clientManager.ts
+++ b/Vyline/backend/src/line/clientManager.ts
@@ -19,6 +19,7 @@ import { childLogger } from "../logger.js";
 import {
   saveToken,
   getToken,
+  storagePathForAccount,
   loadTokens,
   deleteToken,
   updateSessionMeta,
@@ -184,21 +185,11 @@ export async function withTalkChannelIdle<T>(
   return enqueueTalkRpcBackground(accountId, work);
 }
 
-import { dirname, join as pathJoin } from "node:path";
-import { fileURLToPath } from "node:url";
-
-const _dir = dirname(fileURLToPath(import.meta.url));
-
-function storagePathFor(accountId: string): string {
-  const dataDir = process.env.VYLINE_DATA_DIR ?? pathJoin(_dir, "../../data");
-  return `${dataDir}/storage-${accountId}.json`;
-}
-
 function loginInit(accountId: string) {
   const deviceMode = process.env.VYLINE_DEVICE;
   return {
     profile: getVylineProfile(),
-    storagePath: storagePathFor(accountId),
+    storagePath: storagePathForAccount(accountId),
     // VYLINE_DEVICE 未設定時は IOSIPAD（共存 + 安定認証）
     ...(deviceMode !== undefined ? { deviceMode } : {}),
   };
@@ -568,11 +559,7 @@ export async function loginWithAuthToken(
   authToken: string,
   deviceMode?: string,
 ): Promise<VylineClient> {
-  const { dirname, join } = await import("node:path");
-  const { fileURLToPath } = await import("node:url");
-  const _dir = dirname(fileURLToPath(import.meta.url));
-  const dataDir = process.env.VYLINE_DATA_DIR ?? join(_dir, "../../data");
-  const storagePath = join(dataDir, `storage-${accountId}.json`);
+  const storagePath = storagePathForAccount(accountId);
 
   log.info({ accountId }, "login with authToken via Vyline");
 

--- a/Vyline/backend/src/line/clientManager.ts
+++ b/Vyline/backend/src/line/clientManager.ts
@@ -659,7 +659,7 @@ export async function loginContentWithQRCode(
       },
       {
         profile: getVylineProfile(),
-        storagePath: `${storagePathFor(accountId)}.content-secondary`,
+        storagePath: `${storagePathForAccount(accountId)}.content-secondary`,
         deviceMode: "ANDROIDSECONDARY",
       },
     );
@@ -667,7 +667,7 @@ export async function loginContentWithQRCode(
     const token = client.authToken ?? client.base.authToken;
     if (!token) throw new Error("content login completed without auth token");
     await saveToken(contentTokenId(accountId), token, {
-      storageFile: `${storagePathFor(accountId)}.content-secondary`,
+      storageFile: `${storagePathForAccount(accountId)}.content-secondary`,
     });
     contentClients.set(accountId, Promise.resolve(client));
     state.url = null;

--- a/Vyline/backend/src/storage/tokenStore.test.ts
+++ b/Vyline/backend/src/storage/tokenStore.test.ts
@@ -27,11 +27,15 @@ describe("tokenStore account isolation and handoff", () => {
 
     await writeFile(
       join(dataDir, "tokens.json"),
-      JSON.stringify({ legacy: { authToken: "legacy-token", storageFile: "", savedAt: "2026-08-29T00:00:00.000Z" } }),
+      JSON.stringify({
+        legacy: { authToken: "legacy-token", storageFile: "", savedAt: "2026-08-29T00:00:00.000Z" },
+      }),
       "utf8",
     );
     expect((await tokenStore.getToken("legacy"))?.authToken).toBe("legacy-token");
-    expect(await readFile(join(dataDir, "accounts", "legacy", "credentials.json"), "utf8")).toContain("legacy-token");
+    expect(
+      await readFile(join(dataDir, "accounts", "legacy", "credentials.json"), "utf8"),
+    ).toContain("legacy-token");
   });
 
   test("encrypted handoff round-trips without exposing raw credentials", async () => {
@@ -40,7 +44,10 @@ describe("tokenStore account isolation and handoff", () => {
     await mkdir(join(dataDir, "accounts", "source"), { recursive: true });
     await writeFile(
       protocolPath,
-      JSON.stringify({ refreshToken: "refresh-secret", "channelToken:1": { channelAccessToken: "channel-secret" } }),
+      JSON.stringify({
+        refreshToken: "refresh-secret",
+        "channelToken:1": { channelAccessToken: "channel-secret" },
+      }),
       "utf8",
     );
 
@@ -49,7 +56,9 @@ describe("tokenStore account isolation and handoff", () => {
     expect(serialized).not.toContain("primary-secret");
     expect(serialized).not.toContain("refresh-secret");
     expect(serialized).not.toContain("channel-secret");
-    await expect(tokenStore.importCredentialHandoff(bundle, "wrong-passphrase", "wrong")).rejects.toThrow();
+    await expect(
+      tokenStore.importCredentialHandoff(bundle, "wrong-passphrase", "wrong"),
+    ).rejects.toThrow();
 
     await tokenStore.importCredentialHandoff(bundle, "passphrase-123", "restored");
     const restored = await tokenStore.getToken("restored");

--- a/Vyline/backend/src/storage/tokenStore.test.ts
+++ b/Vyline/backend/src/storage/tokenStore.test.ts
@@ -1,0 +1,62 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm, writeFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const dataDir = await mkdtemp(join(tmpdir(), "vyline-token-store-"));
+process.env.VYLINE_DATA_DIR = dataDir;
+const tokenStore = await import(`./tokenStore.ts?test=${crypto.randomUUID()}`);
+
+afterAll(async () => {
+  await rm(dataDir, { recursive: true, force: true });
+});
+
+describe("tokenStore account isolation and handoff", () => {
+  test("stores credentials per account and migrates legacy entries", async () => {
+    await tokenStore.saveToken("account-a", "auth-a", { displayName: "A" });
+    await tokenStore.saveToken("account-b", "auth-b", { displayName: "B" });
+
+    const aRaw = await readFile(join(dataDir, "accounts", "account-a", "credentials.json"), "utf8");
+    const bRaw = await readFile(join(dataDir, "accounts", "account-b", "credentials.json"), "utf8");
+    if (process.platform === "win32") {
+      expect(aRaw).not.toContain("auth-a");
+      expect(bRaw).not.toContain("auth-b");
+    }
+    expect((await tokenStore.getToken("account-a"))?.authToken).toBe("auth-a");
+    expect((await tokenStore.getToken("account-b"))?.authToken).toBe("auth-b");
+
+    await writeFile(
+      join(dataDir, "tokens.json"),
+      JSON.stringify({ legacy: { authToken: "legacy-token", storageFile: "", savedAt: "2026-08-29T00:00:00.000Z" } }),
+      "utf8",
+    );
+    expect((await tokenStore.getToken("legacy"))?.authToken).toBe("legacy-token");
+    expect(await readFile(join(dataDir, "accounts", "legacy", "credentials.json"), "utf8")).toContain("legacy-token");
+  });
+
+  test("encrypted handoff round-trips without exposing raw credentials", async () => {
+    await tokenStore.saveToken("source", "primary-secret", { deviceMode: "IOSIPAD" });
+    const protocolPath = tokenStore.storagePathForAccount("source");
+    await mkdir(join(dataDir, "accounts", "source"), { recursive: true });
+    await writeFile(
+      protocolPath,
+      JSON.stringify({ refreshToken: "refresh-secret", "channelToken:1": { channelAccessToken: "channel-secret" } }),
+      "utf8",
+    );
+
+    const bundle = await tokenStore.exportCredentialHandoff("source", "passphrase-123");
+    const serialized = JSON.stringify(bundle);
+    expect(serialized).not.toContain("primary-secret");
+    expect(serialized).not.toContain("refresh-secret");
+    expect(serialized).not.toContain("channel-secret");
+    await expect(tokenStore.importCredentialHandoff(bundle, "wrong-passphrase", "wrong")).rejects.toThrow();
+
+    await tokenStore.importCredentialHandoff(bundle, "passphrase-123", "restored");
+    const restored = await tokenStore.getToken("restored");
+    expect(restored?.authToken).toBe("primary-secret");
+    expect(restored?.deviceMode).toBe("IOSIPAD");
+    const restoredProtocol = await readFile(tokenStore.storagePathForAccount("restored"), "utf8");
+    expect(restoredProtocol).toContain("refresh-secret");
+    expect(restoredProtocol).toContain("channel-secret");
+  }, 20_000);
+});

--- a/Vyline/backend/src/storage/tokenStore.ts
+++ b/Vyline/backend/src/storage/tokenStore.ts
@@ -83,7 +83,10 @@ async function ensureDataDir(): Promise<void> {
   await mkdir(ACCOUNTS_DIR, { recursive: true });
 }
 
-async function decodePersistedEntry(accountId: string, entry: TokenEntry): Promise<TokenEntry | undefined> {
+async function decodePersistedEntry(
+  accountId: string,
+  entry: TokenEntry,
+): Promise<TokenEntry | undefined> {
   const targetStorage = storagePathForAccount(accountId);
   if (
     entry?.storageFile &&

--- a/Vyline/backend/src/storage/tokenStore.ts
+++ b/Vyline/backend/src/storage/tokenStore.ts
@@ -1,27 +1,17 @@
 /**
  * tokenStore.ts
  *
- * authToken とセッションメタのローカル保存。
- * 保存先: <backend>/data/tokens.json
- *
- * 構造:
- * {
- *   "accountId": {
- *     "authToken": "...",
- *     "storageFile": "<backend>/data/storage-accountId.json",
- *     "savedAt": "ISO8601",
- *     "mid": "u...",
- *     "displayName": "...",
- *     "picturePath": "...",
- *     "statusMessage": "..."
- *   }
- * }
+ * authToken とセッションメタのアカウント別ローカル保存。
+ * 保存先: <backend>/data/accounts/<accountId>/credentials.json
+ * protocol storage: <backend>/data/accounts/<accountId>/protocol.json
+ * 旧 data/tokens.json は読み込み・移行互換のみ。
  */
 
 import { join, dirname } from "node:path";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, readFile, readdir, unlink, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+import { createCipheriv, createDecipheriv, pbkdf2Sync, randomBytes } from "node:crypto";
 import { childLogger } from "../logger.js";
 import { protectSecret, unprotectSecret } from "./secureStore.js";
 
@@ -30,6 +20,21 @@ const log = childLogger("tokenStore");
 const _dir = dirname(fileURLToPath(import.meta.url));
 const DATA_DIR = process.env.VYLINE_DATA_DIR ?? join(_dir, "..", "..", "data");
 const TOKENS_FILE = join(DATA_DIR, "tokens.json");
+const ACCOUNTS_DIR = join(DATA_DIR, "accounts");
+const HANDOFF_SCHEMA = "vyline-credential-handoff";
+const HANDOFF_VERSION = 1;
+
+function accountDir(accountId: string): string {
+  return join(ACCOUNTS_DIR, encodeURIComponent(accountId));
+}
+
+function accountTokenFile(accountId: string): string {
+  return join(accountDir(accountId), "credentials.json");
+}
+
+export function storagePathForAccount(accountId: string): string {
+  return join(accountDir(accountId), "protocol.json");
+}
 
 export interface TokenEntry {
   authToken: string;
@@ -54,16 +59,6 @@ export interface TokenEntry {
 
 export type TokenMap = Record<string, TokenEntry>;
 
-async function persistTokens(tokens: TokenMap): Promise<void> {
-  const persisted = Object.fromEntries(
-    Object.entries(tokens).map(([id, entry]) => {
-      const { authToken: _plain, ...safeEntry } = entry;
-      return [id, entry.authTokenProtected ? safeEntry : entry];
-    }),
-  );
-  await writeFile(TOKENS_FILE, JSON.stringify(persisted, null, 2), "utf-8");
-}
-
 export type SessionMeta = {
   storageFile?: string;
   mid?: string;
@@ -85,29 +80,73 @@ async function ensureDataDir(): Promise<void> {
     await mkdir(DATA_DIR, { recursive: true });
     log.debug({ dir: DATA_DIR }, "created data dir");
   }
+  await mkdir(ACCOUNTS_DIR, { recursive: true });
+}
+
+async function decodePersistedEntry(accountId: string, entry: TokenEntry): Promise<TokenEntry | undefined> {
+  const targetStorage = storagePathForAccount(accountId);
+  if (
+    entry?.storageFile &&
+    entry.storageFile !== targetStorage &&
+    existsSync(entry.storageFile) &&
+    !existsSync(targetStorage)
+  ) {
+    await mkdir(accountDir(accountId), { recursive: true });
+    await copyFile(entry.storageFile, targetStorage);
+    log.info({ accountId }, "migrated protocol storage into account directory");
+  }
+  if (entry?.authTokenProtected && typeof entry.authTokenProtected === "string") {
+    const token = await unprotectSecret(entry.authTokenProtected);
+    return { ...entry, authToken: token, storageFile: targetStorage };
+  }
+  if (entry?.authToken && typeof entry.authToken === "string") {
+    return { ...entry, storageFile: targetStorage };
+  }
+  return undefined;
+}
+
+async function persistAccount(accountId: string, entry: TokenEntry): Promise<void> {
+  await mkdir(accountDir(accountId), { recursive: true });
+  const { authToken: _plain, ...safeEntry } = entry;
+  const persisted = entry.authTokenProtected ? safeEntry : entry;
+  await writeFile(accountTokenFile(accountId), JSON.stringify(persisted, null, 2), "utf8");
 }
 
 export async function loadTokens(): Promise<TokenMap> {
   await ensureDataDir();
-  if (!existsSync(TOKENS_FILE)) return {};
+  const cleaned: TokenMap = {};
   try {
-    const raw = await readFile(TOKENS_FILE, "utf-8");
-    const parsed = JSON.parse(raw) as TokenMap;
-    // 空トークンのゴミを除外
-    const cleaned: TokenMap = {};
-    for (const [id, entry] of Object.entries(parsed)) {
-      if (entry?.authTokenProtected && typeof entry.authTokenProtected === "string") {
-        const token = await unprotectSecret(entry.authTokenProtected);
-        cleaned[id] = { ...entry, authToken: token };
-      } else if (entry?.authToken && typeof entry.authToken === "string") {
-        cleaned[id] = entry;
-      }
+    for (const dir of await readdir(ACCOUNTS_DIR, { withFileTypes: true })) {
+      if (!dir.isDirectory()) continue;
+      const id = decodeURIComponent(dir.name);
+      const path = accountTokenFile(id);
+      if (!existsSync(path)) continue;
+      const entry = JSON.parse(await readFile(path, "utf8")) as TokenEntry;
+      const decoded = await decodePersistedEntry(id, entry);
+      if (decoded) cleaned[id] = decoded;
     }
-    return cleaned;
   } catch (err) {
-    log.warn({ err }, "failed to parse tokens.json, returning empty");
-    return {};
+    log.warn({ err }, "failed to read account credential files");
   }
+
+  // Legacy shared tokens.json remains readable. Account files win, and a legacy
+  // entry is migrated lazily without deleting the recoverable source file.
+  if (existsSync(TOKENS_FILE)) {
+    try {
+      const parsed = JSON.parse(await readFile(TOKENS_FILE, "utf8")) as TokenMap;
+      for (const [id, entry] of Object.entries(parsed)) {
+        if (cleaned[id]) continue;
+        const decoded = await decodePersistedEntry(id, entry);
+        if (decoded) {
+          cleaned[id] = decoded;
+          await persistAccount(id, decoded);
+        }
+      }
+    } catch (err) {
+      log.warn({ err }, "failed to parse legacy tokens.json");
+    }
+  }
+  return cleaned;
 }
 
 function normalizeAuthToken(authToken: unknown): string | null {
@@ -139,8 +178,7 @@ export async function saveToken(
   const existing = tokens[accountId];
   const entry: TokenEntry = {
     authToken: token,
-    storageFile:
-      meta?.storageFile ?? existing?.storageFile ?? join(DATA_DIR, `storage-${accountId}.json`),
+    storageFile: storagePathForAccount(accountId),
     savedAt: new Date().toISOString(),
   };
   try {
@@ -163,8 +201,7 @@ export async function saveToken(
   if (deviceMode) entry.deviceMode = deviceMode;
   if (premium) entry.premium = premium;
   tokens[accountId] = entry;
-
-  await persistTokens(tokens);
+  await persistAccount(accountId, entry);
   log.info({ accountId, displayName: entry.displayName, mid: entry.mid }, "token saved");
 }
 
@@ -179,15 +216,101 @@ export async function updateSessionMeta(accountId: string, meta: SessionMeta): P
   if (meta.deviceMode != null) existing.deviceMode = meta.deviceMode;
   if (meta.premium != null) existing.premium = meta.premium;
   existing.savedAt = new Date().toISOString();
-  tokens[accountId] = existing;
-  await persistTokens(tokens);
+  await persistAccount(accountId, existing);
 }
 
 export async function deleteToken(accountId: string): Promise<void> {
-  const tokens = await loadTokens();
-  delete tokens[accountId];
-  await persistTokens(tokens);
+  try {
+    await unlink(accountTokenFile(accountId));
+  } catch {
+    // already absent
+  }
   log.info({ accountId }, "token deleted");
+}
+
+export interface CredentialHandoffBundle {
+  schema: typeof HANDOFF_SCHEMA;
+  version: typeof HANDOFF_VERSION;
+  accountId: string;
+  createdAt: string;
+  salt: string;
+  iv: string;
+  tag: string;
+  ciphertext: string;
+}
+
+function handoffKey(passphrase: string, salt: Buffer): Buffer {
+  if (passphrase.length < 8) throw new Error("引き継ぎパスフレーズは8文字以上にしてください");
+  return pbkdf2Sync(passphrase, salt, 210_000, 32, "sha256");
+}
+
+/** Auth/refresh/channel tokens and protocol credentials as an encrypted portable bundle. */
+export async function exportCredentialHandoff(
+  accountId: string,
+  passphrase: string,
+): Promise<CredentialHandoffBundle> {
+  const entry = await getToken(accountId);
+  if (!entry) throw new Error("保存済みセッションがありません");
+  let protocol: Record<string, unknown> = {};
+  if (existsSync(entry.storageFile)) {
+    protocol = JSON.parse(await readFile(entry.storageFile, "utf8")) as Record<string, unknown>;
+  }
+  const payload = JSON.stringify({
+    authToken: entry.authToken,
+    meta: {
+      mid: entry.mid,
+      displayName: entry.displayName,
+      picturePath: entry.picturePath,
+      statusMessage: entry.statusMessage,
+      deviceMode: entry.deviceMode,
+      premium: entry.premium,
+    },
+    protocol,
+  });
+  const salt = randomBytes(16);
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", handoffKey(passphrase, salt), iv);
+  const ciphertext = Buffer.concat([cipher.update(payload, "utf8"), cipher.final()]);
+  return {
+    schema: HANDOFF_SCHEMA,
+    version: HANDOFF_VERSION,
+    accountId,
+    createdAt: new Date().toISOString(),
+    salt: salt.toString("base64"),
+    iv: iv.toString("base64"),
+    tag: cipher.getAuthTag().toString("base64"),
+    ciphertext: ciphertext.toString("base64"),
+  };
+}
+
+export async function importCredentialHandoff(
+  bundle: CredentialHandoffBundle,
+  passphrase: string,
+  targetAccountId = bundle.accountId,
+): Promise<void> {
+  if (bundle.schema !== HANDOFF_SCHEMA || bundle.version !== HANDOFF_VERSION) {
+    throw new Error("未対応の引き継ぎファイルです");
+  }
+  const salt = Buffer.from(bundle.salt, "base64");
+  const decipher = createDecipheriv(
+    "aes-256-gcm",
+    handoffKey(passphrase, salt),
+    Buffer.from(bundle.iv, "base64"),
+  );
+  decipher.setAuthTag(Buffer.from(bundle.tag, "base64"));
+  const raw = Buffer.concat([
+    decipher.update(Buffer.from(bundle.ciphertext, "base64")),
+    decipher.final(),
+  ]).toString("utf8");
+  const payload = JSON.parse(raw) as {
+    authToken: string;
+    meta?: SessionMeta;
+    protocol?: Record<string, unknown>;
+  };
+  await saveToken(targetAccountId, payload.authToken, payload.meta);
+  const target = storagePathForAccount(targetAccountId);
+  await mkdir(accountDir(targetAccountId), { recursive: true });
+  await writeFile(target, JSON.stringify(payload.protocol ?? {}), "utf8");
 }
 
 export async function getToken(accountId: string): Promise<TokenEntry | undefined> {

--- a/docs/analysis/README.md
+++ b/docs/analysis/README.md
@@ -26,6 +26,7 @@ agents は `bun run vyline:delta` のレポートが指す feature ごとに、�
 | sbc-key-restore          | [sbc-key-restore.md](./sbc-key-restore.md)       | SBC クラウドバックアップ鍵取り出し（/EKBS4・/LKBS4） |
 | ios-backup-history       | [ios-backup-history-extraction.md](./ios-backup-history-extraction.md) | iOS バックアップ履歴取り出し作業の全経緯・手順       |
 | calls                    | [calls.md](./calls.md)                           |                                                      |
+| token-lifecycle          | [token-lifecycle.md](./token-lifecycle.md)       | auth / refresh / channel / request token と安全な引き継ぎ |
 
 **ドキュメント索引**
 

--- a/docs/analysis/token-lifecycle.md
+++ b/docs/analysis/token-lifecycle.md
@@ -1,0 +1,76 @@
+# LINE token lifecycle in Vyline
+
+最終更新: 2026-08-29
+
+Vyline が扱う認証情報を「何に使うか」「どこへ保存するか」「どう更新するか」で分離したメモ。通常の VylineBackup には認証情報を含めない。
+
+## 種類
+
+| 種類 | 用途 / スコープ | 保存 | 更新・失効時 |
+|---|---|---|---|
+| Primary auth/access token | Talk / Square など LINE の主要 RPC のログイン資格情報 | `data/accounts/<accountId>/credentials.json`。Windows は DPAPI (CurrentUser) で保護 | refresh token による更新、または再ログイン。更新後は token watcher が再保存 |
+| Refresh token | Primary token の更新 | アカウント専用 `protocol.json` の `refreshToken` | Talk 側の認証失効時に使用。別 PC への移動は暗号化 handoff のみ |
+| Channel `channelAccessToken` | Channel ID ごとの REST gateway。`X-Line-ChannelToken` に設定 | `protocol.json` の `channelToken:<channelId>` | 401 時に invalidate → 1回だけ再発行 → 再試行。手動再発行 API も提供 |
+| Channel response `token` | 一部 Channel RPC が返す互換フィールド | `channelAccessToken` が無い場合だけ互換 fallback | Gateway 用には優先しない。これを優先すると 401 になり得る |
+| Request token | `issueRequestTokenWithAuthScheme` で発行する短寿命トークン | 永続保存しない | Web / auto-login フロー専用。`getReturnUrlWithRequestTokenForAutoLogin` と組み合わせる |
+| E2EE / device secrets | E2EE 鍵・証明書・端末に紐づく protocol credential | `protocol.json` | Channel token とは別物。移行時のみ暗号化 handoff に含める |
+
+## Channel token lifecycle
+
+`ChannelTokenManager` がアカウントの protocol storage を正本として管理する。
+
+1. メモリ → `protocol.json` の順で既存 `channelAccessToken` を探す。
+2. 無ければ `issueChannelToken` を優先して発行する。
+3. 承認が必要、または usable token が返らない場合だけ `approveChannelAndIssueChannelToken` を使う。
+4. 同一 channel の同時発行は 1 本へまとめる。
+5. REST gateway が 401 を返した場合は保存値を破棄し、再発行して 1 回だけ再試行する。
+6. API から明示再発行も可能だが、新しい token 値自体は HTTP 応答へ返さない。
+
+現在この統一 lifecycle を VOOM、Album、Timeline 系から利用する。
+
+## Known Channel IDs
+
+| Channel | ID |
+|---|---:|
+| TIMELINE | `1341209950` |
+| HOME | `1341209850` |
+| HOME26 | `2007835442` |
+| NOTE | `1655599932` |
+| SQUARE_NOTE | `1657618623` |
+| ALBUM | `1375220249` |
+
+Note 系は操作ごとに HOME / NOTE / SQUARE_NOTE のどれを要求するかが異なる可能性があるため、HAR / Desktop 証拠を優先して選ぶ。ID を推測で統一しない。
+
+## Account storage layout
+
+```text
+backend/data/
+  accounts/
+    <accountId>/
+      credentials.json   # primary auth token (Windows: DPAPI) + session metadata
+      protocol.json      # refresh/channel/E2EE/device protocol KV
+  tokens.json            # legacy: read/migration only
+  backups/               # chats/messages/media only; credentials are excluded
+```
+
+旧 `tokens.json` は読み込み時にアカウント別 `credentials.json` へコピーする。復旧用として旧ファイルは自動削除しない。既存エントリが旧 `storage-<accountId>.json` を参照している場合も、そのパスを優先して互換性を維持する。
+
+## Encrypted credential handoff
+
+通常バックアップとは別に、明示操作でのみ認証情報を移せる。
+
+- AES-256-GCM で payload を暗号化する。
+- 鍵は入力された passphrase から PBKDF2-SHA256 / 210,000 iterations で導出する。
+- salt 16 bytes、IV 12 bytes を毎回ランダム生成する。
+- passphrase はディスクへ保存しない。
+- primary auth token、session metadata、`protocol.json` 全体を暗号化 payload に含める。
+- import 先の `accountId` を指定できるため、別環境のアカウント領域へ安全に復元できる。
+- bundle JSON 自体には raw auth / refresh / channel token を平文で含めない。
+
+内部 API:
+
+- `POST /line/:accountId/credentials/handoff/export`
+- `POST /line/:accountId/credentials/handoff/import`
+- `POST /line/:accountId/credentials/channel/:channelId/reissue`
+
+`credentials.json` や `protocol.json` をそのまま ZIP に入れる方式は採用しない。

--- a/docs/developer-guide/multi-account.md
+++ b/docs/developer-guide/multi-account.md
@@ -12,7 +12,8 @@ Vyline はログインセッションの `accountId` と、設定・引継ぎ・
 | Setup 進捗 | `settings.json` 内の `setup` | ✅ MID ごと。途中再開・完了済み判定に使用 |
 | 引継ぎ記録 | `data/accounts/<safe-mid>/handoff.json` | ✅ MID ごと。認証情報は含めない |
 | 診断ログ | `data/logs/diagnostics-<safe-mid>.jsonl` | ✅ MID ごと。保存前にマスキング |
-| セッション / トークン | `data/tokens.json` | ✅ accountId ごと。Windows は DPAPI(CurrentUser) で暗号化して保存 |
+| Primary セッション / auth token | `data/accounts/<accountId>/credentials.json` | ✅ accountId ごと。Windows は DPAPI(CurrentUser) で暗号化して保存 |
+| Protocol credential | `data/accounts/<accountId>/protocol.json` | ✅ refresh token / channel token / E2EE・device credential を accountId ごとに分離 |
 | チャット / メッセージ DB | `data/chatdb-{accountId}.json` | ✅ ファイル単位 |
 | プロフィール等キャッシュ | `data/vyline-cache-{accountId}.json` | ✅ |
 | 既読レンジ | `data/vyline-readRanges-{accountId}.json` | ✅ |
@@ -41,11 +42,13 @@ Vyline はログインセッションの `accountId` と、設定・引継ぎ・
 
 既存の accountId サフィックス付きストレージは、互換性を壊さないため継続して読み取ります。`storage/accountDirs.ts` を使う領域は、新レイアウトを優先し、旧フラットファイルを見つけた場合に新レイアウトへコピーします。元ファイルは削除しません。
 
-トークンや既存のチャット DB を一度に移動するマイグレーションは、データ消失リスクを避けるため未実施です。移行対象を追加する場合は、コピー → 検証 → 旧形式の読み取りフォールバック → 将来のメジャー版での削除、の順を守ります。
+旧 `data/tokens.json` は読み込み時に `data/accounts/<accountId>/credentials.json` へ遅延コピーします。旧ファイルは復旧用として削除せず、既存 `storage-<accountId>.json` 参照も維持します。新規セッションの protocol storage は `data/accounts/<accountId>/protocol.json` を使います。
+
+認証情報を別 PC へ引き継ぐ場合は通常の引継ぎ ZIP / VylineBackup へ混ぜず、専用の encrypted credential handoff を使用します。AES-256-GCM + PBKDF2-SHA256 で auth / refresh / channel / E2EE・device credential をまとめて暗号化し、passphrase は保存しません。詳細は [token-lifecycle.md](../analysis/token-lifecycle.md) を参照してください。
 
 ## セキュリティ上の注意
 
-- 認証トークン、Cookie、E2EE 鍵、パスワード、秘密鍵は引継ぎ ZIP と診断ログに含めない
+- 認証トークン、Cookie、E2EE 鍵、パスワード、秘密鍵は通常の引継ぎ ZIP / VylineBackup / 診断ログに含めない。移行が必要な場合だけ encrypted credential handoff を使う
 - Windows のトークン暗号化は現在の Windows ユーザーに結び付く。別ユーザー・別 PC へファイルだけをコピーしても復号できない
 - アカウント削除・全データ削除は、既存ストレージを含むため明示的なバックアップ確認を伴う別操作として扱う
 - Web／サブデバイスからの接続は、そのブラウザのランダムなインストール ID と有効セッションの両方を検証する


### PR DESCRIPTION
## Summary
- centralize channel-token caching, persistence, invalidation, and reissue in the protocol submodule
- retry VOOM/Album channel-auth requests once after 401 with a fresh token
- store credentials per account under data/accounts/<accountId>/
- protect the primary auth token with the existing Windows DPAPI secure store
- add encrypted portable credential handoff using AES-256-GCM + PBKDF2-SHA256
- keep ordinary VylineBackup credential-free
- add manual channel-token reissue API without returning the raw token secret
- preserve legacy tokens.json via lazy migration
- document token types, known channel IDs, lifecycle rules, storage, reissue, and handoff

## Protocol dependency
- vyline-api PR #8: https://github.com/nezumi0627/vyline-api/pull/8

## Verification
- 16 targeted tests pass
- protocol/backend/desktop typechecks pass
- git diff --check passes

## Note
The repository-wide typecheck reaches create-plugin and fails only because an unrelated pre-existing untracked Vyline/packages/create-plugin/my-vyline-plugin target already exists in this worktree; the affected product packages above typecheck successfully.