### PR TITLE
docs(protocol): add LIFF sender helper and expand Note/Album docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -64,6 +64,8 @@ LINE との通常の通信は発生します。これは法的助言ではあり
 | [protocol/dictionary.md](./protocol/dictionary.md) | RPC 辞書・Desktop 検証表・API 早見 |
 | [login-flow.md](./login-flow.md)                   | QR / Email E2EE ログインフロー     |
 | [analysis/README.md](./analysis/README.md)         | 機能別解析メモ索引                 |
+| [analysis/liff.md](./analysis/liff.md)             | LIFF token / share / sender helper |
+| [analysis/note-album.md](./analysis/note-album.md) | Note/Album ChannelToken・CRUD・OBS  |
 | [analysis/stickers.md](./analysis/stickers.md)     | スタンプ/絵文字 API 解析           |
 | [analysis/line-emoji.md](./analysis/line-emoji.md) | LINE 絵文字 (sticon) 解析          |
 | [analysis/stability-read-revoke-multi-account.md](./analysis/stability-read-revoke-multi-account.md) | 取消・既読者・複数アカウント・MID検索の安定化 |

--- a/docs/analysis/README.md
+++ b/docs/analysis/README.md
@@ -1,6 +1,6 @@
 # Desktop / プロトコル分析メモ
 
-最終更新: 2026-08-24
+最終更新: 2026-08-29
 
 LINE Desktop 更新や RPC 差分を調べた結果を置く場所。  
 agents は `bun run vyline:delta` のレポートが指す feature ごとに、ここに追記する。
@@ -21,6 +21,8 @@ agents は `bun run vyline:delta` のレポートが指す feature ごとに、�
 | sync-events              | [sync-events.md](./sync-events.md)               |                                                      |
 | stickers                 | [stickers.md](./stickers.md)                     |                                                      |
 | line-emoji               | [line-emoji.md](./line-emoji.md)                 |                                                      |
+| liff                     | [liff.md](./liff.md)                             | token / share / sender helper                        |
+| note / album             | [note-album.md](./note-album.md)                 | ChannelToken / CRUD / OBS upload・download           |
 | history-restore          | [history-restore.md](./history-restore.md)       | [e2ee-decrypt-journey.md](./e2ee-decrypt-journey.md) |
 | edb-decrypt              | [edb-decrypt.md](./edb-decrypt.md)               | Desktop .edb 全履歴 dump（メモリ捕捉方式）           |
 | sbc-key-restore          | [sbc-key-restore.md](./sbc-key-restore.md)       | SBC クラウドバックアップ鍵取り出し（/EKBS4・/LKBS4） |

--- a/docs/analysis/liff.md
+++ b/docs/analysis/liff.md
@@ -1,0 +1,83 @@
+# LIFF 実装メモ
+
+最終更新: 2026-08-29
+
+Vyline の LIFF は `@vyline/protocol` の `stack/base/service/liff/mod.ts` と `stack/client/features/liff.ts` を正本とする。UI 固有の表現はここへ持ち込まず、LIFF view/token 取得と share payload の組み立てを protocol 層で扱う。
+
+## 主要フロー
+
+1. `issueLiffView({ liffId, chatMid })` を `/LIFF1` に送る。
+2. `LiffViewResponse.accessToken` を利用する。`getLiffToken()` は `CONSENT_REQUIRED` の場合だけ同意処理を試し、成功後に再発行する。
+3. `sendLiff()` / `client.liff.shareMessage(s)` が `https://api.line.me/message/v3/share` に `Authorization: Bearer <LIFF access token>` と `{ messages }` を送る。
+4. `forceIssue` を指定すると宛先単位の LIFF token cache を使わず再発行する。
+
+LIFF access token は通常の LINE access token や Note/Album の ChannelToken と別物。保存・ログ出力・引き継ぎ時に同じ値として扱わない。
+
+## 高レベル message helper
+
+`stack/client/features/liff.ts` には `text` / `sticker` / `image` / `flex` がある。追加の任意フィールドが必要な場合は UI に直接 JSON 組み立てを置かず、protocol helper で表現する。
+
+### `sender`
+
+LIFF share payload では次の sender metadata を付加できる。
+
+```ts
+const message = client.liffMessage.withSender(
+  { type: "text", text: "Hello!" },
+  {
+    name: "Cony",
+    iconUrl: "https://example.com/icon.png",
+  },
+);
+```
+
+実際の helper は namespace export される `liff` から利用する想定:
+
+```ts
+import { Client, liff } from "@vyline/protocol/stack";
+
+const message = liff.withSender(liff.text("Hello!"), {
+  name: "Cony",
+  iconUrl: "https://example.com/icon.png",
+});
+
+await client.liff.shareMessage(chatMid, message);
+```
+
+生成される payload:
+
+```json
+{
+  "type": "text",
+  "text": "Hello!",
+  "sender": {
+    "name": "Cony",
+    "iconUrl": "https://example.com/icon.png"
+  }
+}
+```
+
+`withSender()` は元 message を変更せず新しい object を返す。現時点では UI には接続しない。
+
+### `sender` と `sentBy` の違い
+
+既存 `text(body, sentBy)` の `sentBy` は `label` / `iconUrl` / `linkUrl` を持つ既存の footer metadata で、今回の `sender: { name, iconUrl }` とは別フィールド。互換性維持のため統合・置換しない。
+
+## LIFF feature 実装
+
+アプリ本体の `Vyline/backend/src/service/liffFeatures.ts` では、用途ごとの LIFF ID を使い schedule / ladder / poll などの HTTP API を呼ぶ。アプリごとに token header の形が異なるため、共通化するときも `X-Liff-Token` と `x-liff-access-token` / `x-liff-id-token` を混同しない。
+
+## エラー確認
+
+- `CONSENT_REQUIRED`: `getLiffToken()` の同意フローを確認する。
+- 401/403: LIFF ID・chat context・token header の組み合わせを確認し、LINE access token や ChannelToken を代入しない。
+- share 失敗: `forceIssue: true` で LIFF token を再取得して切り分ける。
+- payload rejection: UI から送られた object ではなく protocol helper の単体テストで shape を固定する。
+
+## 関連ソース
+
+- `Vyline/packages/protocol/stack/base/service/liff/mod.ts`
+- `Vyline/packages/protocol/stack/client/features/liff.ts`
+- `Vyline/packages/protocol/stack/client/features/liff.test.ts`
+- `Vyline/backend/src/service/liffFeatures.ts`
+- `Vyline/backend/src/api/line.ts`

--- a/docs/analysis/liff.md
+++ b/docs/analysis/liff.md
@@ -19,7 +19,7 @@ LIFF access token は通常の LINE access token や Note/Album の ChannelToken
 
 ### `sender`
 
-今回追加する helper は namespace export される `liff` から利用する。
+namespace export される `liff` から利用できる。
 
 ```ts
 import { liff } from "@vyline/protocol/stack";
@@ -49,7 +49,41 @@ await client.liff.shareMessage(chatMid, message);
 
 ### `sender` と `sentBy` の違い
 
-既存 `text(body, sentBy)` の `sentBy` は `label` / `iconUrl` / `linkUrl` を持つ既存の footer metadata で、今回の `sender: { name, iconUrl }` とは別フィールド。互換性維持のため統合・置換しない。
+履歴上、`sentBy` は Vyline の初期 LIFF 実装から存在していた互換 metadata で、`label` / `iconUrl` / `linkUrl` を持つ。一方、`sender` は LINE Messaging API の正式な送信者表示カスタマイズで、`name` / `iconUrl` を持つ。
+
+そのため表示文字列・名前の正本は `sender.name`、アイコンは `sender.iconUrl` を優先する。LINE 公式の `sender` には URL フィールドがないため、URL が必要な場合だけ既存の `sentBy.linkUrl` を併用する。
+
+3項目をまとめて指定したい場合は `withAttribution()` を使う。
+
+```ts
+const message = liff.withAttribution(liff.text("Hello!"), {
+  name: "Cony",
+  iconUrl: "https://example.com/icon.png",
+  linkUrl: "https://example.com/profile",
+});
+```
+
+生成される payload:
+
+```json
+{
+  "type": "text",
+  "text": "Hello!",
+  "sender": {
+    "name": "Cony",
+    "iconUrl": "https://example.com/icon.png"
+  },
+  "sentBy": {
+    "label": "Cony",
+    "iconUrl": "https://example.com/icon.png",
+    "linkUrl": "https://example.com/profile"
+  }
+}
+```
+
+`withAttribution()` は常に正規の `sender` を生成し、`linkUrl` が指定された場合だけ同じ表示名・アイコンを `sentBy` にも複製して URL を保持する。名前・アイコンだけなら `withSender()`、名前・アイコン・URL の3項目なら `withAttribution()` を使う。
+
+`sentBy` を LINE 公式 schema として扱わないこと。現時点で LINE Developers の公式資料上に `sentBy` の仕様は確認できていない。
 
 ## LIFF feature 実装
 

--- a/docs/analysis/liff.md
+++ b/docs/analysis/liff.md
@@ -19,22 +19,10 @@ LIFF access token は通常の LINE access token や Note/Album の ChannelToken
 
 ### `sender`
 
-LIFF share payload では次の sender metadata を付加できる。
+今回追加する helper は namespace export される `liff` から利用する。
 
 ```ts
-const message = client.liffMessage.withSender(
-  { type: "text", text: "Hello!" },
-  {
-    name: "Cony",
-    iconUrl: "https://example.com/icon.png",
-  },
-);
-```
-
-実際の helper は namespace export される `liff` から利用する想定:
-
-```ts
-import { Client, liff } from "@vyline/protocol/stack";
+import { liff } from "@vyline/protocol/stack";
 
 const message = liff.withSender(liff.text("Hello!"), {
   name: "Cony",

--- a/docs/analysis/liff.md
+++ b/docs/analysis/liff.md
@@ -53,13 +53,17 @@ await client.liff.shareMessage(chatMid, message);
 
 そのため表示文字列・名前の正本は `sender.name`、アイコンは `sender.iconUrl` を優先する。LINE 公式の `sender` には URL フィールドがないため、URL が必要な場合だけ既存の `sentBy.linkUrl` を併用する。
 
-3項目をまとめて指定したい場合は `withAttribution()` を使う。
+通常の送信では、text / flex / image なども含めて LINE の message JSON をそのまま `sendLiff()` に渡す。表示名・アイコン・URL も message 内の `sender` にまとめて指定する。
 
 ```ts
-const message = liff.withAttribution(liff.text("Hello!"), {
-  name: "Cony",
-  iconUrl: "https://example.com/icon.png",
-  linkUrl: "https://example.com/profile",
+await client.liff.sendLiff(chatMid, {
+  type: "text",
+  text: "Hello!",
+  sender: {
+    name: "Cony",
+    iconUrl: "https://example.com/icon.png",
+    linkUrl: "https://example.com/profile",
+  },
 });
 ```
 
@@ -81,7 +85,7 @@ const message = liff.withAttribution(liff.text("Hello!"), {
 }
 ```
 
-`withAttribution()` は常に正規の `sender` を生成し、`linkUrl` が指定された場合だけ同じ表示名・アイコンを `sentBy` にも複製して URL を保持する。名前・アイコンだけなら `withSender()`、名前・アイコン・URL の3項目なら `withAttribution()` を使う。
+`sendLiff()` は内部で正規の `sender` を生成し、`sender.linkUrl` が指定された場合だけ同じ表示名・アイコンを `sentBy` にも複製して URL を保持する。呼び出し側は通常 `sentBy` を意識しなくてよい。`liff.text()` / `withSender()` / `withAttribution()` など既存 helper は互換・低レベル用途として残す。
 
 `sentBy` を LINE 公式 schema として扱わないこと。現時点で LINE Developers の公式資料上に `sentBy` の仕様は確認できていない。
 

--- a/docs/analysis/liff.md
+++ b/docs/analysis/liff.md
@@ -49,11 +49,11 @@ await client.liff.shareMessage(chatMid, message);
 
 ### `sender` と `sentBy` の違い
 
-履歴上、`sentBy` は Vyline の初期 LIFF 実装から存在していた互換 metadata で、`label` / `iconUrl` / `linkUrl` を持つ。一方、`sender` は LINE Messaging API の正式な送信者表示カスタマイズで、`name` / `iconUrl` を持つ。
+Vyline の公開 API では分かりやすい `sender: { name, iconUrl, linkUrl }` を受け付ける。実際の LIFF share 送信時には、この値を LINE 側で表示確認できた `sentBy: { label, iconUrl, linkUrl }` へ変換する。
 
-そのため表示文字列・名前の正本は `sender.name`、アイコンは `sender.iconUrl` を優先する。LINE 公式の `sender` には URL フィールドがないため、URL が必要な場合だけ既存の `sentBy.linkUrl` を併用する。
+つまり呼び出し側の正本は `sender.name` / `sender.iconUrl` / `sender.linkUrl`、wire payload の正本は `sentBy.label` / `sentBy.iconUrl` / `sentBy.linkUrl` とする。UI 側が `sentBy` の命名差を意識する必要はない。
 
-通常の送信では、text / flex / image なども含めて LINE の message JSON をそのまま `sendLiff()` に渡す。表示名・アイコン・URL も message 内の `sender` にまとめて指定する。
+通常の送信では、text / flex / image などの message JSON を `sendLiff()` に渡し、表示名・アイコン・URLだけ `sender` にまとめて指定する。
 
 ```ts
 await client.liff.sendLiff(chatMid, {
@@ -85,9 +85,9 @@ await client.liff.sendLiff(chatMid, {
 }
 ```
 
-`sendLiff()` は内部で正規の `sender` を生成し、`sender.linkUrl` が指定された場合だけ同じ表示名・アイコンを `sentBy` にも複製して URL を保持する。呼び出し側は通常 `sentBy` を意識しなくてよい。`liff.text()` / `withSender()` / `withAttribution()` など既存 helper は互換・低レベル用途として残す。
+`sendLiff()` は送信直前に `sender` を取り除き、同じ値を `sentBy` へ正規化する。実アカウントの許可済みテストグループでも、この形で LIFF share が成功し送信者表示を確認できた。`liff.text()` / `withSender()` / `withAttribution()` は互換・低レベル用途として残す。
 
-`sentBy` を LINE 公式 schema として扱わないこと。現時点で LINE Developers の公式資料上に `sentBy` の仕様は確認できていない。
+`sentBy` は公開 LIFF SDK の一般的な message 型として文書化されている前提にはせず、Vyline では実通信・実機表示で確認した LIFF share 用 wire metadata として扱う。
 
 ## LIFF feature 実装
 

--- a/docs/analysis/note-album.md
+++ b/docs/analysis/note-album.md
@@ -1,0 +1,115 @@
+# Note / Album API 実装メモ
+
+最終更新: 2026-08-29
+
+LINE のノートとアルバムは Talk RPC ではなく、ChannelToken を使う REST/OBS 系 API が中心。Vyline は既定デバイス `IOSIPAD` の通常ログインセッションから必要な ChannelToken を発行し、Note/Album 専用の2回目ログインを前提にしない。
+
+## 認証の整理
+
+| 用途 | Channel ID | 主な認証 |
+| --- | --- | --- |
+| Note | `1655599932` | `X-Line-ChannelToken` + ログイン済み MID/アプリ情報 |
+| Square Note | `1657618623` | Square Note 用 ChannelToken |
+| Album | `1375220249` | `X-Line-ChannelToken` + `X-Line-Mid` / `X-Line-Chat-Id` |
+
+ChannelToken は `channelTokens.get(channelId, { approve: true })` から取得し、401 の場合は `channelTokens.reissue(channelId, true)` で再発行する。通常の LINE access token、LIFF access token、ChannelToken を相互流用しない。
+
+## Note
+
+正本:
+
+- protocol: `Vyline/packages/protocol/stack/base/timeline/mod.ts`
+- BFF service: `Vyline/backend/src/service/noteService.ts`
+- HTTP routes: `Vyline/backend/src/api/line.ts`
+
+### 実装済み操作
+
+- 一覧取得
+- 単体取得
+- 作成
+- 更新
+- 削除
+- チャットへの共有
+- いいね / いいね解除 / 状態取得 / 一覧取得
+- コメント作成
+- 投稿メディア upload
+- コメント画像 upload
+
+Note REST は主に `https://legy-jp.line-apps.com/ext/note/nt/api/v57/...` を使う。投稿 CRUD は `post/create.json`, `post/update.json`, `post/delete.json`, `post/get.json`, `post/list.json`, `post/share.json` 系。
+
+### 投稿メディア
+
+現在の iOS/iPad 実測経路では投稿メディアを `obs-jp.line-apps.com/r/privnote/post/<oid>` に upload する。`x-obs-params` は JSON を base64 化した値を使い、レスポンスの `x-obs-oid` / `x-obs-hash` を Note payload の media entry に反映する。
+
+コメント画像は投稿メディアと OBS namespace が異なる。`myhome/cmt` 系を使い、Note コメントの `contentsList` には `categoryId: "media"` と `serviceName: "myhome"`, `obsNamespace: "cmt"` を設定する。コメント画像と投稿画像の object id を使い回さない。
+
+### 401 の扱い
+
+以前の 401 は upload 完了前の HAR や未完了 ChannelToken フローを根拠に固定実装しない。現在は ChannelToken manager を正本にして、token 取得完了後に OBS/REST を実行し、401 の場合だけ明示的に再発行して再試行する。
+
+## Album
+
+正本:
+
+- protocol: `Vyline/packages/protocol/stack/base/album/mod.ts`
+- BFF service: `Vyline/backend/src/service/albumService.ts`
+- HTTP routes: `Vyline/backend/src/api/line.ts`
+
+### 実装済み操作
+
+- アルバム一覧 / preview
+- 作成
+- タイトル更新
+- 削除
+- チャット共有
+- 写真一覧
+- 写真追加
+- 写真削除
+- メディア upload
+- メディア download
+
+Album REST は `https://legy-jp.line-apps.com/ext/album/api/v6/...` を使う。チャット対象は `X-Line-Chat-Id`、ChannelToken は Album channel `1375220249` を利用する。
+
+### Album OBS upload
+
+画像 upload は `https://obs-jp.line-apps.com/r/album/a/<oid>`。主要 header:
+
+- `X-Line-ChannelToken`
+- `X-Line-Mid`（対象 chat id）
+- `X-Line-Album`
+- `Upload-Draft-Interop-Version: 6`
+- `Upload-Complete: ?1`
+- `content-type: application/octet-stream`
+- `x-obs-params`
+
+upload 後は `x-obs-oid` を優先して写真作成 payload の `obsResourceId.oid` に使う。`obsResourceId` の既定は `sid: "a"`, `svc: "album"`。
+
+### download
+
+`/r/album/a/<oid>/m1200` 系を使い、upload と同じ Album ChannelToken / chat / album context を付ける。UI では API response を直接保存せず、既存 media storage / cache 方針に合わせる。
+
+## BFF の方針
+
+任意 URL/path を受け取る proxy は公開しない。`Vyline/backend/src/api/line.ts` には操作ごとの固定 route を置き、入力検証後に `noteService.ts` / `albumService.ts` へ委譲する。
+
+主な route family:
+
+- `/:accountId/notes...`
+- `/:accountId/albums...`
+
+認証情報・ChannelToken・OBS header は frontend へ露出させない。
+
+## 検証時のチェックリスト
+
+1. 通常の `IOSIPAD` ログイン1回で session が利用可能か。
+2. ChannelToken が対象 channel ID で発行・保存されているか。
+3. REST の chat/home context が実対象と一致するか。
+4. upload 完了レスポンスの object id/hash を次の create/update に使っているか。
+5. 401 時は同じ stale token の単純再送ではなく再発行しているか。
+6. 作成テストでは最後に削除まで行い、テストデータを残さない。
+
+## 関連ドキュメント
+
+- [token-lifecycle.md](./token-lifecycle.md)
+- [dual-login-desktop.md](./dual-login-desktop.md)
+- [../protocol/dictionary.md](../protocol/dictionary.md)


### PR DESCRIPTION
## Summary
- update the protocol submodule with LIFF `sender` support and focused tests
- expose `sender: { name, iconUrl, linkUrl }` to callers and document that send-time normalization uses LINE's verified `sentBy: { label, iconUrl, linkUrl }` wire shape
- document LIFF token/share flow
- document Note/Album ChannelToken, CRUD, OBS upload/download, iOS/iPad session behavior, and 401 reissue guidance
- add the LIFF / Note / Album analysis docs to the documentation indexes

## UI
- no UI integration for LIFF sender yet, by design

## Dependency
- merge protocol PR nezumi0627/vyline-api#9 first

## Verification
- protocol typecheck: passed
- protocol build: passed
- LIFF tests: 10/10 passed
- live LIFF send in the permitted test group succeeded and sender attribution was confirmed
- GitHub Actions are being re-checked after the final protocol/docs update