### PR TITLE
feat(ui): プロフィールにノート・アルバム一覧を追加

### DIFF
--- a/Vyline/apps/desktop/src/components/profile-content-panel.tsx
+++ b/Vyline/apps/desktop/src/components/profile-content-panel.tsx
@@ -1,0 +1,242 @@
+import { useEffect, useState } from "react";
+import { api } from "@/api/client";
+
+type PanelKind = "notes" | "albums";
+
+function records(value: unknown, keys: string[]) {
+  if (!value || typeof value !== "object") return [];
+  const root = value as Record<string, unknown>;
+  const result =
+    root.result && typeof root.result === "object"
+      ? (root.result as Record<string, unknown>)
+      : root;
+  for (const key of keys) {
+    const list = result[key];
+    if (Array.isArray(list)) {
+      return list.filter(
+        (item): item is Record<string, unknown> => !!item && typeof item === "object",
+      );
+    }
+  }
+  return [];
+}
+
+function noteText(post: Record<string, unknown>) {
+  const contents =
+    post.contents && typeof post.contents === "object"
+      ? (post.contents as Record<string, unknown>)
+      : post;
+  return String(contents.text ?? post.text ?? "").trim();
+}
+
+export function ProfileContentPanel({
+  kind,
+  accountId,
+  chatId,
+}: {
+  kind: PanelKind;
+  accountId: string;
+  chatId: string;
+}) {
+  const [items, setItems] = useState<Array<Record<string, unknown>>>([]);
+  const [photos, setPhotos] = useState<Array<Record<string, unknown>>>([]);
+  const [selectedAlbumId, setSelectedAlbumId] = useState("");
+  const [selectedAlbumTitle, setSelectedAlbumTitle] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const value =
+        kind === "notes"
+          ? await api.line.notes.list(accountId, chatId)
+          : await api.line.albums.list(accountId, { chatId });
+      setItems(
+        records(
+          value,
+          kind === "notes"
+            ? ["posts", "items", "postList", "feeds"]
+            : ["albums", "items", "albumList"],
+        ),
+      );
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    setSelectedAlbumId("");
+    setSelectedAlbumTitle("");
+    setPhotos([]);
+    void refresh();
+  }, [accountId, chatId, kind]);
+
+  const openAlbum = async (id: string, title: string) => {
+    setSelectedAlbumId(id);
+    setSelectedAlbumTitle(title);
+    setLoading(true);
+    setError(null);
+    try {
+      setPhotos(records(await api.line.albums.photos(accountId, id, chatId), ["photos", "items"]));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="px-5 pb-6">
+      <div className="mb-4 flex items-center justify-between">
+        <div className="min-w-0">
+          <p className="truncate text-sm font-semibold">
+            {kind === "notes"
+              ? "ノート一覧"
+              : selectedAlbumId
+                ? selectedAlbumTitle
+                : "アルバム一覧"}
+          </p>
+          <p className="mt-0.5 text-xs text-[var(--vy-text-dim)]">
+            {kind === "notes"
+              ? "このトークに保存されているノート"
+              : selectedAlbumId
+                ? `${photos.length}件のメディア`
+                : "このトークで共有されているアルバム"}
+          </p>
+        </div>
+        <button
+          type="button"
+          disabled={loading}
+          onClick={() => {
+            if (selectedAlbumId) {
+              setSelectedAlbumId("");
+              setSelectedAlbumTitle("");
+              setPhotos([]);
+            } else {
+              void refresh();
+            }
+          }}
+          className="shrink-0 rounded-lg px-2.5 py-1.5 text-xs font-medium text-[var(--vy-accent)] transition-colors hover:bg-[var(--vy-surface-2)] disabled:opacity-50"
+        >
+          {selectedAlbumId ? "一覧へ" : "再読み込み"}
+        </button>
+      </div>
+
+      {error && (
+        <div className="mb-3 rounded-xl border border-[color-mix(in_oklab,var(--vy-danger)_35%,var(--vy-border))] bg-[color-mix(in_oklab,var(--vy-danger)_8%,transparent)] px-3 py-2 text-xs text-[var(--vy-danger)]">
+          {error}
+        </div>
+      )}
+
+      {loading && items.length === 0 && photos.length === 0 ? (
+        <div className="py-16 text-center text-sm text-[var(--vy-text-dim)]">読み込み中…</div>
+      ) : kind === "notes" ? (
+        items.length === 0 ? (
+          <Empty label="ノートはまだありません" />
+        ) : (
+          <div className="space-y-2">
+            {items.map((post, index) => {
+              const id = String(post.postId ?? post.id ?? index);
+              const text = noteText(post);
+              return (
+                <article
+                  key={id}
+                  className="rounded-2xl border border-[var(--vy-border)] bg-[var(--vy-surface-2)] px-4 py-3"
+                >
+                  <p className="whitespace-pre-wrap break-words text-sm leading-6">
+                    {text || "画像・動画・スタンプを含むノート"}
+                  </p>
+                  <p className="mt-2 truncate text-[10px] text-[var(--vy-text-dim)]">{id}</p>
+                </article>
+              );
+            })}
+          </div>
+        )
+      ) : selectedAlbumId ? (
+        photos.length === 0 ? (
+          <Empty label="このアルバムには写真がありません" />
+        ) : (
+          <div className="grid grid-cols-2 gap-2">
+            {photos.map((photo, index) => {
+              const resource =
+                photo.obsResourceId && typeof photo.obsResourceId === "object"
+                  ? (photo.obsResourceId as Record<string, unknown>)
+                  : undefined;
+              const oid = String(photo.oid ?? resource?.oid ?? "");
+              if (!oid) return null;
+              const isVideo =
+                String(photo.resourceType ?? resource?.sid ?? "").toLowerCase() === "v";
+              const src = api.line.albums.mediaUrl(
+                accountId,
+                selectedAlbumId,
+                oid,
+                chatId,
+                isVideo ? "video" : "image",
+              );
+              return isVideo ? (
+                <video
+                  key={`${oid}-${index}`}
+                  src={src}
+                  controls
+                  preload="metadata"
+                  className="aspect-square w-full rounded-xl border border-[var(--vy-border)] bg-black object-cover"
+                />
+              ) : (
+                <img
+                  key={`${oid}-${index}`}
+                  src={src}
+                  alt="アルバム写真"
+                  loading="lazy"
+                  className="aspect-square w-full rounded-xl border border-[var(--vy-border)] bg-[var(--vy-surface-2)] object-cover"
+                />
+              );
+            })}
+          </div>
+        )
+      ) : items.length === 0 ? (
+        <Empty label="アルバムはまだありません" />
+      ) : (
+        <div className="grid grid-cols-2 gap-2">
+          {items.map((album, index) => {
+            const id = String(album.albumId ?? album.id ?? "");
+            const title = String(album.title ?? album.name ?? `アルバム ${index + 1}`);
+            return (
+              <button
+                key={id || index}
+                type="button"
+                disabled={!id}
+                onClick={() => id && void openAlbum(id, title)}
+                className="group overflow-hidden rounded-2xl border border-[var(--vy-border)] bg-[var(--vy-surface-2)] text-left transition-transform hover:-translate-y-0.5 disabled:opacity-50"
+              >
+                <div className="grid aspect-[4/3] grid-cols-2 gap-px bg-[var(--vy-border)]">
+                  {[0, 1, 2, 3].map((cell) => (
+                    <span
+                      key={cell}
+                      className="bg-[color-mix(in_oklab,var(--vy-accent)_12%,var(--vy-surface))] transition-colors group-hover:bg-[color-mix(in_oklab,var(--vy-accent)_18%,var(--vy-surface))]"
+                    />
+                  ))}
+                </div>
+                <div className="px-3 py-2.5">
+                  <p className="truncate text-sm font-medium">{title}</p>
+                  <p className="mt-0.5 truncate text-[10px] text-[var(--vy-text-dim)]">{id}</p>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Empty({ label }: { label: string }) {
+  return (
+    <div className="rounded-2xl border border-dashed border-[var(--vy-border)] bg-[var(--vy-surface-2)] px-4 py-14 text-center text-sm text-[var(--vy-text-dim)]">
+      {label}
+    </div>
+  );
+}

--- a/Vyline/apps/desktop/src/components/profile-drawer.tsx
+++ b/Vyline/apps/desktop/src/components/profile-drawer.tsx
@@ -15,10 +15,13 @@ import {
   IconCheck,
   IconDownload,
   IconMemo,
+  IconArrowLeft,
+  IconPaperclip,
 } from "@/components/icons";
 import { looksLikeMid, mapMember } from "@/lib/mappers";
 import { dismissChatMid } from "@/utils/dismissedChats";
 import { AgentIActionDialog } from "@/components/agent-i-action-dialog";
+import { ProfileContentPanel } from "@/components/profile-content-panel";
 
 type RichInfo = {
   statusMessage?: string;
@@ -57,6 +60,11 @@ export function ProfileDrawer({ chat }: { chat: Chat }) {
   const [verifyMsg, setVerifyMsg] = useState<string | null>(null);
   const [apiCommonGroups, setApiCommonGroups] = useState<Chat[] | null>(null);
   const [agentPrompt, setAgentPrompt] = useState<string | null>(null);
+  const [view, setView] = useState<"profile" | "notes" | "albums">("profile");
+
+  useEffect(() => {
+    setView("profile");
+  }, [chat.id]);
 
   // 共通グループ: VylineCache 一括読み（RPC なし）→ 失敗時は従来のローカル判定へ
   const commonGroups = useMemo(() => {
@@ -414,7 +422,21 @@ export function ProfileDrawer({ chat }: { chat: Chat }) {
       />
       <aside className="vy-drawer-in fixed inset-y-0 right-0 z-40 flex w-[min(360px,88vw)] flex-col border-l border-[var(--vy-border)] bg-[var(--vy-surface)] xl:relative xl:z-0 xl:w-[340px]">
         <div className="flex items-center justify-between px-4 py-3">
-          <span className="text-sm font-semibold">プロフィール</span>
+          <div className="flex min-w-0 items-center gap-1">
+            {view !== "profile" && (
+              <button
+                type="button"
+                onClick={() => setView("profile")}
+                aria-label="プロフィールに戻る"
+                className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-[var(--vy-text-dim)] transition-colors hover:bg-[var(--vy-surface-2)] hover:text-[var(--vy-text)] focus-visible:ring-2 focus-visible:ring-[var(--vy-accent)] focus-visible:outline-none"
+              >
+                <IconArrowLeft size={18} />
+              </button>
+            )}
+            <span className="truncate text-sm font-semibold">
+              {view === "profile" ? "プロフィール" : view === "notes" ? "ノート" : "アルバム"}
+            </span>
+          </div>
           <button
             type="button"
             onClick={() => setProfileDrawer(false)}
@@ -425,277 +447,299 @@ export function ProfileDrawer({ chat }: { chat: Chat }) {
           </button>
         </div>
 
-        <div className="vy-scroll flex-1 overflow-y-auto px-5 pb-6">
-          <div className="overflow-hidden rounded-2xl border border-[var(--vy-border)]">
-            <div
-              className="h-28 bg-[color-mix(in_oklab,var(--vy-accent)_18%,var(--vy-surface-2))]"
-              style={
-                showBackground
-                  ? {
-                      backgroundImage: `linear-gradient(180deg, color-mix(in oklab, black 8%, transparent), color-mix(in oklab, black 20%, transparent)), url(${backgroundUrl})`,
-                      backgroundSize: "cover",
-                      backgroundPosition: "center",
-                    }
-                  : { background: `color-mix(in oklab, ${chat.color} 22%, var(--vy-surface-2))` }
-              }
-            />
-            <div className="-mt-12 flex flex-col items-center px-4 pb-4 text-center">
-              <Avatar
-                glyph={streamerMode ? "•" : chat.avatar}
-                color={chat.color}
-                size={88}
-                online={chat.online}
-                imageUrl={streamerMode ? undefined : chat.avatarUrl}
-                icon={!streamerMode && chat.isSelf ? <IconMemo size={44} /> : undefined}
+        {view === "profile" ? (
+          <div className="vy-scroll flex-1 overflow-y-auto px-5 pb-6">
+            <div className="overflow-hidden rounded-2xl border border-[var(--vy-border)]">
+              <div
+                className="h-28 bg-[color-mix(in_oklab,var(--vy-accent)_18%,var(--vy-surface-2))]"
+                style={
+                  showBackground
+                    ? {
+                        backgroundImage: `linear-gradient(180deg, color-mix(in oklab, black 8%, transparent), color-mix(in oklab, black 20%, transparent)), url(${backgroundUrl})`,
+                        backgroundSize: "cover",
+                        backgroundPosition: "center",
+                      }
+                    : { background: `color-mix(in oklab, ${chat.color} 22%, var(--vy-surface-2))` }
+                }
               />
-              {editing ? (
-                <div className="mt-3 flex w-full items-center gap-2">
-                  <input
-                    value={nameInput}
-                    onChange={(e) => setNameInput(e.target.value)}
-                    className="w-full rounded-lg border border-[var(--vy-border)] bg-[var(--vy-surface-2)] px-3 py-2 text-center text-lg font-semibold outline-none focus-visible:ring-2 focus-visible:ring-[var(--vy-accent)]"
-                    aria-label={chat.type === "friend" ? "友だち表示名" : "表示名（ローカル）"}
-                  />
-                  <button
-                    type="button"
-                    disabled={busy}
-                    onClick={() => void saveName()}
-                    aria-label="保存"
-                    className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-[var(--vy-accent-contrast)] disabled:opacity-50"
-                    style={{ background: "var(--vy-accent)" }}
-                  >
-                    <IconCheck size={18} />
-                  </button>
-                </div>
-              ) : (
-                <div className="mt-3 flex items-center gap-2">
-                  <h2 className="text-xl font-bold">{name}</h2>
-                  {!streamerMode && chat.isOfficial && <OfficialBadge />}
-                  {chat.isSelf && selfPremium && <PremiumBadge size={14} compact />}
-                  {!streamerMode && !chat.isSelf && (
+              <div className="-mt-12 flex flex-col items-center px-4 pb-4 text-center">
+                <Avatar
+                  glyph={streamerMode ? "•" : chat.avatar}
+                  color={chat.color}
+                  size={88}
+                  online={chat.online}
+                  imageUrl={streamerMode ? undefined : chat.avatarUrl}
+                  icon={!streamerMode && chat.isSelf ? <IconMemo size={44} /> : undefined}
+                />
+                {editing ? (
+                  <div className="mt-3 flex w-full items-center gap-2">
+                    <input
+                      value={nameInput}
+                      onChange={(e) => setNameInput(e.target.value)}
+                      className="w-full rounded-lg border border-[var(--vy-border)] bg-[var(--vy-surface-2)] px-3 py-2 text-center text-lg font-semibold outline-none focus-visible:ring-2 focus-visible:ring-[var(--vy-accent)]"
+                      aria-label={chat.type === "friend" ? "友だち表示名" : "表示名（ローカル）"}
+                    />
                     <button
                       type="button"
-                      onClick={() => setEditing(true)}
-                      aria-label="表示名を変更"
-                      className="text-[var(--vy-text-dim)] transition-colors hover:text-[var(--vy-accent)]"
+                      disabled={busy}
+                      onClick={() => void saveName()}
+                      aria-label="保存"
+                      className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-[var(--vy-accent-contrast)] disabled:opacity-50"
+                      style={{ background: "var(--vy-accent)" }}
                     >
-                      <IconEdit size={16} />
+                      <IconCheck size={18} />
                     </button>
-                  )}
-                </div>
-              )}
-              {chat.left && (
-                <span className="mt-2 rounded-full bg-[color-mix(in_oklab,var(--vy-danger)_18%,transparent)] px-2.5 py-0.5 text-xs font-medium text-[var(--vy-danger)]">
-                  {chat.type === "friend" ? "アカウント削除済み" : "退出済み"}
-                </span>
-              )}
-              {isBlocked && (
-                <span className="mt-2 rounded-full bg-[color-mix(in_oklab,var(--vy-danger)_18%,transparent)] px-2.5 py-0.5 text-xs font-medium text-[var(--vy-danger)]">
-                  ブロック中
-                </span>
-              )}
-              {!streamerMode && (
-                <p className="mt-1 font-mono text-[0.65rem] break-all text-[var(--vy-text-dim)] select-all">
-                  {chat.id}
-                </p>
-              )}
-              {!streamerMode &&
-                settings.showStatusMessage &&
-                (chat.statusMessage ?? rich.statusMessage) && (
-                  <p className="mt-1 text-sm text-[var(--vy-text-dim)]">
-                    {chat.statusMessage ?? rich.statusMessage}
+                  </div>
+                ) : (
+                  <div className="mt-3 flex items-center gap-2">
+                    <h2 className="text-xl font-bold">{name}</h2>
+                    {!streamerMode && chat.isOfficial && <OfficialBadge />}
+                    {chat.isSelf && selfPremium && <PremiumBadge size={14} compact />}
+                    {!streamerMode && !chat.isSelf && (
+                      <button
+                        type="button"
+                        onClick={() => setEditing(true)}
+                        aria-label="表示名を変更"
+                        className="text-[var(--vy-text-dim)] transition-colors hover:text-[var(--vy-accent)]"
+                      >
+                        <IconEdit size={16} />
+                      </button>
+                    )}
+                  </div>
+                )}
+                {chat.left && (
+                  <span className="mt-2 rounded-full bg-[color-mix(in_oklab,var(--vy-danger)_18%,transparent)] px-2.5 py-0.5 text-xs font-medium text-[var(--vy-danger)]">
+                    {chat.type === "friend" ? "アカウント削除済み" : "退出済み"}
+                  </span>
+                )}
+                {isBlocked && (
+                  <span className="mt-2 rounded-full bg-[color-mix(in_oklab,var(--vy-danger)_18%,transparent)] px-2.5 py-0.5 text-xs font-medium text-[var(--vy-danger)]">
+                    ブロック中
+                  </span>
+                )}
+                {!streamerMode && (
+                  <p className="mt-1 font-mono text-[0.65rem] break-all text-[var(--vy-text-dim)] select-all">
+                    {chat.id}
                   </p>
                 )}
+                {!streamerMode &&
+                  settings.showStatusMessage &&
+                  (chat.statusMessage ?? rich.statusMessage) && (
+                    <p className="mt-1 text-sm text-[var(--vy-text-dim)]">
+                      {chat.statusMessage ?? rich.statusMessage}
+                    </p>
+                  )}
+              </div>
             </div>
-          </div>
 
-          {!streamerMode && (chat.isOfficial || rich.userType === 2) && (
-            <div className="mt-4">
-              <span className="inline-flex w-fit items-center gap-1.5 rounded-full bg-[color-mix(in_oklab,var(--vy-accent)_16%,transparent)] px-2.5 py-1 text-xs font-medium text-[var(--vy-accent)]">
-                <OfficialBadge className="ml-0" />
-                公式アカウント
-              </span>
-            </div>
-          )}
-
-          {!streamerMode && (chat.left || isBlocked) && (
-            <div className="mt-4 space-y-1 rounded-xl border border-[var(--vy-border)] bg-[var(--vy-surface-2)] px-3 py-2 text-sm">
-              {chat.left && <p className="text-[var(--vy-danger)]">アカウントは削除済みです</p>}
-              {isBlocked && (
-                <p className="text-[var(--vy-danger)]">アカウントをブロックしています</p>
-              )}
-            </div>
-          )}
-
-          <div className="mt-6 grid grid-cols-3 gap-2">
-            <Action icon={<IconChat size={20} />} label="トーク" onClick={handleTalk} />
-            <Action icon={<IconPhone size={20} />} label="音声通話" disabled />
-            <Action icon={<IconVideo size={20} />} label="ビデオ通話" disabled />
-            <Action
-              icon={<IconDownload size={20} />}
-              label="トーク保存"
-              onClick={() => {
-                const { accountId } = useStore.getState();
-                if (!accountId) return;
-                setActionMsg("保存中…");
-                void api.line
-                  .exportMessages(accountId, chat.id, "txt")
-                  .then(() => setActionMsg("トークを保存しました"))
-                  .catch((err) =>
-                    setActionMsg(err instanceof Error ? err.message : "保存に失敗しました"),
-                  );
-              }}
-            />
-          </div>
-
-          {!streamerMode && settings.betaAgentI && chat.type === "friend" && !chat.isSelf && (
-            <button
-              type="button"
-              disabled={!conversationText}
-              onClick={() =>
-                setAgentPrompt(
-                  `次の「${name}」とのこれまでの会話を日本語で5行以内に要約してください。重要な決定、約束、TODOを含めてください。\n\n${conversationText}`,
-                )
-              }
-              className="mt-3 flex w-full items-center justify-center gap-2 rounded-xl border border-[var(--vy-border)] px-3 py-2.5 text-sm disabled:opacity-50"
-            >
-              AIでこの人との会話を要約
-            </button>
-          )}
-
-          {!streamerMode &&
-            settings.betaBlockCheckManual &&
-            chat.type === "friend" &&
-            !chat.isOfficial && (
-              <div className="mt-3">
-                <button
-                  type="button"
-                  disabled={verifyBusy}
-                  onClick={() => {
-                    if (!accountId) return;
-                    setVerifyBusy(true);
-                    setVerifyMsg(null);
-                    void api.line
-                      .verifyFriendBlockStatus(accountId, chat.id)
-                      .then((res) => {
-                        const result = res.results?.[0];
-                        setVerifyMsg(
-                          result?.status === "blocked"
-                            ? "ブロック中です"
-                            : result?.status === "not_blocked"
-                              ? "ブロックされていません"
-                              : (result?.reason ?? "確認できませんでした"),
-                        );
-                      })
-                      .catch((err) =>
-                        setVerifyMsg(err instanceof Error ? err.message : "確認に失敗しました"),
-                      )
-                      .finally(() => setVerifyBusy(false));
-                  }}
-                  className="w-full rounded-xl border border-[var(--vy-border)] px-3 py-2 text-sm transition-colors hover:bg-[var(--vy-surface-2)] disabled:opacity-50"
-                >
-                  {verifyBusy ? "ブロック状態を確認中…" : "ブロック状態を確認"}
-                </button>
-                {verifyMsg && <p className="mt-1 text-xs text-[var(--vy-text-dim)]">{verifyMsg}</p>}
+            {!streamerMode && (chat.isOfficial || rich.userType === 2) && (
+              <div className="mt-4">
+                <span className="inline-flex w-fit items-center gap-1.5 rounded-full bg-[color-mix(in_oklab,var(--vy-accent)_16%,transparent)] px-2.5 py-1 text-xs font-medium text-[var(--vy-accent)]">
+                  <OfficialBadge className="ml-0" />
+                  公式アカウント
+                </span>
               </div>
             )}
 
-          {chat.type === "friend" && !streamerMode && !chat.isSelf && commonGroups.length > 0 && (
-            <div className="mt-6">
-              <div className="mb-2 flex items-center gap-2 text-xs font-medium text-[var(--vy-text-dim)]">
-                <IconUsers size={15} />
-                共通のグループ ({commonGroups.length})
+            {!streamerMode && (chat.left || isBlocked) && (
+              <div className="mt-4 space-y-1 rounded-xl border border-[var(--vy-border)] bg-[var(--vy-surface-2)] px-3 py-2 text-sm">
+                {chat.left && <p className="text-[var(--vy-danger)]">アカウントは削除済みです</p>}
+                {isBlocked && (
+                  <p className="text-[var(--vy-danger)]">アカウントをブロックしています</p>
+                )}
               </div>
-              <div className="overflow-hidden rounded-xl border border-[var(--vy-border)]">
-                {commonGroups.map((g, i) => (
+            )}
+
+            <div className="mt-6 grid grid-cols-3 gap-2">
+              <Action icon={<IconChat size={20} />} label="トーク" onClick={handleTalk} />
+              <Action icon={<IconPhone size={20} />} label="音声通話" disabled />
+              <Action icon={<IconVideo size={20} />} label="ビデオ通話" disabled />
+              <Action
+                icon={<IconMemo size={20} />}
+                label="ノート"
+                onClick={() => setView("notes")}
+              />
+              <Action
+                icon={<IconPaperclip size={20} />}
+                label="アルバム"
+                onClick={() => setView("albums")}
+              />
+              <Action
+                icon={<IconDownload size={20} />}
+                label="トーク保存"
+                onClick={() => {
+                  const { accountId } = useStore.getState();
+                  if (!accountId) return;
+                  setActionMsg("保存中…");
+                  void api.line
+                    .exportMessages(accountId, chat.id, "txt")
+                    .then(() => setActionMsg("トークを保存しました"))
+                    .catch((err) =>
+                      setActionMsg(err instanceof Error ? err.message : "保存に失敗しました"),
+                    );
+                }}
+              />
+            </div>
+
+            {!streamerMode && settings.betaAgentI && chat.type === "friend" && !chat.isSelf && (
+              <button
+                type="button"
+                disabled={!conversationText}
+                onClick={() =>
+                  setAgentPrompt(
+                    `次の「${name}」とのこれまでの会話を日本語で5行以内に要約してください。重要な決定、約束、TODOを含めてください。\n\n${conversationText}`,
+                  )
+                }
+                className="mt-3 flex w-full items-center justify-center gap-2 rounded-xl border border-[var(--vy-border)] px-3 py-2.5 text-sm disabled:opacity-50"
+              >
+                AIでこの人との会話を要約
+              </button>
+            )}
+
+            {!streamerMode &&
+              settings.betaBlockCheckManual &&
+              chat.type === "friend" &&
+              !chat.isOfficial && (
+                <div className="mt-3">
                   <button
-                    key={g.id}
                     type="button"
+                    disabled={verifyBusy}
                     onClick={() => {
-                      setProfileDrawer(false);
-                      openChat(g.id);
+                      if (!accountId) return;
+                      setVerifyBusy(true);
+                      setVerifyMsg(null);
+                      void api.line
+                        .verifyFriendBlockStatus(accountId, chat.id)
+                        .then((res) => {
+                          const result = res.results?.[0];
+                          setVerifyMsg(
+                            result?.status === "blocked"
+                              ? "ブロック中です"
+                              : result?.status === "not_blocked"
+                                ? "ブロックされていません"
+                                : (result?.reason ?? "確認できませんでした"),
+                          );
+                        })
+                        .catch((err) =>
+                          setVerifyMsg(err instanceof Error ? err.message : "確認に失敗しました"),
+                        )
+                        .finally(() => setVerifyBusy(false));
                     }}
-                    className="flex w-full items-center gap-3 px-3 py-2.5 text-left transition-colors hover:bg-[var(--vy-surface-2)] focus-visible:ring-2 focus-visible:ring-[var(--vy-accent)] focus-visible:outline-none"
-                    style={i > 0 ? { borderTop: "1px solid var(--vy-border)" } : undefined}
+                    className="w-full rounded-xl border border-[var(--vy-border)] px-3 py-2 text-sm transition-colors hover:bg-[var(--vy-surface-2)] disabled:opacity-50"
                   >
-                    <Avatar glyph={g.avatar} color={g.color} size={36} imageUrl={g.avatarUrl} />
-                    <span className="truncate text-sm font-medium">{displayName(g, false)}</span>
+                    {verifyBusy ? "ブロック状態を確認中…" : "ブロック状態を確認"}
                   </button>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {chat.type === "group" && chat.members && !chat.left && (
-            <div className="mt-6">
-              <div className="mb-2 flex items-center gap-2 text-xs font-medium text-[var(--vy-text-dim)]">
-                <IconUsers size={15} />
-                メンバー {chat.members.length}人
-              </div>
-              <div className="overflow-hidden rounded-xl border border-[var(--vy-border)]">
-                {chat.members.map((m, i) => (
-                  <button
-                    key={m.id}
-                    type="button"
-                    onClick={() => openMemberProfile(chat.id, m.id)}
-                    className="flex w-full items-center gap-3 px-3 py-2.5 text-left transition-colors hover:bg-[var(--vy-surface-2)] focus-visible:ring-2 focus-visible:ring-[var(--vy-accent)] focus-visible:outline-none"
-                    style={i > 0 ? { borderTop: "1px solid var(--vy-border)" } : undefined}
-                  >
-                    <Avatar
-                      glyph={streamerMode ? "•" : m.avatar}
-                      color={m.color}
-                      size={36}
-                      imageUrl={streamerMode ? undefined : m.avatarUrl}
-                    />
-                    <span className="truncate text-sm font-medium">
-                      {streamerMode
-                        ? "メンバー"
-                        : looksLikeMid(m.name)
-                          ? membersLoading
-                            ? "取得中…"
-                            : `${m.name.slice(0, 12)}…`
-                          : m.name}
-                    </span>
-                  </button>
-                ))}
-              </div>
-              {!streamerMode && accountId && (
-                <InviteToGroupRow
-                  chatMid={chat.id}
-                  accountId={accountId}
-                  onDone={(msg) => setActionMsg(msg)}
-                />
+                  {verifyMsg && (
+                    <p className="mt-1 text-xs text-[var(--vy-text-dim)]">{verifyMsg}</p>
+                  )}
+                </div>
               )}
-            </div>
-          )}
 
-          {!streamerMode && !chat.isSelf && (
-            <button
-              type="button"
-              disabled={busy}
-              onClick={() => void leaveOrBlock()}
-              className="mt-6 flex w-full items-center gap-3 rounded-xl border border-[var(--vy-border)] px-4 py-3 text-sm font-medium text-[var(--vy-danger)] transition-colors hover:bg-[color-mix(in_oklab,var(--vy-danger)_12%,transparent)] focus-visible:ring-2 focus-visible:ring-[var(--vy-danger)] focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              <IconLogout size={18} />
-              {chat.type === "group"
-                ? chat.left
-                  ? busy
-                    ? "削除中…"
-                    : "一覧から削除"
-                  : busy
-                    ? "退出中…"
-                    : "グループを退出"
-                : isBlocked
-                  ? busy
-                    ? "解除中…"
-                    : "ブロックを解除"
-                  : busy
-                    ? "処理中…"
-                    : "ブロック"}
-            </button>
-          )}
-          {actionMsg && <p className="mt-2 text-xs text-[var(--vy-text-dim)]">{actionMsg}</p>}
-        </div>
+            {chat.type === "friend" && !streamerMode && !chat.isSelf && commonGroups.length > 0 && (
+              <div className="mt-6">
+                <div className="mb-2 flex items-center gap-2 text-xs font-medium text-[var(--vy-text-dim)]">
+                  <IconUsers size={15} />
+                  共通のグループ ({commonGroups.length})
+                </div>
+                <div className="overflow-hidden rounded-xl border border-[var(--vy-border)]">
+                  {commonGroups.map((g, i) => (
+                    <button
+                      key={g.id}
+                      type="button"
+                      onClick={() => {
+                        setProfileDrawer(false);
+                        openChat(g.id);
+                      }}
+                      className="flex w-full items-center gap-3 px-3 py-2.5 text-left transition-colors hover:bg-[var(--vy-surface-2)] focus-visible:ring-2 focus-visible:ring-[var(--vy-accent)] focus-visible:outline-none"
+                      style={i > 0 ? { borderTop: "1px solid var(--vy-border)" } : undefined}
+                    >
+                      <Avatar glyph={g.avatar} color={g.color} size={36} imageUrl={g.avatarUrl} />
+                      <span className="truncate text-sm font-medium">{displayName(g, false)}</span>
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {chat.type === "group" && chat.members && !chat.left && (
+              <div className="mt-6">
+                <div className="mb-2 flex items-center gap-2 text-xs font-medium text-[var(--vy-text-dim)]">
+                  <IconUsers size={15} />
+                  メンバー {chat.members.length}人
+                </div>
+                <div className="overflow-hidden rounded-xl border border-[var(--vy-border)]">
+                  {chat.members.map((m, i) => (
+                    <button
+                      key={m.id}
+                      type="button"
+                      onClick={() => openMemberProfile(chat.id, m.id)}
+                      className="flex w-full items-center gap-3 px-3 py-2.5 text-left transition-colors hover:bg-[var(--vy-surface-2)] focus-visible:ring-2 focus-visible:ring-[var(--vy-accent)] focus-visible:outline-none"
+                      style={i > 0 ? { borderTop: "1px solid var(--vy-border)" } : undefined}
+                    >
+                      <Avatar
+                        glyph={streamerMode ? "•" : m.avatar}
+                        color={m.color}
+                        size={36}
+                        imageUrl={streamerMode ? undefined : m.avatarUrl}
+                      />
+                      <span className="truncate text-sm font-medium">
+                        {streamerMode
+                          ? "メンバー"
+                          : looksLikeMid(m.name)
+                            ? membersLoading
+                              ? "取得中…"
+                              : `${m.name.slice(0, 12)}…`
+                            : m.name}
+                      </span>
+                    </button>
+                  ))}
+                </div>
+                {!streamerMode && accountId && (
+                  <InviteToGroupRow
+                    chatMid={chat.id}
+                    accountId={accountId}
+                    onDone={(msg) => setActionMsg(msg)}
+                  />
+                )}
+              </div>
+            )}
+
+            {!streamerMode && !chat.isSelf && (
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => void leaveOrBlock()}
+                className="mt-6 flex w-full items-center gap-3 rounded-xl border border-[var(--vy-border)] px-4 py-3 text-sm font-medium text-[var(--vy-danger)] transition-colors hover:bg-[color-mix(in_oklab,var(--vy-danger)_12%,transparent)] focus-visible:ring-2 focus-visible:ring-[var(--vy-danger)] focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <IconLogout size={18} />
+                {chat.type === "group"
+                  ? chat.left
+                    ? busy
+                      ? "削除中…"
+                      : "一覧から削除"
+                    : busy
+                      ? "退出中…"
+                      : "グループを退出"
+                  : isBlocked
+                    ? busy
+                      ? "解除中…"
+                      : "ブロックを解除"
+                    : busy
+                      ? "処理中…"
+                      : "ブロック"}
+              </button>
+            )}
+            {actionMsg && <p className="mt-2 text-xs text-[var(--vy-text-dim)]">{actionMsg}</p>}
+          </div>
+        ) : accountId ? (
+          <div className="vy-scroll flex-1 overflow-y-auto">
+            <ProfileContentPanel kind={view} accountId={accountId} chatId={chat.id} />
+          </div>
+        ) : (
+          <div className="flex flex-1 items-center justify-center px-6 text-center text-sm text-[var(--vy-text-dim)]">
+            ログイン情報を取得できませんでした
+          </div>
+        )}
       </aside>
       {agentPrompt && (
         <AgentIActionDialog


### PR DESCRIPTION
## Summary

プロフィールドロワーからノート／アルバムを直接確認できるUIを追加します。

## Changes

- グループ・個人チャットのプロフィールに「ノート」「アルバム」を追加
- クリック時、モーダルではなくプロフィール欄そのものを一覧表示へ切り替え
- ノート一覧の読み込み・再読み込み・empty/error/loading state
- アルバム一覧からアルバム内の画像／動画グリッドへ遷移
- 戻る操作でプロフィールへ復帰
- 既存の Note/Album API と CRUD 実装を再利用し、重複実装は追加しない

## Verification

- desktop typecheck ✅
- lint ✅
- desktop build ✅
- git diff --check ✅
- pre-push checks で typecheck / lint / build の実行を確認
