### PR TITLE
fix(auth): generate device-confirmation PIN with a CSPRNG

### DIFF
--- a/Vyline/backend/src/api/auth.ts
+++ b/Vyline/backend/src/api/auth.ts
@@ -14,6 +14,7 @@
  * DELETE /auth/accounts/:id — アカウント削除
  */
 
+import { randomInt } from "node:crypto";
 import { Hono } from "hono";
 import { childLogger } from "../logger.js";
 import {
@@ -39,8 +40,9 @@ const emailLoginState = new Map<
   { status: EmailLoginStatus; pincode: string | null; error: string | null }
 >();
 
+// 端末確認 PIN は認証情報。Math.random は予測可能なため CSPRNG を使う。
 function random6DigitPin(): string {
-  return String(Math.floor(100000 + Math.random() * 900000));
+  return String(randomInt(100000, 1000000));
 }
 
 // ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The email-login device-confirmation PIN is generated with `Math.random()`, which is not a cryptographically secure random source. This PIN is a security credential, so it should come from a CSPRNG.

```ts
// Vyline/backend/src/api/auth.ts
function random6DigitPin(): string {
  return String(Math.floor(100000 + Math.random() * 900000));
}
```

## Why it matters

`random6DigitPin()` is passed into `loginWithEmail(...)` as `pincode` and, as the existing comment at `auth.ts` notes, must match the value used for E2EE — it gates the device confirmation that drives `decryptKeyChain`. In other words, whoever can produce the correct 6-digit PIN can complete the device-confirmation step.

`Math.random()` is backed by V8's non-cryptographic xorshift128+ PRNG, whose internal state can be reconstructed from a handful of observed outputs. PINs generated by the same backend process are therefore correlated and predictable: an attacker who can observe some PINs from a shared/hosted Vyline instance (e.g. their own account) can predict a victim's PIN instead of brute-forcing 10⁶ possibilities against a rate limiter.

## Fix

Use `randomInt` from `node:crypto`:

```ts
import { randomInt } from "node:crypto";

function random6DigitPin(): string {
  return String(randomInt(100000, 1000000));
}
```

`randomInt(100000, 1000000)` returns an integer in `[100000, 999999]` — the exact same range and 6-digit format as before. Only the randomness source changes to a CSPRNG, so there is no behavioral/format regression.

## Verification

- `bun run --cwd Vyline/backend typecheck` — passes
- `biome check` on the changed file — passes
- Ran 200,000 iterations of the new implementation: min `100017`, max `999990`, zero non-6-digit outputs — range and format identical to the previous implementation.

## Scope

Single-line behavioral change plus one import and a comment. Other `Math.random()` uses in the codebase are for non-security purposes (local IDs, backoff jitter, cosmetic theme generation) and are intentionally left unchanged.