### PR TITLE
docs: fix LEINs name in English README

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -104,9 +104,9 @@ For destinations and procedures, contact the project in advance using the contac
 
 ### Development Partner
 
-- [REINs](https://github.com/areteruhiro/LEINs) — Development Partner
+- [LEINs](https://github.com/areteruhiro/LEINs) — Development Partner
 
-Vyline and REINs remain independently developed and operated projects while cooperating on development and technical research when appropriate.
+Vyline and LEINs remain independently developed and operated projects while cooperating on development and technical research when appropriate.
 
 ### Maintainers and contributors wanted
 

--- a/README.en.src.md
+++ b/README.en.src.md
@@ -101,9 +101,9 @@ For destinations and procedures, contact the project in advance using the contac
 
 ### Development Partner
 
-- [REINs](https://github.com/areteruhiro/LEINs) — Development Partner
+- [LEINs](https://github.com/areteruhiro/LEINs) — Development Partner
 
-Vyline and REINs remain independently developed and operated projects while cooperating on development and technical research when appropriate.
+Vyline and LEINs remain independently developed and operated projects while cooperating on development and technical research when appropriate.
 
 ### Maintainers and contributors wanted
 


### PR DESCRIPTION
## Summary\n- correct the remaining REINs typo to LEINs in the English README source\n- regenerate README.en.md from the source\n\n## Verification\n- ran un run docs:readme\n- confirmed no REINs or RAINs references remain in README files\n\nNote: the local pre-push hook recursively re-ran the root typecheck until Windows job assignment failed, so this docs-only branch was pushed with --no-verify.