### PR TITLE
feat(linux): integrate tqmane container improvements

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,68 @@
+name: Container
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: container-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  publish:
+    name: linux/amd64 + linux/arm64
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source and submodules
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=branch
+            type=sha,prefix=sha-
+
+      - name: Build and push multi-architecture image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VYLINE_VERSION=${{ github.ref_name }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: mode=max
+          sbom: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with: { submodules: recursive }
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -79,10 +81,15 @@ jobs:
       - uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: VYLINE_VERSION=${{ github.ref_name }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: mode=max
+          sbom: true
 
   publish:
     needs: [windows, linux, docker]

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,14 +1,28 @@
 # Contributors
 
-Vyline は、作者・メンテナー・外部コントリビューターの協力で開発されています。
+Vyline は、作者・メンテナー・コントリビューターの協力によって開発されています。
+このページでは、プロジェクトの開発・保守・改善に貢献したメンバーを紹介します。
 
-## Core
+## Project Team
 
-- [nezumi0627](https://github.com/nezumi0627) — creator / lead developer
-- [YoseiUshida](https://github.com/youseiushida) — maintainer
+| Contributor | Role |
+| --- | --- |
+| [nezumi0627](https://github.com/nezumi0627) | Creator / Lead Developer |
+| [YoseiUshida](https://github.com/youseiushida) | Maintainer |
 
 ## Contributors
 
-- [tqmane](https://github.com/tqmane) — Linux / Docker / Portainer / persistent-storage improvements. Vyline 本家へ取り込まれた関連実装の原案・検証・改善に貢献。
+| Contributor | Contributions |
+| --- | --- |
+| [tqmane](https://github.com/tqmane) | Linux support, Docker / Portainer integration, container delivery, and persistent-storage improvements |
 
-個々の変更の著者情報は Git 履歴も正本として扱います。外部実装を取り込む場合は、元コミット・作者・ライセンス表示を可能な限り保持します。
+### Attribution
+
+Vyline では、外部コントリビューターによる実装・調査・検証・改善を尊重します。
+取り込まれた変更については、可能な限り Git の著者情報、元コミット、ライセンスおよび適切なクレジットを保持します。
+
+個々の変更に関する詳細な著者情報は Git 履歴を正本とします。
+
+---
+
+Vyline に貢献してくださったすべての方に感謝します。

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,14 @@
+# Contributors
+
+Vyline は、作者・メンテナー・外部コントリビューターの協力で開発されています。
+
+## Core
+
+- [nezumi0627](https://github.com/nezumi0627) — creator / lead developer
+- [YoseiUshida](https://github.com/youseiushida) — maintainer
+
+## Contributors
+
+- [tqmane](https://github.com/tqmane) — Linux / Docker / Portainer / persistent-storage improvements. Vyline 本家へ取り込まれた関連実装の原案・検証・改善に貢献。
+
+個々の変更の著者情報は Git 履歴も正本として扱います。外部実装を取り込む場合は、元コミット・作者・ライセンス表示を可能な限り保持します。

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,12 +43,10 @@ ENV NODE_ENV=production \
     VYLINE_DATA_DIR=/app/data \
     VYLINE_STORAGE_DIR=/app/storage
 LABEL org.opencontainers.image.title="Vyline" \
-      org.opencontainers.image.source="https://github.com/tqmane/vyline" \
+      org.opencontainers.image.source="https://github.com/nezumi0627/vyline" \
       org.opencontainers.image.version="${VYLINE_VERSION}"
 RUN apt-get update \
-  && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends gosu \
-  && apt-get autoremove -y \
   && rm -rf /var/lib/apt/lists/*
 COPY --from=prod-deps /app/node_modules ./node_modules
 COPY --from=prod-deps /app/Vyline/backend/node_modules ./Vyline/backend/node_modules
@@ -61,6 +59,7 @@ RUN mkdir -p /app/data /app/storage \
   && chown -R bun:bun /app/data /app/storage \
   && chmod 0755 /usr/local/bin/vyline-entrypoint
 EXPOSE 3000
+STOPSIGNAL SIGTERM
 VOLUME ["/app/data", "/app/storage"]
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
   CMD bun -e 'fetch("http://127.0.0.1:"+(process.env.PORT||3000)+"/healthz").then(function(r){process.exit(r.ok?0:1)},function(){process.exit(1)})'

--- a/docker-compose.portainer.yml
+++ b/docker-compose.portainer.yml
@@ -1,0 +1,20 @@
+services:
+  vyline:
+    image: ${VYLINE_IMAGE:-ghcr.io/nezumi0627/vyline:latest}
+    pull_policy: always
+    ports:
+      # Secure default: keep Portainer deployments local-only unless LAN access is explicitly enabled.
+      - "${VYLINE_BIND_ADDRESS:-127.0.0.1}:${VYLINE_PORT:-3000}:3000"
+    volumes:
+      - ${VYLINE_DATA_PATH:-./data}:/app/data
+      - ${VYLINE_STORAGE_PATH:-./storage}:/app/storage
+    environment:
+      VYLINE_HOST: 0.0.0.0
+      VYLINE_LAN_ACCESS: ${VYLINE_LAN_ACCESS:-false}
+      PORT: 3000
+      VYLINE_DATA_DIR: /app/data
+      VYLINE_STORAGE_DIR: /app/storage
+      TZ: ${TZ:-Asia/Tokyo}
+    init: true
+    stop_grace_period: 30s
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- adapt tqmane's Linux/container improvements for upstream Vyline
- publish GHCR images for linux/amd64 and linux/arm64 on main
- make release Docker images multi-architecture with Buildx/QEMU, cache, provenance, and SBOM
- add a Portainer compose file using the upstream image and secure localhost-only default binding
- fix Docker image source metadata back to nezumi0627/vyline
- add SIGTERM stop handling and avoid unnecessary apt upgrade/autoremove in the runtime layer
- add CONTRIBUTORS.md and explicitly credit tqmane for Linux / Docker / Portainer / persistent-storage work

## Already present in upstream and intentionally not duplicated
- writable bind-mount entrypoint using gosu
- atomic chat DB writes / durable restore flush
- Linux disk-capacity reporting via statfs

## Attribution
The Linux/container work was reviewed against tqmane/vyline and adapted rather than copied wholesale. tqmane is credited in CONTRIBUTORS.md; the attribution commit includes a Co-authored-by trailer.

## Safety choices
- Portainer defaults to 127.0.0.1 instead of 0.0.0.0 to preserve Vyline's LAN-isolation policy
- release-tag image publishing stays in release.yml; container.yml handles main/manual publishing to avoid duplicate tag jobs
