### PR TITLE
perf: reduce startup restore and cache overhead

### DIFF
--- a/Vyline/apps/desktop/src/App.tsx
+++ b/Vyline/apps/desktop/src/App.tsx
@@ -1,18 +1,28 @@
+import { lazy, Suspense } from "react";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
-import { LoginPage } from "./pages/LoginPage.js";
 import { VylineApp } from "./pages/VylineApp.js";
-import { SubdevicePage } from "./pages/SubdevicePage.js";
-import { PrDemoPage } from "./pages/PrDemoPage.js";
+
+const LoginPage = lazy(() =>
+  import("./pages/LoginPage.js").then((module) => ({ default: module.LoginPage })),
+);
+const SubdevicePage = lazy(() =>
+  import("./pages/SubdevicePage.js").then((module) => ({ default: module.SubdevicePage })),
+);
+const PrDemoPage = lazy(() =>
+  import("./pages/PrDemoPage.js").then((module) => ({ default: module.PrDemoPage })),
+);
 
 export function App() {
   return (
     <BrowserRouter>
-      <Routes>
-        <Route path="/pr-demo" element={<PrDemoPage />} />
-        <Route path="/login" element={<LoginPage />} />
-        <Route path="/subdevice" element={<SubdevicePage />} />
-        <Route path="/*" element={<VylineApp />} />
-      </Routes>
+      <Suspense fallback={null}>
+        <Routes>
+          <Route path="/pr-demo" element={<PrDemoPage />} />
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/subdevice" element={<SubdevicePage />} />
+          <Route path="/*" element={<VylineApp />} />
+        </Routes>
+      </Suspense>
     </BrowserRouter>
   );
 }

--- a/Vyline/apps/desktop/src/components/chat-shell.tsx
+++ b/Vyline/apps/desktop/src/components/chat-shell.tsx
@@ -1,9 +1,12 @@
-import { memo, useCallback, useEffect, useRef, useState } from "react";
+import { lazy, memo, Suspense, useCallback, useEffect, useRef, useState } from "react";
 import { useStore } from "@/lib/store";
 import { Sidebar } from "@/components/sidebar";
-import { ChatArea } from "@/components/chat-area";
 import { cn } from "@/lib/utils";
 import { IconPanelLeft } from "@/components/icons";
+
+const ChatArea = lazy(() =>
+  import("@/components/chat-area").then((module) => ({ default: module.ChatArea })),
+);
 
 function ChatShellBase() {
   const activeChatId = useStore((s) => s.activeChatId);
@@ -93,7 +96,15 @@ function ChatShellBase() {
         >
           <IconPanelLeft size={17} />
         </button>
-        <ChatArea />
+        {activeChatId ? (
+          <Suspense fallback={null}>
+            <ChatArea />
+          </Suspense>
+        ) : (
+          <div className="hidden flex-1 items-center justify-center bg-[var(--vy-chat-bg)] md:flex">
+            <p className="text-sm text-[var(--vy-text-dim)]">チャットを選択してください</p>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/Vyline/apps/desktop/src/hooks/useLineData.ts
+++ b/Vyline/apps/desktop/src/hooks/useLineData.ts
@@ -478,7 +478,8 @@ export function useLineData({ accountId }: UseLineDataOptions) {
       await loadBootstrap();
       if (accountIdRef.current !== accountId) return;
       void loadProfile();
-      await loadChats({ refresh: true, light: true });
+      // 通常起動は backend の TTL/freshness 判定に任せ、remote refresh を強制しない。
+      await loadChats({ light: true });
       if (accountIdRef.current !== accountId) return;
 
       window.setTimeout(() => {

--- a/Vyline/apps/desktop/src/pages/VylineApp.tsx
+++ b/Vyline/apps/desktop/src/pages/VylineApp.tsx
@@ -1,16 +1,23 @@
-import { useEffect, useState } from "react";
+import { lazy, Suspense, useEffect, useState } from "react";
 import { Navigate } from "react-router-dom";
 import { useAuthStore } from "../stores/authStore.js";
 import { useStore } from "../lib/store.js";
 import { useVylineSync } from "../hooks/useVylineSync.js";
 import { ThemeApplier } from "../components/theme-applier.js";
-import { HubHome } from "../components/hub-home.js";
 import { ChatShell } from "../components/chat-shell.js";
-import { SettingsSections } from "../components/settings-sections.js";
 import { FloatNotice } from "../components/float-notice.js";
 import { TosConsentGate, hasTosConsent } from "../components/tos-consent.js";
 import { api } from "../api/client.js";
 import { VylineSetup } from "../components/vyline-setup.js";
+
+const HubHome = lazy(() =>
+  import("../components/hub-home.js").then((module) => ({ default: module.HubHome })),
+);
+const SettingsSections = lazy(() =>
+  import("../components/settings-sections.js").then((module) => ({
+    default: module.SettingsSections,
+  })),
+);
 
 export function VylineApp() {
   const initialized = useAuthStore((s) => s.initialized);
@@ -95,7 +102,9 @@ export function VylineApp() {
       {notice && !indexing?.active && <FloatNotice>{notice}</FloatNotice>}
       {screen === "home" && showUpdateNote && (
         <div className="vy-screen-enter h-full">
-          <HubHome />
+          <Suspense fallback={null}>
+            <HubHome />
+          </Suspense>
         </div>
       )}
       {(screen === "chat" || (screen === "home" && !showUpdateNote)) && (
@@ -105,7 +114,9 @@ export function VylineApp() {
       )}
       {screen === "settings" && (
         <div className="vy-screen-enter h-full">
-          <SettingsSections />
+          <Suspense fallback={null}>
+            <SettingsSections />
+          </Suspense>
         </div>
       )}
     </main>

--- a/Vyline/apps/desktop/src/stores/authStore.ts
+++ b/Vyline/apps/desktop/src/stores/authStore.ts
@@ -101,21 +101,9 @@ export const useAuthStore = create<AuthState>()(
         const res = await api.auth.accounts();
         if (!res.ok) return;
 
-        let active = res.active;
-        let saved = res.saved;
-        let sessions = res.sessions ?? [];
-
-        // メモリに無いが tokens.json にある → restore
-        const missing = saved.filter((id) => !active.includes(id));
-        if (missing.length > 0) {
-          await Promise.allSettled(missing.map((id) => api.auth.restore(id)));
-          const again = await api.auth.accounts();
-          if (again.ok) {
-            active = again.active;
-            saved = again.saved;
-            sessions = again.sessions ?? sessions;
-          }
-        }
+        const active = res.active;
+        const saved = res.saved;
+        const sessions = res.sessions ?? [];
 
         set({ accounts: active, saved, sessions });
 

--- a/Vyline/backend/src/api/auth.ts
+++ b/Vyline/backend/src/api/auth.ts
@@ -29,6 +29,7 @@ import {
   getContentQrState,
   loginContentWithQRCode,
   removeClient,
+  waitForSessionRestore,
 } from "../line/clientManager.js";
 import { deleteToken, loadTokens, listSavedSessions } from "../storage/tokenStore.js";
 
@@ -321,6 +322,7 @@ authRouter.post("/switch/:id", async (c) => {
 // GET /auth/accounts
 // ─────────────────────────────────────────────
 authRouter.get("/accounts", async (c) => {
+  await waitForSessionRestore();
   const active = listAccounts();
   const saved = await loadTokens();
   const sessions = await listSavedSessions();

--- a/Vyline/backend/src/index.ts
+++ b/Vyline/backend/src/index.ts
@@ -21,7 +21,6 @@ import { publicRouter } from "./api/public.js";
 import { lineOpenApiSpec } from "./api/openapi.line.js";
 import { getClient, restoreAllSessions } from "./line/clientManager.js";
 import { initVylineProfile } from "./vyline/profileBridge.js";
-import { warmAccountCache } from "./storage/chatStore.js";
 import type { CallWsData } from "./call/callManager.js";
 import { ensureCdnCacheDir } from "./storage/cdnAssetCache.js";
 import { ensureMediaStorageDir } from "./storage/mediaStorage.js";
@@ -357,16 +356,9 @@ void ensureCdnCacheDir().catch(() => undefined);
 void ensureMediaStorageDir().catch(() => undefined);
 void import("./tailscale.js").then((m) => m.startTailscaleWatcher(PORT)).catch(() => undefined);
 
-restoreAllSessions()
-  .then(async () => {
-    const { listAccounts } = await import("./line/clientManager.js");
-    for (const id of listAccounts()) {
-      await warmAccountCache(id).catch(() => undefined);
-    }
-  })
-  .catch((err) => {
-    logger.warn({ err }, "session restore had errors");
-  });
+restoreAllSessions().catch((err) => {
+  logger.warn({ err }, "session restore had errors");
+});
 
 type CallWsHandlers = typeof import("./call/callManager.js").callWebSocketHandler;
 let callWsHandlers: CallWsHandlers | null = null;

--- a/Vyline/backend/src/line/clientManager.ts
+++ b/Vyline/backend/src/line/clientManager.ts
@@ -48,6 +48,8 @@ interface ManagedClient {
 }
 
 const clients = new Map<string, ManagedClient>();
+const tokenRestoreInflight = new Map<string, Promise<VylineClient>>();
+let initialSessionRestore: Promise<void> | null = null;
 const contentClients = new Map<string, Promise<VylineClient>>();
 const contentQrState = new Map<
   string,
@@ -527,7 +529,7 @@ export async function loginWithQRCode(
   }
 }
 
-export async function loginWithToken(accountId: string): Promise<VylineClient> {
+async function loginWithTokenImpl(accountId: string): Promise<VylineClient> {
   const entry = await getToken(accountId);
   if (!entry) throw new Error(`no token for accountId: ${accountId}`);
 
@@ -540,7 +542,6 @@ export async function loginWithToken(accountId: string): Promise<VylineClient> {
   });
 
   watchAuthToken(client, accountId);
-  void warmLineCache(accountId).catch(() => undefined);
   clients.set(accountId, {
     client,
     accountId,
@@ -549,9 +550,26 @@ export async function loginWithToken(accountId: string): Promise<VylineClient> {
     pincode: null,
     loggedInAt: Date.now(),
   });
+  void warmLineCache(accountId).catch(() => undefined);
   restorePluginsForSession(accountId);
   log.info({ accountId }, "token login success");
   return client;
+}
+
+export function loginWithToken(accountId: string): Promise<VylineClient> {
+  const existing = clients.get(accountId);
+  if (existing?.loggedInAt !== null && existing?.client) {
+    return Promise.resolve(existing.client);
+  }
+
+  const inflight = tokenRestoreInflight.get(accountId);
+  if (inflight) return inflight;
+
+  const restore = loginWithTokenImpl(accountId).finally(() => {
+    tokenRestoreInflight.delete(accountId);
+  });
+  tokenRestoreInflight.set(accountId, restore);
+  return restore;
 }
 
 export async function loginWithAuthToken(
@@ -570,7 +588,6 @@ export async function loginWithAuthToken(
   });
 
   watchAuthToken(client, accountId);
-  void warmLineCache(accountId).catch(() => undefined);
   clients.set(accountId, {
     client,
     accountId,
@@ -579,12 +596,13 @@ export async function loginWithAuthToken(
     pincode: null,
     loggedInAt: Date.now(),
   });
+  void warmLineCache(accountId).catch(() => undefined);
   restorePluginsForSession(accountId);
   log.info({ accountId }, "authToken login success");
   return client;
 }
 
-export async function restoreAllSessions(): Promise<void> {
+async function restoreAllSessionsImpl(): Promise<void> {
   const tokens = await loadTokens();
   const ids = Object.keys(tokens).filter((id) => !id.endsWith(":content"));
   if (ids.length === 0) {
@@ -615,6 +633,17 @@ export async function restoreAllSessions(): Promise<void> {
       }
     }),
   );
+}
+
+export function restoreAllSessions(): Promise<void> {
+  if (!initialSessionRestore) {
+    initialSessionRestore = restoreAllSessionsImpl();
+  }
+  return initialSessionRestore;
+}
+
+export function waitForSessionRestore(): Promise<void> {
+  return restoreAllSessions();
 }
 
 export function getClient(accountId: string): VylineClient | undefined {

--- a/Vyline/backend/src/service/lineService.ts
+++ b/Vyline/backend/src/service/lineService.ts
@@ -2665,7 +2665,9 @@ async function fetchChatsCore(
       const chatsAge = meta.chatsSyncedAt
         ? now - Date.parse(meta.chatsSyncedAt)
         : Number.POSITIVE_INFINITY;
-      const needsBg = opts?.refresh || chatsAge > CHATS_CACHE_MS || !memCached;
+      // disk cache の freshness を正本にする。プロセス再起動直後に memory cache が
+      // 空でも、disk cache が新鮮なら remote RPC は再実行しない。
+      const needsBg = Boolean(opts?.refresh) || chatsAge > CHATS_CACHE_MS;
 
       if (needsBg) {
         const syncPromise = enqueueTalkRpcBackground(accountId, async () => {
@@ -2698,6 +2700,9 @@ async function fetchChatsCore(
       }
       if (memCached && now - memCached.at < CHATS_CACHE_MS) {
         return memCached.chats;
+      }
+      if (chatsAge <= CHATS_CACHE_MS) {
+        chatsCache.set(accountId, { at: now, chats: local });
       }
       return local;
     }

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,7 @@ LINE との通常の通信は発生します。これは法的助言ではあり
 | [onboarding.md](./onboarding.md)     | 初日チェックリスト（環境・コード地図・Desktop ツール）             |
 | [CONTRIBUTING.md](./CONTRIBUTING.md) | 機能追加フロー（辞書 → Desktop → domain → BFF）                    |
 | [development.md](./development.md)   | 開発コマンド・環境変数                                             |
+| [performance.md](./performance.md)   | 起動時間・CPU・メモリ計測と Bun/Vite 最適化                       |
 | [architecture.md](./architecture.md) | 層構造・データフロー                                               |
 | [distribution.md](./distribution.md) | Windows exe / アップデーター / リリース手順                        |
 | [selfhosting.md](./selfhosting.md)   | Docker セルフホスト・Cloudflare Access・データ永続化               |

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,132 @@
+# Vyline パフォーマンス最適化
+
+最終更新: 2026-08-30
+
+Vyline は「体感速度を落とさず、起動時間・CPU・メモリを継続的に抑える」ことを優先する。
+最適化は必ず **計測 → ボトルネック特定 → 最小変更 → 同条件で再計測** の順で行う。
+
+## 2026-08-30 基準値
+
+Windows 11 / Bun 1.4.0 / Vite 6.4.2 で測定。
+
+| 項目 | 計測値 |
+| --- | ---: |
+| 通常の Vite dev 起動 | 平均 284 ms（271 / 307 / 274 ms） |
+| `vite --force` 依存再最適化 | 平均 312 ms（336 / 302 / 298 ms） |
+| 単独 Vite 起動（別測定） | 約 2.0 s |
+| ユーザー報告の遅い起動 | 9.508 s |
+| Vite config load | 約 249 ms |
+| backend `/healthz` median | 約 1.4 ms |
+| backend `/healthz` p95 | 約 6.2 ms |
+| frontend dev RSS | 約 295 MB（通常開発サーバー） |
+| backend dev RSS | 約 124 MB |
+
+Vite 単体では 9.5 秒を再現しなかった一方、アプリ起動ロジックには実際の重複処理が見つかった。
+保存済みセッションがある場合、session restore・cache warm・履歴 index が重複し、LINE RPC / CPU / disk I/O を起動直後に不要に増やす構造だった。
+
+ログイン済み状態で最適化後の `/auth/accounts` 完了までを 3 回測定した結果は 878.9 / 916.8 / 991.7 ms、平均約 0.93 秒。backend health-ready は約 0.41〜0.54 秒だった。
+
+## 現在採用している最適化
+
+### 1. session restore の所有者を backend に一本化する
+
+起動時の保存済みセッション復元は backend の `restoreAllSessions()` だけが担当する。frontend の `refreshAccounts()` は `/auth/accounts` から復元完了後の状態を読むだけで、追加の `/auth/restore` を自動実行しない。
+
+さらに `loginWithToken()` は account ごとの in-flight Promise を共有する。同じ account に restore 要求が同時到着しても LINE session の生成は 1 回だけ行う。
+
+### 2. 通常の restore で履歴 index を走らせない
+
+`warmLineCache()` はローカル cache の warm だけを行う。session restore の副作用として `runAccountIndex({ topChats: 16, messagesPerChat: 30 })` のような全履歴 crawl を開始しない。
+
+履歴 index は明示操作に限定し、cache がある通常起動で remote history crawl を繰り返さない。
+
+### 3. cache warm を 1 回にする
+
+`loginWithToken()` 内で client 登録後に `warmLineCache()` を開始する。`index.ts` 側で restore 完了後に全 account を再度 `warmAccountCache()` しない。
+
+client を `clients` に登録してから warm を始めることで、warm 中に `requireClient()` が未登録状態を見る race も避ける。
+
+### 4. disk cache の freshness を再起動後も引き継ぐ
+
+chat 一覧は memory cache が空という理由だけで remote sync しない。`chatsSyncedAt` が TTL 内なら disk cache を memory cache に昇格し、frontend も通常起動では `refresh=true` を強制しない。
+
+TTL 超過または明示 refresh の場合だけ remote sync する。
+
+### 5. 起動時に不要な画面を遅延ロードする
+
+`LoginPage`、`SubdevicePage`、`PrDemoPage`、`SettingsSections`、`HubHome`、`ChatArea` は `React.lazy()` で必要時だけロードする。チャット未選択時はメッセージ表示・入力系を読み込まない。
+
+2026-08-30 の production build では主要な lazy-load 適用後、初期 JS は 632.42 kB → 401.77 kB、gzip は 187.55 kB → 125.81 kB まで縮小した。
+
+### 6. ポーリングと大量データ処理
+
+`useVylineSync` の既存 scheduler と単一フライト制御を維持し、短い固定 timer を追加しない。store hydrate は連続更新をまとめ、メッセージ一覧は仮想化して全件 DOM 化を避ける。
+
+## Bun 1.4 方針
+
+- 通常開発は `bun --watch` を使い、別 watcher を重ねない。
+- `--smol` はメモリ削減と引き換えに性能を落とすため既定値にはしない。
+- CPU 調査は `--cpu-prof` / `--cpu-prof-md`、メモリ調査は `--heap-prof` / `--heap-prof-md` を使う。
+- Bun / Vite の cache directory は常用で削除しない。削除すると依存再最適化コストを再度払う。
+
+## 計測手順
+
+### Vite 起動
+
+```powershell
+cd Vyline/apps/desktop
+bun .\node_modules\vite\bin\vite.js
+bun .\node_modules\vite\bin\vite.js --force
+```
+
+`ready in ... ms` を最低 3 回記録し、warm と `--force` を混ぜて比較しない。
+
+### transform のボトルネック
+
+```powershell
+cd Vyline/apps/desktop
+bun .\node_modules\vite\bin\vite.js --debug transform
+```
+
+ページを開き、数十〜数百 ms かかる module を確認する。巨大 component が通常起動に不要なら dynamic import / `React.lazy()` を優先する。
+
+### production bundle
+
+```powershell
+bun run build
+```
+
+初期 chunk の gzip サイズを前回値と比較する。単に chunk 数を増やすのではなく「起動時に不要な機能」を分離する。
+
+### backend CPU / heap
+
+一時的な調査時だけ profiler を有効にする。
+
+```powershell
+bun --cpu-prof-md Vyline/backend/src/index.ts
+bun --heap-prof-md Vyline/backend/src/index.ts
+```
+
+profiler 自体にオーバーヘッドがあるため通常開発では有効にしない。
+
+## 回帰防止ルール
+
+- startup session restore の所有者を複数レイヤーに作らない。backend が唯一の owner。
+- 同一 account の login / restore は single-flight にする。
+- session restore の副作用として remote history index や全 chat crawl を開始しない。
+- cache warm を複数箇所から重複起動しない。
+- memory cache が空という理由だけで新鮮な disk cache を無効扱いしない。
+- 通常起動の frontend から `refresh=true` を強制しない。freshness は backend の TTL 判定を正本にする。
+- 設定、バックアップ、解析、QR、管理 UI のような通常チャットに不要な機能は lazy load を優先する。
+- polling / timer を追加する前に既存 scheduler に統合できないか確認する。
+- cache は上限または失効条件を持たせる。
+- `React.memo` / `useMemo` は profiler で再 render が原因と確認できた場所だけに使う。
+- `server.warmup` は広い glob を指定しない。起動時間と初回表示の両方を再計測し、明確に改善した場合だけ採用する。
+- 速度改善が計測ノイズ内ならコードを増やさない。
+
+## 現在の判断
+
+フロントの初期 import graph 改善だけでなく、backend/frontend 間の起動責務の重複をなくすことが重要だった。
+基本方針は「1 account = 1 restore」「restore = session 復元だけ」「重い履歴 index は明示実行」。
+
+今後は起動時に発生する LINE RPC 数、disk I/O、timer、cache warm、store hydrate を先に数え、同じデータを複数レイヤーで取り直していないかを優先して確認する。


### PR DESCRIPTION
## Summary
- make backend the single owner of startup session restore and deduplicate concurrent token restores per account
- remove duplicate cache warming and avoid automatic history crawling during normal restore
- reuse fresh disk chat cache across process restarts and stop forcing frontend startup refreshes
- lazy-load login, subdevice/demo, settings, hub, and chat-heavy UI chunks
- document Bun 1.4 startup, CPU, memory, profiling, and regression rules in docs/performance.md

## Verification
- frontend typecheck: pass
- backend typecheck: pass
- full pre-push typecheck/lint checks: pass
- production build: pass (3.93s)
- git diff --check: pass
- logged-in startup to /auth/accounts: 878.9 / 916.8 / 991.7 ms (~0.93s average)
- backend health-ready observed at ~0.41-0.54s

The PR intentionally excludes unrelated API/RPC rename work from the earlier development branch.