### PR TITLE
fix(media): correct multi-image sending, detection and display

### DIFF
--- a/Vyline/apps/desktop/src/components/chat-area.tsx
+++ b/Vyline/apps/desktop/src/components/chat-area.tsx
@@ -34,6 +34,7 @@ import {
 } from "@/components/icons";
 import { AgentIActionDialog } from "@/components/agent-i-action-dialog";
 import { findFirstUnreadMessage } from "@/lib/chatScroll";
+import { shareImageMediaGroup } from "@/lib/mediaGroup";
 
 function dayLabel(ts: number): string {
   const d = new Date(ts);
@@ -62,21 +63,6 @@ type MsgRow =
       searching: boolean;
       highlight?: string;
     };
-
-function canGroupImageMessage(message: Message): boolean {
-  return message.kind === "image" && Boolean(message.imageSrc) && !message.replyToId;
-}
-
-function shouldGroupAdjacentImages(left: Message, right: Message): boolean {
-  return (
-    canGroupImageMessage(left) &&
-    canGroupImageMessage(right) &&
-    left.authorId === right.authorId &&
-    left.chatId === right.chatId &&
-    dayLabel(left.createdAt) === dayLabel(right.createdAt) &&
-    Math.abs(right.createdAt - left.createdAt) <= 30_000
-  );
-}
 
 function compareMessagesOldestFirst(left: Message, right: Message): number {
   const byTime = left.createdAt - right.createdAt;
@@ -167,29 +153,35 @@ function ChatAreaBase() {
         out.push({ key: `day-${m.id}`, item: { key: `day-${m.id}`, kind: "day", label: dl } });
       }
       const prev = chatMessages[i - 1];
-      const mediaGroup = canGroupImageMessage(m) ? [m] : undefined;
+      const mediaGroup = m.mediaGroup && !m.replyToId ? [m] : undefined;
       if (mediaGroup) {
         while (
           i + 1 < chatMessages.length &&
-          shouldGroupAdjacentImages(mediaGroup[mediaGroup.length - 1]!, chatMessages[i + 1]!)
+          shareImageMediaGroup(mediaGroup[mediaGroup.length - 1]!, chatMessages[i + 1]!)
         ) {
           mediaGroup.push(chatMessages[i + 1]!);
           i++;
         }
+        mediaGroup.sort(
+          (left, right) =>
+            (left.mediaGroup?.sequence ?? Number.MAX_SAFE_INTEGER) -
+            (right.mediaGroup?.sequence ?? Number.MAX_SAFE_INTEGER),
+        );
       }
-      const lastInRow = mediaGroup?.[mediaGroup.length - 1] ?? m;
+      const primaryMessage = mediaGroup?.[0] ?? m;
+      const lastInRow = mediaGroup?.[mediaGroup.length - 1] ?? primaryMessage;
       const next = chatMessages[i + 1];
       const sameAuthorAsNext =
         next && next.authorId === lastInRow.authorId && dayLabel(next.createdAt) === dl;
       const sameAuthorAsPrev =
-        prev && prev.authorId === m.authorId && dayLabel(prev.createdAt) === lastDay;
-      const groupIds = mediaGroup?.map((item) => item.id) ?? [m.id];
+        prev && prev.authorId === primaryMessage.authorId && dayLabel(prev.createdAt) === lastDay;
+      const groupIds = mediaGroup?.map((item) => item.id) ?? [primaryMessage.id];
       out.push({
-        key: `msg-${m.id}`,
+        key: `msg-${primaryMessage.id}`,
         item: {
-          key: `msg-${m.id}`,
+          key: `msg-${primaryMessage.id}`,
           kind: "msg",
-          message: m,
+          message: primaryMessage,
           mediaGroup: mediaGroup && mediaGroup.length > 1 ? mediaGroup : undefined,
           index: i,
           sameAuthorAsPrev: Boolean(sameAuthorAsPrev),

--- a/Vyline/apps/desktop/src/components/message-input.tsx
+++ b/Vyline/apps/desktop/src/components/message-input.tsx
@@ -378,10 +378,14 @@ export function MessageInput({ chatId }: { chatId: string }) {
             );
           }
           const dataBase64 = await blobToBase64(prepared.blob);
+          const filename =
+            item.kind === "image" && prepared.mime === "image/jpeg" && prepared.blob !== item.file
+              ? `${(item.file.name || "image").replace(/\.[^.]+$/, "")}.jpg`
+              : item.file.name || (item.kind === "video" ? "video.mp4" : "image.jpg");
           return {
             dataBase64,
             mimeType: prepared.mime,
-            filename: item.file.name || (item.kind === "video" ? "video.mp4" : "image.jpg"),
+            filename,
             mediaType: item.kind,
           };
         }),

--- a/Vyline/apps/desktop/src/lib/mappers.ts
+++ b/Vyline/apps/desktop/src/lib/mappers.ts
@@ -25,6 +25,7 @@ import {
 import { parseSticonReplace } from "../utils/lineSticon.js";
 import { parseMentions } from "../utils/mention.js";
 import type { Chat, Member, Message, MessageKind, MessageStatus } from "./store-types.js";
+import { parseImageMediaGroup } from "./mediaGroup.js";
 
 const COLORS = ["#2aabee", "#06c755", "#f0728f", "#7c5cff", "#f5a623", "#2dd4bf", "#a78bfa"];
 
@@ -409,6 +410,7 @@ export function mapMessage(
     text,
     sticker: stickerSrc,
     imageSrc,
+    mediaGroup: kind === "image" ? parseImageMediaGroup(meta) : undefined,
     audioSrc,
     audioSeconds: kind === "audio" ? parseAudioDuration(m.contentMetadata ?? null) : undefined,
     altText,

--- a/Vyline/apps/desktop/src/lib/mediaGroup.test.ts
+++ b/Vyline/apps/desktop/src/lib/mediaGroup.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+import { parseImageMediaGroup, shareImageMediaGroup } from "./mediaGroup.js";
+import type { Message } from "./store-types.js";
+
+function image(id: string, mediaGroup?: Message["mediaGroup"]): Message {
+  return {
+    id,
+    chatId: "c-test",
+    authorId: "u-test",
+    kind: "image",
+    imageSrc: `/media/${id}`,
+    mediaGroup,
+    createdAt: Number(id),
+    status: "sent",
+    read: false,
+    messageState: "normal",
+  };
+}
+
+describe("image media groups", () => {
+  it("parses a real LINE multi-image group", () => {
+    expect(parseImageMediaGroup({ GID: "629629126478921814", GSEQ: "2", GTOTAL: "3" })).toEqual({
+      id: "629629126478921814",
+      sequence: 2,
+      total: 3,
+    });
+  });
+
+  it("rejects standalone and invalid group metadata", () => {
+    expect(parseImageMediaGroup({})).toBeUndefined();
+    expect(parseImageMediaGroup({ GID: "0", GSEQ: "1", GTOTAL: "3" })).toBeUndefined();
+    expect(parseImageMediaGroup({ GID: "1", GSEQ: "1", GTOTAL: "1" })).toBeUndefined();
+    expect(parseImageMediaGroup({ GID: "1", GSEQ: "4", GTOTAL: "3" })).toBeUndefined();
+    expect(parseImageMediaGroup({ GID: "1", GSEQ: "x", GTOTAL: "3" })).toBeUndefined();
+  });
+
+  it("groups only messages with the same real GID", () => {
+    const first = image("1", { id: "group-a", sequence: 1, total: 3 });
+    const second = image("2", { id: "group-a", sequence: 2, total: 3 });
+    const other = image("3", { id: "group-b", sequence: 3, total: 3 });
+    expect(shareImageMediaGroup(first, second)).toBe(true);
+    expect(shareImageMediaGroup(second, other)).toBe(false);
+  });
+
+  it("does not group consecutive standalone images", () => {
+    expect(shareImageMediaGroup(image("1"), image("2"))).toBe(false);
+  });
+});

--- a/Vyline/apps/desktop/src/lib/mediaGroup.ts
+++ b/Vyline/apps/desktop/src/lib/mediaGroup.ts
@@ -1,0 +1,39 @@
+import type { Message } from "./store-types.js";
+
+export type ImageMediaGroup = NonNullable<Message["mediaGroup"]>;
+
+function parseInteger(value: unknown): number | undefined {
+  if (typeof value !== "string" && typeof value !== "number") return undefined;
+  const parsed = Number(value);
+  return Number.isInteger(parsed) ? parsed : undefined;
+}
+
+export function parseImageMediaGroup(
+  meta?: Record<string, unknown> | null,
+): ImageMediaGroup | undefined {
+  const id = typeof meta?.GID === "string" ? meta.GID.trim() : "";
+  const total = parseInteger(meta?.GTOTAL);
+  const sequence = parseInteger(meta?.GSEQ);
+  if (!id || id === "0" || total == null || total <= 1 || sequence == null) return undefined;
+  if (sequence < 1 || sequence > total) return undefined;
+  return { id, sequence, total };
+}
+
+export function shareImageMediaGroup(left: Message, right: Message): boolean {
+  const leftGroup = left.mediaGroup;
+  const rightGroup = right.mediaGroup;
+  return Boolean(
+    left.kind === "image" &&
+      right.kind === "image" &&
+      left.imageSrc &&
+      right.imageSrc &&
+      !left.replyToId &&
+      !right.replyToId &&
+      leftGroup &&
+      rightGroup &&
+      leftGroup.id === rightGroup.id &&
+      leftGroup.total === rightGroup.total &&
+      left.authorId === right.authorId &&
+      left.chatId === right.chatId,
+  );
+}

--- a/Vyline/apps/desktop/src/lib/store-types.ts
+++ b/Vyline/apps/desktop/src/lib/store-types.ts
@@ -62,6 +62,12 @@ export type Message = {
   text?: string;
   sticker?: string;
   imageSrc?: string;
+  /** LINE 複数画像グループ（contentMetadata.GID/GSEQ/GTOTAL） */
+  mediaGroup?: {
+    id: string;
+    sequence: number;
+    total: number;
+  };
   audioSrc?: string;
   audioSeconds?: number;
   /** Flex / RICH の ALT_TEXT（プレビュー・コピー用） */

--- a/Vyline/apps/desktop/src/lib/store.ts
+++ b/Vyline/apps/desktop/src/lib/store.ts
@@ -1465,9 +1465,13 @@ export const useStore = create<State>()(
             binary += String.fromCharCode(...bytes.subarray(i, i + chunk));
           }
           const dataBase64 = btoa(binary);
+          const filename =
+            !isVideo && mime === "image/jpeg" && blob !== file
+              ? `${(file.name || "image").replace(/\.[^.]+$/, "")}.jpg`
+              : file.name || (isVideo ? "video.mp4" : "image.jpg");
           const res = await api.line.sendMedia(accountId!, chatId, dataBase64, {
             mimeType: mime,
-            filename: file.name || (isVideo ? "video.mp4" : "image.jpg"),
+            filename,
             mediaType: isVideo ? "video" : "image",
           });
           if (res.ok) {

--- a/Vyline/backend/src/service/lineService.ts
+++ b/Vyline/backend/src/service/lineService.ts
@@ -4468,6 +4468,8 @@ export async function sendMediaBatch(
                   : "file")
         );
       });
+      const groupedImageBatch =
+        items.length > 1 && batchMediaTypes.every((type) => type === "image" || type === "gif");
       let plainMode =
         noE2eePeers.has(chatMid) ||
         (await determinePlainMediaFlow(client, accountId, chatMid, batchMediaTypes));
@@ -4488,9 +4490,10 @@ export async function sendMediaBatch(
         plainMode = plainMode || noE2eePeers.has(chatMid);
       }
 
-      if (plainMode) {
-        // Desktop 準拠: OBS /r/talk/m/reqseq に連番 reqseq でアップロードし、
-        // サーバ側にメッセージを生成させる（HAR 実績と同じ経路）。
+      if (plainMode || groupedImageBatch) {
+        // Desktop/iOS 準拠: 複数画像は OBS /r/talk/m/reqseq へ順次アップロードし、
+        // 1 枚目の応答で発行された GID を X-Talk-Meta で 2 枚目以降へ引き継ぐ。
+        // 画像以外の plain media batch は従来どおり連番 reqseq のみで送る。
         // thrift sendMessage を併用すると flow=1 チャットでは履歴に載らないため
         // 失敗時のフォールバック送信も行わない（二重送信になる）。
         const uploaded = await client.base.obs.uploadObjTalkBatch(
@@ -4507,9 +4510,46 @@ export async function sendMediaBatch(
               ((item.mediaType ?? "image") === "image" ? "screenshot.png" : "file.bin"),
           })),
         );
-        // reqseq 生成メッセージは OBS から OID が取れないため、
-        // アップロード応答の objId（== 生成メッセージID の実測）をキーに
-        // 送信バイトを永続メディアストレージに置く。
+
+        // OBS 201 だけでは LINE 履歴への生成を保証できない。
+        // x-obs-oid (objId) が実際の LINE メッセージ ID として履歴に現れたものだけ
+        // 成功扱いにする。reqseq に必要な header が欠けた場合の false positive を防ぐ。
+        const uploadedIds = uploaded.flatMap((result) =>
+          result && !("error" in result) && result.objId ? [result.objId] : [],
+        );
+        const confirmedIds = new Set<string>();
+        for (let attempt = 0; attempt < 5 && confirmedIds.size < uploadedIds.length; attempt++) {
+          try {
+            // messageBox の lastDeliveredMessageId は送信直後に数秒遅れることがあるため、
+            // delta 用の合成カーソルで「現在時刻まで」を直接読む。
+            const history = await runTalkFetchUrgent(accountId, () =>
+              fetchMessagesInner(accountId, chatMid, Math.max(30, uploadedIds.length * 4), {
+                lite: true,
+                delta: true,
+                deltaAfterId: uploadedIds[0] ?? "0",
+              }),
+            );
+            const historyIds = new Set(history.map((message) => message.id));
+            for (const id of uploadedIds) {
+              if (historyIds.has(id)) confirmedIds.add(id);
+            }
+          } catch (err) {
+            log.warn(
+              {
+                accountId,
+                chatMid,
+                attempt: attempt + 1,
+                err: err instanceof Error ? err.message : String(err),
+              },
+              "media batch history verification failed",
+            );
+          }
+
+          if (confirmedIds.size < uploadedIds.length && attempt < 4) {
+            await new Promise<void>((resolve) => setTimeout(resolve, 300 * (attempt + 1)));
+          }
+        }
+
         let count = 0;
         for (let i = 0; i < uploaded.length; i++) {
           const result = uploaded[i];
@@ -4525,6 +4565,20 @@ export async function sendMediaBatch(
             );
             continue;
           }
+
+          if (!confirmedIds.has(result.objId)) {
+            log.warn(
+              {
+                accountId,
+                chatMid,
+                index: i,
+                objId: result.objId,
+              },
+              "media batch item was accepted by OBS but not confirmed in LINE history",
+            );
+            continue;
+          }
+
           count++;
           const binary = Uint8Array.from(atob(items[i]!.dataBase64), (c) => c.charCodeAt(0));
           await writeMediaStorage(
@@ -4542,8 +4596,9 @@ export async function sendMediaBatch(
             count,
             total: items.length,
             batch: true,
-            plain: true,
+            plain: plainMode,
             reqseq: true,
+            grouped: groupedImageBatch,
           },
           "media batch sent via OBS reqseq",
         );

--- a/scripts/sendTestMediaBatch.ts
+++ b/scripts/sendTestMediaBatch.ts
@@ -8,14 +8,11 @@
  * 生成画像は実行ごとにランダム色の PNG。
  */
 
-import { writeFileSync, mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { deflateSync } from "node:zlib";
 
 const APPROVED_TEST_CHATS = new Set([
   "c1efe9d6cf1848350bc91848a8a29963e", // うがうがうー
   "u81c530b68cc2efdd36911d214bd5f084", // ねずBOT
-  "u7c6ea9ca829a8dd6249015f79e53a703", // ClockAngel（テスト垢）
 ]);
 
 function arg(name: string, fallback: string): string {
@@ -23,7 +20,7 @@ function arg(name: string, fallback: string): string {
   return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback;
 }
 
-/** 単色 PNG を生成する（依存なし） */
+/** 単色 PNG を生成する（IDAT は zlib 圧縮が必須） */
 function solidPng(r: number, g: number, b: number, size = 64): Buffer {
   const w = size;
   const h = size;
@@ -65,7 +62,7 @@ function solidPng(r: number, g: number, b: number, size = 64): Buffer {
   return Buffer.concat([
     Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
     chunk("IHDR", ihdr),
-    chunk("IDAT", raw),
+    chunk("IDAT", deflateSync(raw)),
     chunk("IEND", Buffer.alloc(0)),
   ]);
 }
@@ -108,7 +105,14 @@ console.log(body);
 
 // 履歴を確認して relation / IMAGE の有無を表示
 await new Promise((r) => setTimeout(r, 4000));
-const hist = await fetch(`${base}/line/${account}/messages/${chatMid}?limit=${count + 5}&force=1`);
+const hist = await fetch(
+  `${base}/line/${account}/getPreviousMessagesV2WithRequest/${chatMid}?limit=${count + 5}&force=1`,
+);
+if (!hist.ok) {
+  console.error(`GET /getPreviousMessagesV2WithRequest -> ${hist.status}`);
+  console.error(await hist.text());
+  process.exit(1);
+}
 const data = (await hist.json()) as {
   messages?: Array<{ id: string; contentType: string; relatedMessageId?: string }>;
 };


### PR DESCRIPTION
## 変更内容

### 送信の修正
- 複数画像を単なる複数回送信ではなく、LINE の `GID` / `GSEQ` / `GTOTAL` を使う実グループ送信へ変更
- 1枚目でLINEから発行された GID を後続画像へ引き継ぐ protocol 実装を参照
- OBS が受理しただけでは成功扱いせず、LINE履歴に実メッセージが生成されたことを確認
- JPEG変換後も元拡張子が残るケースを修正し、`.jpg` として送信
- テスト用PNG生成を正しいzlib圧縮PNGへ修正し、許可済みテスト先だけに制限

### 判定の修正
- 「同じ送信者の画像が30秒以内に連続したら複数画像」とする推測判定を削除
- `contentMetadata.GID/GSEQ/GTOTAL` が有効な画像だけを複数画像として判定
- 単独画像や別GIDの画像が誤ってまとまらない回帰テストを追加

### 表示の修正
- 同一GIDの画像だけをグループ表示
- `GSEQ` 順に並べてLINE側の画像順序を保持

## Protocol
- nezumi0627/vyline-api#14

## 確認
- media group tests: 4 passed
- protocol grouped upload tests: 2 passed
- frontend typecheck: passed
- backend typecheck: passed
- protocol typecheck: passed
- repository lint: 226 files passed
- production frontend build: passed
- 許可済みチャット「うがうがうー」で3画像を実送信し、同一GID + GSEQ 1/2/3 + GTOTAL 3 を確認済み