### PR TITLE
docs(dev): adopt task-scoped git worktrees

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md — Vyline エージェント向けガイド
 
-最終更新: 2026-08-29
+最終更新: 2026-08-30
 
 このファイルは AI エージェントが Vyline プロジェクトを理解しタスクを実行するための包括的なガイドです。
 
@@ -331,16 +331,28 @@ bun run bump -- 0.7.0 --tag  # git tag v0.7.0 まで自動作成
 
 **機能・改善・バグ修正などの変更を PR で出す場合は、必ず新しいブランチを切ってから PR を開き、承認後にマージする。**
 
+### 推奨: 1 task = 1 branch = 1 git worktree
+
+複数のAIエージェント・人間・IDEが並行してVylineを触る場合、repository全体のコピーではなく **タスクごとに独立した Git worktree** を使う。
+
+- 標準作業領域: `E:\projects\Vyline-worktrees\<task-name>`
+- `.codex-worktrees` のような特定エージェント専用名は新規利用しない
+- 本体 `E:\projects\Vyline` を複数タスクの共有編集場所にしない
+- 他worktreeのdirty差分・未追跡ファイルは触らない
+- 作業完了後はPRをmergeしてから `git worktree remove` で片付ける
+- 詳細手順: `docs/development-worktrees.md`
+
 - `main` は Branch Protection Rules により保護されており、直接 push はブロックされる（`Cannot update this protected ref.`）
 - フローは次のとおり:
 
 ```
-1. main から作業ブランチを切る
-   git checkout main && git pull && git checkout -b feature/<名前>
-2. 変更をコミットしてブランチに push
+1. origin/main から作業branch + worktreeを作る
+   git fetch origin
+   git worktree add -b feature/<名前> E:\projects\Vyline-worktrees\<名前> origin/main
+2. worktree内で変更をコミットしてbranchにpush
    git push -u origin feature/<名前>
 3. GitHub で PR を作成（base: main ← head: feature/<名前>）
-4. レビュー・承認後にマージする（repo 所有者以外のマージはブロックされる）
+4. レビュー・承認後にマージし、worktreeを削除する
 ```
 
 - 小さな修正（1 コミットのドキュメント更新など）でも、main への直接 push はせずブランチ経由にする

--- a/README.en.md
+++ b/README.en.md
@@ -514,6 +514,8 @@ Contributions to bug fixes, feature improvements, documentation, and design are 
 
 Read the [contribution guide](docs/CONTRIBUTING.md) before participating. Never include analysed software, sessions, keys, tokens, or other sensitive information in a Pull Request.
 
+For parallel development, Vyline recommends **`1 task = 1 branch = 1 git worktree`**. Do not clone or copy the whole repository for each feature; create a task-specific worktree under `Vyline-worktrees` instead. See [Git Worktree development](docs/development-worktrees.md) for the workflow.
+
 ### Agent / Skill policy
 
 Development may use coding-agent Skills such as Ponytail, Caveman, agent-skills-standard, addyosmani agent-skills, and Minimize-Cursor-Cost as needed. Their purpose is to avoid unnecessary code and overengineering while maintaining review quality.

--- a/README.en.src.md
+++ b/README.en.src.md
@@ -511,6 +511,8 @@ Contributions to bug fixes, feature improvements, documentation, and design are 
 
 Read the [contribution guide](docs/CONTRIBUTING.md) before participating. Never include analysed software, sessions, keys, tokens, or other sensitive information in a Pull Request.
 
+For parallel development, Vyline recommends **`1 task = 1 branch = 1 git worktree`**. Do not clone or copy the whole repository for each feature; create a task-specific worktree under `Vyline-worktrees` instead. See [Git Worktree development](docs/development-worktrees.md) for the workflow.
+
 ### Agent / Skill policy
 
 Development may use coding-agent Skills such as Ponytail, Caveman, agent-skills-standard, addyosmani agent-skills, and Minimize-Cursor-Cost as needed. Their purpose is to avoid unnecessary code and overengineering while maintaining review quality.

--- a/README.md
+++ b/README.md
@@ -514,6 +514,8 @@ bun run vyline:find-native -- sendMessage  # ネイティブシンボルを検�
 
 参加前に [コントリビューションガイド](docs/CONTRIBUTING.md) を確認してください。Pull Request に解析対象ソフトウェア、セッション、鍵、トークンなどの機密情報を含めないでください。
 
+並行開発では **`1 task = 1 branch = 1 git worktree`** を推奨します。repository全体を機能ごとにコピーせず、`Vyline-worktrees` 配下へタスク単位のworktreeを作成してください。詳しい手順は [Git Worktree 開発フロー](docs/development-worktrees.md) にまとめています。
+
 ### エージェント / Skill 方針
 
 開発では必要に応じて Ponytail、Caveman、agent-skills-standard、addyosmani agent-skills、Minimize-Cursor-Cost などの coding-agent 用 Skill を利用します。不要なコードと過剰設計を避け、レビュー品質を保つことが目的です。

--- a/README.src.md
+++ b/README.src.md
@@ -513,6 +513,8 @@ bun run vyline:find-native -- sendMessage  # ネイティブシンボルを検�
 
 参加前に [コントリビューションガイド](docs/CONTRIBUTING.md) を確認してください。Pull Request に解析対象ソフトウェア、セッション、鍵、トークンなどの機密情報を含めないでください。
 
+並行開発では **`1 task = 1 branch = 1 git worktree`** を推奨します。repository全体を機能ごとにコピーせず、`Vyline-worktrees` 配下へタスク単位のworktreeを作成してください。詳しい手順は [Git Worktree 開発フロー](docs/development-worktrees.md) にまとめています。
+
 ### エージェント / Skill 方針
 
 開発では必要に応じて Ponytail、Caveman、agent-skills-standard、addyosmani agent-skills、Minimize-Cursor-Cost などの coding-agent 用 Skill を利用します。不要なコードと過剰設計を避け、レビュー品質を保つことが目的です。

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # CONTRIBUTING — Vyline への貢献ガイド
 
-最終更新: 2026-08-24
+最終更新: 2026-08-30
 
 新規参入者向け。**UI/UX を触らずにプロトコル・backend・protocol を伸ばす**ときの道筋です。
 
@@ -39,6 +39,12 @@ bun run dev   # backend :3001 + frontend :5173
 ```
 
 詳細: [development.md](./development.md)
+
+### 並行開発は Git worktree を使う
+
+Vyline の推奨開発方式は **`1 task = 1 branch = 1 git worktree`** です。複数のAIエージェント、人間、IDEが同時に作業する場合も、repository全体をコピーせずタスクごとにworktreeを分離してください。
+
+標準配置、作成・削除手順、競合時の扱いは [development-worktrees.md](./development-worktrees.md) を参照してください。
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Vyline ドキュメント索引
 
-最終更新: 2026-08-29
+最終更新: 2026-08-30
 
 新規参入者は **[onboarding.md](./onboarding.md)** から始めてください。
 エージェントは **[../AGENTS.md](../AGENTS.md)** を最初に読んでください。
@@ -42,6 +42,7 @@ LINE との通常の通信は発生します。これは法的助言ではあり
 | [onboarding.md](./onboarding.md)     | 初日チェックリスト（環境・コード地図・Desktop ツール）             |
 | [CONTRIBUTING.md](./CONTRIBUTING.md) | 機能追加フロー（辞書 → Desktop → domain → BFF）                    |
 | [development.md](./development.md)   | 開発コマンド・環境変数                                             |
+| [development-worktrees.md](./development-worktrees.md) | **推奨: 1 task = 1 branch = 1 git worktree** の並行開発フロー |
 | [performance.md](./performance.md)   | 起動時間・CPU・メモリ計測と Bun/Vite 最適化                       |
 | [architecture.md](./architecture.md) | 層構造・データフロー                                               |
 | [distribution.md](./distribution.md) | Windows exe / アップデーター / リリース手順                        |

--- a/docs/development-worktrees.md
+++ b/docs/development-worktrees.md
@@ -1,0 +1,92 @@
+# Git Worktree 開発フロー
+
+最終更新: 2026-08-30
+
+Vyline では、複数の人間・AI エージェント・IDE が同時に開発するときの競合を減らすため、**`1 task = 1 branch = 1 git worktree`** を推奨開発方式とします。
+
+repository 全体を `Vyline-feature-a` のようにコピーして並行作業する方式は、Git metadata、submodule、依存関係、未追跡ファイルの状態が分岐しやすいため、新規作業では原則使いません。
+
+## 推奨レイアウト
+
+worktree は repository の外に置きます。Windows では次の配置を推奨します。
+
+```text
+E:\projects\
+├─ Vyline\
+└─ Vyline-worktrees\
+   ├─ note-album\
+   ├─ openchat\
+   ├─ security\
+   └─ token-refresh\
+```
+
+`.codex-worktrees` のような特定エージェント専用名は新規利用しません。`Vyline-worktrees` は Codex、他の AI、IDE、人間の開発者で共通利用できる作業領域です。
+
+## 新しいタスクを始める
+
+まず本体 repository で remote を更新し、タスク専用 branch と worktree を同時に作ります。
+
+```powershell
+cd E:\projects\Vyline
+git fetch origin
+git worktree add -b feature/<task-name> E:\projects\Vyline-worktrees\<task-name> origin/main
+cd E:\projects\Vyline-worktrees\<task-name>
+git submodule update --init --recursive
+bun install
+```
+
+branch prefix は担当者・用途の既存ルールに合わせて `feature/`、`fix/`、`docs/`、エージェント固有prefixなどを使えます。重要なのは、**同じ branch を複数 worktree で同時編集しないこと**です。
+
+## 作業中のルール
+
+- 1つのタスクは1つのworktreeだけで編集する。
+- 他タスクのworktreeにある未コミット差分・未追跡ファイルを触らない。
+- submodule の branch / commit pointer もタスクごとに確認する。
+- 本体 `E:\projects\Vyline` を複数AIの共有作業場にしない。
+- 共通変更が必要になった場合は、先にPRへ分離するか、依存するbranchを明示してrebaseする。
+- secrets、session、token、`Vyline/backend/data/` はworktree間でコピーしない。
+
+状態確認:
+
+```powershell
+git worktree list
+git status --short --branch
+```
+
+## PR とマージ
+
+作業が完了したら通常のbranchと同じようにcommit / pushし、`main` 向けPRを作成します。
+
+```powershell
+git add <files>
+git commit -m "feat(scope): describe change"
+git push -u origin feature/<task-name>
+```
+
+PR が merge されたあと、worktreeに未保存作業がないことを確認して削除します。
+
+```powershell
+cd E:\projects\Vyline
+git worktree remove E:\projects\Vyline-worktrees\<task-name>
+git worktree prune
+git branch -d feature/<task-name>
+```
+
+`--force` は未コミット差分や未追跡ファイルを失う可能性があるため、通常の後片付けでは使いません。
+
+## 競合したとき
+
+同じファイルを複数タスクで変更する必要が出た場合でも、worktree同士のファイルを直接コピーして上書きしません。
+
+1. 先に片方をcommitする。
+2. 必要ならPRを先行してmergeする。
+3. もう片方のbranchで `origin/main` をrebaseする。
+4. Gitが示した競合だけを解決して再検証する。
+
+これにより「どのAIの変更か分からない」「コピー先だけ修正されて本体へ戻っていない」という状態を避けられます。
+
+## 既存の古いコピー / worktree
+
+既存の `Vyline-*` コピーや `.codex-worktrees` は、未push commit・submodule差分・未追跡ファイルがないことを確認するまで手動削除・リネームしません。
+
+特に submodule を含む登録済みworktreeは、フォルダをExplorerから移動するとGit管理情報が壊れることがあります。整理時は `git worktree list` で登録状態を確認し、Git経由で扱ってください。


### PR DESCRIPTION
## Summary
- recommend 1 task = 1 branch = 1 git worktree
- standardize new worktrees under E:\projects\Vyline-worktrees\<task-name>
- document creation, cleanup, conflicts, submodules, secrets, and migration from old copy-based workflows
- update AGENTS, README sources/generated README, CONTRIBUTING, and docs index

## Verification
- bun run docs:readme
- bun run typecheck
- bun run lint
- bun run build
- git diff --check

## Notes
- existing legacy .codex-worktrees are left in place until their active tasks finish; new work uses the neutral Vyline-worktrees directory