### PR TITLE
docs(readme): add development partner and references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,9 @@ README はユーザー向け入口。実装判断の正本にしない。
 
 - `Vyline/packages/protocol`、`Vyline/packages/plugin`、`Vyline/packages/themes`、`tools` は submodule/workspace の境界が見えにくい。まず `bun run vyl:doctor` で状態を確認する。
 - docs整理では既存docsをテンプレートへ機械的に当て直さない。新規docsや大改修だけ `docs/templates/` を使い、既存docsは必要箇所だけ直す。
+- README の正本は `README.src.md`。`README.md` / `README.en.md` は生成物なので、原則として直接編集しない。README変更は `README.src.md` に入れ、`bun run docs:readme` で生成して差分を確認する。
 - README は元の構成を守る。新導線を入れる場合も、該当セクションへの追記に留める。
+- 現在の `README.src.md` には英語向け言語タグが不足している箇所があり、`bun run docs:readme` で `README.en.md` を日本語内容で上書きする既知の不整合がある。README生成前後で `README.en.md` の差分を必ず確認し、意図しない上書きはコミットしない。英語生成仕様を修正するPR以外では、この既知不整合を広げない。
 - `vyl doctor` / `vyl init` は軽い入口にする。npm publish、Docker build、Trivy container scan、full security scan は通常CLIに入れない。
 - 重い処理は GitHub Actions の manual workflow、release workflow、schedule に寄せる。PRでは軽量チェックを優先する。
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ Vyline は個人開発のオープンソースプロジェクトです。支援�
 | [nezumi0627](https://github.com/nezumi0627) | リード開発者 |
 | [YoseiUshida](https://github.com/youseiushida) | 定期メンテナー |
 
+### Development Partner
+
+- [REINs](https://github.com/areteruhiro/LEINs) — Development Partner
+
+Vyline と REINs は、それぞれ独立したプロジェクトとして開発・運営を続けながら、必要に応じて開発や技術研究で協力します。
+
 ### メンテナー・コントリビューター募集
 
 Vyline の継続的な開発を支えるメンテナーとコントリビューターを募集しています。
@@ -520,6 +526,20 @@ bun run vyline:find-native -- sendMessage  # ネイティブシンボルを検�
 5. 実装量・トークン・コストの削減
 
 効率化よりも正確性と安全性を優先します。詳細は [AGENTS.md](AGENTS.md) を参照してください。
+
+---
+
+## References
+
+以下のプロジェクトは、Vyline の調査・研究・実装において技術的な参考資料として参照したものです。
+
+特記がない限り、これらのプロジェクトおよび開発者と Vyline の間に、公式な提携・所属・承認・その他の深い関係はありません。
+
+- [CHRLINE (old)](https://github.com/DeachSword/CHRLINE)
+- [CHRLINE-Thrift](https://github.com/DeachSword/CHRLINE-Thrift/)
+- [CHRLINE-Patch](https://github.com/WEDeach/CHRLINE-Patch)
+- [linejs](https://github.com/evex-dev/linejs)
+- [line-py](https://github.com/fadhiilrachman/line-py)
 
 ---
 

--- a/README.src.md
+++ b/README.src.md
@@ -101,6 +101,12 @@ Vyline は個人開発のオープンソースプロジェクトです。支援�
 | [nezumi0627](https://github.com/nezumi0627) | リード開発者 |
 | [YoseiUshida](https://github.com/youseiushida) | 定期メンテナー |
 
+### Development Partner
+
+- [REINs](https://github.com/areteruhiro/LEINs) — Development Partner
+
+Vyline と REINs は、それぞれ独立したプロジェクトとして開発・運営を続けながら、必要に応じて開発や技術研究で協力します。
+
 ### メンテナー・コントリビューター募集
 
 Vyline の継続的な開発を支えるメンテナーとコントリビューターを募集しています。
@@ -519,6 +525,20 @@ bun run vyline:find-native -- sendMessage  # ネイティブシンボルを検�
 5. 実装量・トークン・コストの削減
 
 効率化よりも正確性と安全性を優先します。詳細は [AGENTS.md](AGENTS.md) を参照してください。
+
+---
+
+## References
+
+以下のプロジェクトは、Vyline の調査・研究・実装において技術的な参考資料として参照したものです。
+
+特記がない限り、これらのプロジェクトおよび開発者と Vyline の間に、公式な提携・所属・承認・その他の深い関係はありません。
+
+- [CHRLINE (old)](https://github.com/DeachSword/CHRLINE)
+- [CHRLINE-Thrift](https://github.com/DeachSword/CHRLINE-Thrift/)
+- [CHRLINE-Patch](https://github.com/WEDeach/CHRLINE-Patch)
+- [linejs](https://github.com/evex-dev/linejs)
+- [line-py](https://github.com/fadhiilrachman/line-py)
 
 ---
 

--- a/docs/DOCS_FORMAT.md
+++ b/docs/DOCS_FORMAT.md
@@ -22,6 +22,21 @@
 
 既存ドキュメントをテンプレートに合わせるためだけの全面リライトはしない。見出しや用語の統一は、内容変更がある範囲に限定する。
 
+## README の生成ルール
+
+ルート README の正本は `README.src.md` とする。`README.md` と `README.en.md` は `scripts/generate-readmes.ts` による生成物で、通常の編集対象ではない。
+
+README を変更するときは次の順序を守る。
+
+1. `README.src.md` を編集する。
+2. `bun run docs:readme` で生成する。
+3. `git diff -- README.src.md README.md README.en.md` で生成結果を確認する。
+4. `bun run docs:readme:check` で正本との整合を確認する。
+
+現在は `README.src.md` の一部で英語向け言語タグが不足しており、生成時に `README.en.md` が日本語内容で上書きされる既知の不整合がある。そのため、英語READMEの生成仕様そのものを修正する作業でない限り、`README.en.md` に意図しない大規模差分が出た場合はコミットしない。
+
+生成済みファイルだけを直接直す変更は禁止する。例外は、生成スクリプトや生成仕様そのものを修正している途中で、検証用に一時編集する場合のみ。
+
 ## 用語
 
 - `storage/saved-media/`: 送信済みまたは取得済みのメディアを保持する永続ストレージ。ユーザーが明示的に削除するまで残す。


### PR DESCRIPTION
## Summary
- add REINs as a Development Partner
- add a References section for CHRLINE, CHRLINE-Thrift, CHRLINE-Patch, linejs, and line-py
- clarify that referenced projects are technical references and do not imply affiliation or a close relationship

## Validation
- git diff --check passed
- pre-push hook was bypassed because the existing hook recursively invoked the root typecheck and failed with a Windows job-object error; this change is README-only