### PR TITLE
fix: guard expired LINE unsend requests

### DIFF
--- a/Vyline/apps/desktop/src/lib/store.ts
+++ b/Vyline/apps/desktop/src/lib/store.ts
@@ -1,7 +1,11 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { api, type Announcement } from "../api/client.js";
-import type { Chat as LineChat, Message as LineMessage } from "@vyline/types";
+import {
+  canUnsendMessage,
+  type Chat as LineChat,
+  type Message as LineMessage,
+} from "@vyline/types";
 import { THEME_PRESETS } from "@vyline/themes";
 import type {
   Chat,
@@ -1563,6 +1567,15 @@ export const useStore = create<State>()(
           get().showNotice("一度取り消したメッセージは再度取り消せません");
           return;
         }
+        const isPremium = Boolean(get().self.premium?.active);
+        if (!demoMode && !canUnsendMessage(msg.createdAt, isPremium)) {
+          get().showNotice(
+            isPremium
+              ? "送信取り消しできません（LYPプレミアムは送信後7日以内です）"
+              : "送信取り消しできません（通常は送信後1時間以内です）",
+          );
+          return;
+        }
         const prevState = msg.messageState ?? "normal";
         const historyEntry = {
           state: prevState,
@@ -1590,13 +1603,26 @@ export const useStore = create<State>()(
         const res = await api.line.unsend(accountId!, id);
         if (res.ok && activeChatId) await get().refreshMessages(activeChatId, { force: true });
         else if (!res.ok) {
+          set((st) => ({
+            messages: st.messages.map((m) =>
+              m.id === id
+                ? {
+                    ...m,
+                    history: msg.history,
+                    revokedSnapshot: msg.revokedSnapshot,
+                    messageState: prevState,
+                    text: msg.text,
+                  }
+                : m,
+            ),
+          }));
           const errText = res.error ?? "";
           if (
             errText.includes("MESSAGE_NOT_DESTRUCTIBLE") ||
             errText.includes("message too old") ||
             errText.includes("too old")
           ) {
-            get().showNotice("取り消し失敗(送信取り消し可能な時間を過ぎています)");
+            get().showNotice("送信取り消しできません（送信取り消し可能な時間を過ぎています）");
           } else {
             window.alert(errText || "取り消しに失敗しました");
           }

--- a/Vyline/backend/src/service/lineService.ts
+++ b/Vyline/backend/src/service/lineService.ts
@@ -15,6 +15,7 @@ import type {
   LineBirthday,
   CallRoute,
 } from "@vyline/types";
+import { canUnsendMessage } from "@vyline/types";
 import { LINEStruct } from "@vyline/protocol/stack/thrift";
 import { childLogger } from "../logger.js";
 import {
@@ -5074,6 +5075,9 @@ export async function unsendMessage(accountId: string, messageId: string): Promi
   // 送信と同じキューで直列化（送信中と同時に H2 セッションを使うと取り消しが落ちることがある）
   return runSendRpc(accountId, async () => {
     const found = await findStoredMessageByIdLocal(accountId, messageId);
+    if (!found) {
+      throw new Error("MESSAGE_NOT_DESTRUCTIBLE: message timestamp unavailable");
+    }
     const chatMid = found?.chatMid;
     if (chatMid) await assertChatUnlocked(accountId, chatMid);
     if (found) {
@@ -5085,6 +5089,10 @@ export async function unsendMessage(accountId: string, messageId: string): Promi
         stored.contentType === "UNSEND"
       ) {
         throw new Error("MESSAGE_ALREADY_REVOKED: this message was already unsent once");
+      }
+      const premium = await fetchPremiumStatus(accountId);
+      if (!canUnsendMessage(stored.createdTime, premium.active)) {
+        throw new Error("MESSAGE_NOT_DESTRUCTIBLE: message too old");
       }
     }
     const client = requireClient(accountId);

--- a/Vyline/packages/types/src/index.ts
+++ b/Vyline/packages/types/src/index.ts
@@ -67,6 +67,7 @@ export interface VylineCachedGroup {
 }
 
 export * from "./accountFeatures.js";
+export * from "./unsendPolicy.js";
 
 // ─── Chat ─────────────────────────────────────
 

--- a/Vyline/packages/types/src/unsendPolicy.test.ts
+++ b/Vyline/packages/types/src/unsendPolicy.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import {
+  PREMIUM_UNSEND_WINDOW_MS,
+  STANDARD_UNSEND_WINDOW_MS,
+  canUnsendMessage,
+} from "./unsendPolicy.js";
+
+describe("canUnsendMessage", () => {
+  const now = 10_000_000_000;
+
+  test("standard accounts are limited to one hour", () => {
+    expect(canUnsendMessage(now - STANDARD_UNSEND_WINDOW_MS, false, now)).toBe(true);
+    expect(canUnsendMessage(now - STANDARD_UNSEND_WINDOW_MS - 1, false, now)).toBe(false);
+  });
+
+  test("premium accounts are limited to seven days", () => {
+    expect(canUnsendMessage(now - PREMIUM_UNSEND_WINDOW_MS, true, now)).toBe(true);
+    expect(canUnsendMessage(now - PREMIUM_UNSEND_WINDOW_MS - 1, true, now)).toBe(false);
+  });
+
+  test("fails closed when the timestamp is unavailable or invalid", () => {
+    expect(canUnsendMessage(0, false, now)).toBe(false);
+    expect(canUnsendMessage(Number.NaN, true, now)).toBe(false);
+  });
+});

--- a/Vyline/packages/types/src/unsendPolicy.ts
+++ b/Vyline/packages/types/src/unsendPolicy.ts
@@ -1,0 +1,12 @@
+export const STANDARD_UNSEND_WINDOW_MS = 60 * 60 * 1000;
+export const PREMIUM_UNSEND_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+export function getUnsendWindowMs(isPremium: boolean): number {
+  return isPremium ? PREMIUM_UNSEND_WINDOW_MS : STANDARD_UNSEND_WINDOW_MS;
+}
+
+export function canUnsendMessage(createdAt: number, isPremium: boolean, now = Date.now()): boolean {
+  if (!Number.isFinite(createdAt) || createdAt <= 0) return false;
+  const ageMs = now - createdAt;
+  return ageMs >= 0 && ageMs <= getUnsendWindowMs(isPremium);
+}


### PR DESCRIPTION
## Summary
- enforce LINE unsend windows in both UI and backend
- standard accounts: 1 hour
- LYP Premium: 7 days
- fail closed when message timestamp is unavailable
- roll back optimistic UI revoke state when the API rejects the request
- show a clear expiry notice instead of leaving the message as revoked

## Safety
- backend validates the window independently, so direct API calls cannot bypass the UI guard
- expired/unknown messages are blocked before the LINE unsend RPC is sent

## Verification
- bun test Vyline/packages/types/src/unsendPolicy.test.ts
- backend typecheck
- desktop typecheck
- Biome check
- git diff --check
- pre-push full checks and desktop production build passed

## Reference
Official LINE Help Center: standard unsend window is 1 hour; eligible LYP Premium users can unsend within 7 days. OpenChat remains 24 hours regardless of Premium.